### PR TITLE
# Add FT2232H async 245 FIFO transport for high-speed bulk transfers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ VERILOG_FILES = \
 	src/sdram.v \
 	src/glue.v \
 	src/uart.v \
+	src/ft245.v \
 	src/fifo.v \
 	src/util.v \
 	src/pll.v

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CST_FILE = tangprimer25k.cst
 # Gowin IDE output
 BITSTREAM = impl/pnr/spi_flash.fs
 
-.PHONY: all build lint prog flash clean tool ftdi-setup help
+.PHONY: all build lint prog flash clean tool tool-d2xx ftdi-setup help
 
 all: build
 
@@ -55,10 +55,15 @@ ftdi-setup:
 	@echo ""
 	@echo "EEPROM programmed. Unplug and replug the FT2232H now."
 
-# Build the spi-flash-tool
+# Build the spi-flash-tool (default: rs-ftdi backend, pure Rust)
 tool:
 	cargo build --release --manifest-path tool/Cargo.toml
 	@echo "Tool built: tool/target/release/spi-flash-tool"
+
+# Build with D2XX backend (requires ftdi_sio unbind, proprietary C library)
+tool-d2xx:
+	cargo build --release --manifest-path tool/Cargo.toml --no-default-features --features d2xx
+	@echo "Tool built (D2XX backend): tool/target/release/spi-flash-tool"
 
 help:
 	@echo "Tang Primer 25K SPI Flash Emulator"
@@ -67,6 +72,7 @@ help:
 	@echo "  make prog    - Program FPGA (volatile)"
 	@echo "  make flash   - Program to flash (persistent)"
 	@echo "  make lint    - Lint Verilog with yosys"
-	@echo "  make tool    - Build spi-flash-tool"
+	@echo "  make tool    - Build spi-flash-tool (rs-ftdi backend, default)"
+	@echo "  make tool-d2xx - Build spi-flash-tool (D2XX backend)"
 	@echo "  make ftdi-setup - Program FT2232H EEPROM for 245 FIFO"
 	@echo "  make clean   - Clean build artifacts"

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CST_FILE = tangprimer25k.cst
 # Gowin IDE output
 BITSTREAM = impl/pnr/spi_flash.fs
 
-.PHONY: all build lint prog flash clean tool help
+.PHONY: all build lint prog flash clean tool ftdi-setup help
 
 all: build
 
@@ -49,6 +49,12 @@ flash: $(BITSTREAM)
 clean:
 	rm -rf impl
 
+# Program FT2232H EEPROM for async 245 FIFO mode on Channel A
+ftdi-setup:
+	ftdi_eeprom --flash-eeprom ft2232h.conf
+	@echo ""
+	@echo "EEPROM programmed. Unplug and replug the FT2232H now."
+
 # Build the spi-flash-tool
 tool:
 	cargo build --release --manifest-path tool/Cargo.toml
@@ -62,4 +68,5 @@ help:
 	@echo "  make flash   - Program to flash (persistent)"
 	@echo "  make lint    - Lint Verilog with yosys"
 	@echo "  make tool    - Build spi-flash-tool"
+	@echo "  make ftdi-setup - Program FT2232H EEPROM for 245 FIFO"
 	@echo "  make clean   - Clean build artifacts"

--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ NORbert uses a [Sipeed Tang Primer 25K](https://wiki.sipeed.com/hardware/en/tang
 - **64MB backing store** using two SDRAM chips with bit-interleaved storage for zero-overhead serial output
 - **Pipelined prefetch**: SDRAM reads are issued during SPI address/dummy phases so data is ready on the first clock edge
 - **2 Mbaud UART** interface for loading and dumping images from a host PC
+- **FT245 asynchronous FIFO** via FT2232H for faster bulk transfers (requires one-time EEPROM configuration)
 
 ## Hardware
 
 - [Sipeed Tang Primer 25K](https://wiki.sipeed.com/hardware/en/tang/tang-primer-25k/primer-25k.html) (Gowin GW5A-LV25MG121)
 - Tang Primer 25K Dock ext-board (provides SDRAM and USB-UART)
 - SPI signals exposed on PMOD connector J5
+- **Optional:** FT2232H breakout board for FT245 high-speed transport (e.g., CJMCU-FT2232H or any FT2232H module)
 
 ## Building
 
@@ -36,6 +38,7 @@ Without Nix, you'll need:
 - [openFPGALoader](https://github.com/trabucayre/openFPGALoader)
 - [yosys](https://github.com/YosysHQ/yosys) (optional, for linting)
 - Rust toolchain (for the host tool)
+- FTDI D2XX driver/library (only if using FT245 transport)
 
 ### FPGA bitstream
 
@@ -83,6 +86,38 @@ spi-flash-tool ports
 The `configure` command loads a chip definition from [rflasher](https://github.com/benpye/rflasher)'s RON database and sends the JEDEC ID, size, and a generated SFDP table to the FPGA. The chip name is matched by substring, so `W25Q128` is enough if it's unambiguous. Without configuration, NORbert defaults to Winbond W25Q64FV.
 
 Use `-p /dev/ttyUSBx` if your device isn't on the default `/dev/ttyUSB0`.
+
+### FT245 transport (FT2232H)
+
+For much faster bulk transfers (~5 MB/s vs ~200 KB/s over UART), connect an FT2232H module and use `--ft245`:
+
+```
+# List connected FT2232H devices
+spi-flash-tool ft-list
+
+# Use FT245 instead of UART for any command
+spi-flash-tool --ft245 version
+spi-flash-tool --ft245 load firmware.bin --verify
+spi-flash-tool --ft245 dump output.bin --length 0x100000
+spi-flash-tool --ft245 configure W25Q128JV --chips-dir ~/src/rflasher/chips/vendors
+
+# Select a specific FT2232H by serial number (when multiple are connected)
+spi-flash-tool --ft245 --ft-serial FT6XXXXX load firmware.bin
+```
+
+The FT2232H is used in asynchronous 245 FIFO mode. This requires a **one-time EEPROM configuration** to set Channel A to "245 FIFO" mode using [FT_PROG](https://ftdichip.com/utilities/#ft_prog) (Windows) or `ftd2xx_eeprom` (Linux). No special BitMode is set at runtime -- the host tool just opens the device and reads/writes normally.
+
+**Wiring:** Connect the FT2232H Channel A pins to the FPGA dock as follows:
+
+| FT2232H Pin | Signal   | FPGA Pin | Dock Location    |
+|-------------|----------|----------|------------------|
+| AD0-AD7     | D[0:7]   | H5, H8, G7, F5, H7, G8, G5, F3 | PMOD J7 |
+| RXF#        | ft_rxf_n | D10      | PMOD J6 top      |
+| TXE#        | ft_txe_n | G10      | PMOD J6 top      |
+| RD#         | ft_rd_n  | B10      | PMOD J6 top      |
+| WR#         | ft_wr_n  | H11      | Button S0 (core board) |
+
+Note: H11 is a core board button pin, repurposed for FT245 (buttons are unused by NORbert). CLKOUT and OE# are not used in async mode. All signals are 3.3V LVCMOS.
 
 ## SPI read performance
 
@@ -133,13 +168,14 @@ src/
   top.v        Top-level module, clock/reset, bus wiring
   spi_trx.v    SPI flash transceiver (command decoder + data path)
   sdram.v      Dual-chip SDRAM controller with interleaved storage
-  glue.v       UART protocol handler, SPI write engine, LED control
+  glue.v       Protocol handler, UART/FT245 mux, SPI write engine, LED control
   uart.v       UART TX/RX (2 Mbaud)
+  ft245.v      FT2232H async 245 FIFO interface
   fifo.v       Synchronous FIFO (first-word-fall-through)
   util.v       Clock divider, PWM, synchronizers
   pll.v        PLL: 50MHz -> 120MHz with phase-shifted outputs
 tool/
-  src/main.rs  Host-side CLI (Rust) for loading/dumping over UART
+  src/main.rs  Host-side CLI (Rust) for loading/dumping over UART or FT245
   src/chip.rs  Chip definition loading from rflasher RON database
   src/sfdp.rs  SFDP/BFPT table generation from chip definitions
 ```

--- a/build.tcl
+++ b/build.tcl
@@ -11,6 +11,7 @@ add_file src/spi_trx.v
 add_file src/sdram.v
 add_file src/glue.v
 add_file src/uart.v
+add_file src/ft245.v
 add_file src/fifo.v
 add_file src/util.v
 add_file src/pll.v

--- a/flake.nix
+++ b/flake.nix
@@ -138,6 +138,9 @@
             # Build tools
             gnumake
 
+            # FTDI EEPROM programming (FT2232H async 245 setup)
+            libftdi1
+
             # Rust toolchain for spi-flash-tool
             cargo
             rustc
@@ -155,6 +158,7 @@
             echo "  openFPGALoader   - FPGA programming"
             echo "  verilator        - Verilog simulation"
             echo "  gtkwave          - Waveform viewer"
+            echo "  ftdi_eeprom      - FT2232H EEPROM programmer"
             echo "  cargo            - Rust build tool"
             echo ""
             echo "Build commands:"

--- a/ft2232h.conf
+++ b/ft2232h.conf
@@ -1,0 +1,27 @@
+# FT2232H EEPROM configuration for NORbert
+# Programs Channel A as async 245 FIFO for high-speed SDRAM transfer.
+# Channel B left as UART (available for debug if needed).
+#
+# Usage:
+#   ftdi_eeprom --flash-eeprom ft2232h.conf
+#   (then unplug and replug the FT2232H)
+
+vendor_id=0x0403
+product_id=0x6010
+
+manufacturer="FTDI"
+product="NORbert FT245"
+serial="NORbert0"
+use_serial=true
+
+max_power=500
+self_powered=false
+remote_wakeup=false
+
+# Channel A: 245 FIFO mode (async, no CLKOUT needed)
+cha_type=FIFO
+cha_vcp=false
+
+# Channel B: UART (unused, kept as default)
+chb_type=UART
+chb_vcp=true

--- a/spi_flash.gprj
+++ b/spi_flash.gprj
@@ -10,6 +10,7 @@
         <File path="src/sdram.v" type="file.verilog" enable="1"/>
         <File path="src/glue.v" type="file.verilog" enable="1"/>
         <File path="src/uart.v" type="file.verilog" enable="1"/>
+        <File path="src/ft245.v" type="file.verilog" enable="1"/>
         <File path="src/fifo.v" type="file.verilog" enable="1"/>
         <File path="src/util.v" type="file.verilog" enable="1"/>
         <File path="src/pll.v" type="file.verilog" enable="1"/>

--- a/src/ft245.v
+++ b/src/ft245.v
@@ -1,0 +1,213 @@
+// FT245 Asynchronous FIFO Interface for FT2232H
+//
+// Implements FT2232H async 245 FIFO mode.  The FT2232H EEPROM must be
+// configured to set Channel A to "245 FIFO" mode (one-time setup with
+// FT_PROG).  No CLKOUT or OE# signals are used -- in async mode the
+// data bus direction is implicit from RD#.
+//
+// Provides the same byte-level interface as uart.v so glue.v can
+// use either transport interchangeably.
+//
+// Async FIFO read protocol (FT2232H -> FPGA):
+//   1. RXF# low indicates data available
+//   2. Assert RD# low -- FT2232H drives D[7:0]
+//   3. Wait >=50ns for data valid (t3 in FT2232H datasheet)
+//   4. Sample D[7:0], deassert RD# high
+//   5. Wait for recovery, check RXF# for next byte
+//
+// Async FIFO write protocol (FPGA -> FT2232H):
+//   1. TXE# low indicates space available
+//   2. Drive D[7:0] with data
+//   3. Assert WR# low, hold >=50ns (t9 in FT2232H datasheet)
+//   4. Deassert WR# high -- rising edge latches data
+
+`default_nettype none
+
+module ft245(
+    input wire clk,           // System clock (120MHz)
+    input wire reset,
+
+    // FT2232H physical interface
+    inout wire [7:0] ft_data, // Bidirectional data bus
+    input wire ft_rxf_n,      // RX FIFO not empty (active low)
+    input wire ft_txe_n,      // TX FIFO not full  (active low)
+    output reg ft_rd_n,       // Read strobe  (active low, FPGA output)
+    output reg ft_wr_n,       // Write strobe (active low, FPGA output)
+
+    // Byte-level interface (system clock domain, matches uart.v)
+    output reg [7:0] rxd,
+    output reg rxd_strobe,
+    input wire [7:0] txd,
+    input wire txd_strobe,
+    output wire txd_ready
+);
+
+    // -----------------------------------------------------------------
+    // Timing parameters (120MHz clock, ~8.3ns per cycle)
+    // All delays include margin above FT2232H datasheet minimums.
+    // -----------------------------------------------------------------
+    localparam [3:0]
+        DELAY_RD_DATA  = 4'd7,  // RD# active to data valid (~58ns, min 50ns)
+        DELAY_RD_RECOV = 4'd5,  // RD# recovery + sync pipeline (~42ns)
+        DELAY_WR_PULSE = 4'd7,  // WR# active pulse width (~58ns, min 50ns)
+        DELAY_WR_RECOV = 4'd5;  // WR# recovery + sync pipeline (~42ns)
+
+    // -----------------------------------------------------------------
+    // Synchronize FT2232H status inputs into system clock domain.
+    // -----------------------------------------------------------------
+    reg [1:0] rxf_sync, txe_sync;
+
+    wire rxf_low = !rxf_sync[1];   // Data available from FT2232H
+    wire txe_low = !txe_sync[1];   // FT2232H can accept data
+
+    always @(posedge clk) begin
+        rxf_sync <= {rxf_sync[0], ft_rxf_n};
+        txe_sync <= {txe_sync[0], ft_txe_n};
+    end
+
+    // -----------------------------------------------------------------
+    // Data bus tristate control
+    // -----------------------------------------------------------------
+    reg data_oe;
+    reg [7:0] data_out;
+    assign ft_data = data_oe ? data_out : 8'bz;
+
+    // -----------------------------------------------------------------
+    // TX pending buffer -- captures txd_strobe from glue
+    // -----------------------------------------------------------------
+    reg tx_pending;
+    reg [7:0] tx_byte;
+    assign txd_ready = !tx_pending;
+
+    // -----------------------------------------------------------------
+    // Delay counter
+    // -----------------------------------------------------------------
+    reg [3:0] delay_cnt;
+
+    // -----------------------------------------------------------------
+    // State machine
+    // -----------------------------------------------------------------
+    localparam [2:0]
+        ST_IDLE       = 3'd0,
+        ST_RD_STROBE  = 3'd1,   // RD# asserted, waiting for data valid
+        ST_RD_SAMPLE  = 3'd2,   // Sample data, deassert RD#
+        ST_RD_RECOVER = 3'd3,   // RD# recovery, check for more data
+        ST_WR_DRIVE   = 3'd4,   // Data driven, WR# asserted
+        ST_WR_RECOVER = 3'd5;   // WR# deasserted, recovery
+
+    reg [2:0] state;
+
+    always @(posedge clk) begin
+        rxd_strobe <= 0;
+
+        if (reset) begin
+            state      <= ST_IDLE;
+            ft_rd_n    <= 1;
+            ft_wr_n    <= 1;
+            data_oe    <= 0;
+            data_out   <= 0;
+            tx_pending <= 0;
+            tx_byte    <= 0;
+            rxd        <= 0;
+            delay_cnt  <= 0;
+        end
+        else begin
+            // Latch TX request from glue
+            if (txd_strobe && !tx_pending) begin
+                tx_pending <= 1;
+                tx_byte    <= txd;
+            end
+
+            case (state)
+                // ---------------------------------------------------
+                // IDLE: arbitrate between read (priority) and write
+                // ---------------------------------------------------
+                ST_IDLE: begin
+                    if (rxf_low && !tx_pending) begin
+                        // Start read: assert RD# (FT2232H drives bus)
+                        ft_rd_n   <= 0;
+                        data_oe   <= 0;
+                        delay_cnt <= DELAY_RD_DATA - 1;
+                        state     <= ST_RD_STROBE;
+                    end
+                    else if (tx_pending && txe_low) begin
+                        // Start write: drive data + assert WR#
+                        data_out  <= tx_byte;
+                        data_oe   <= 1;
+                        ft_wr_n   <= 0;
+                        delay_cnt <= DELAY_WR_PULSE - 1;
+                        state     <= ST_WR_DRIVE;
+                    end
+                end
+
+                // ---------------------------------------------------
+                // READ path: RD# -> delay -> sample -> recover
+                // ---------------------------------------------------
+
+                // RD# asserted, waiting for data to become valid
+                ST_RD_STROBE: begin
+                    if (delay_cnt != 0)
+                        delay_cnt <= delay_cnt - 1;
+                    else
+                        state <= ST_RD_SAMPLE;
+                end
+
+                // Sample data, deassert RD#
+                ST_RD_SAMPLE: begin
+                    rxd        <= ft_data;   // Direct sample (data stable for ~50ns)
+                    rxd_strobe <= 1;
+                    ft_rd_n    <= 1;
+                    delay_cnt  <= DELAY_RD_RECOV - 1;
+                    state      <= ST_RD_RECOVER;
+                end
+
+                // Recovery: wait for RXF# to update, check for more data
+                ST_RD_RECOVER: begin
+                    if (delay_cnt != 0)
+                        delay_cnt <= delay_cnt - 1;
+                    else begin
+                        if (rxf_low && !tx_pending) begin
+                            // More data available: re-assert RD#
+                            ft_rd_n   <= 0;
+                            delay_cnt <= DELAY_RD_DATA - 1;
+                            state     <= ST_RD_STROBE;
+                        end
+                        else begin
+                            state <= ST_IDLE;
+                        end
+                    end
+                end
+
+                // ---------------------------------------------------
+                // WRITE path: drive data + WR# -> latch -> release
+                // ---------------------------------------------------
+
+                // WR# asserted with data, holding for pulse width
+                ST_WR_DRIVE: begin
+                    if (delay_cnt != 0)
+                        delay_cnt <= delay_cnt - 1;
+                    else begin
+                        // Deassert WR# (rising edge latches data in FT2232H)
+                        ft_wr_n    <= 1;
+                        tx_pending <= 0;
+                        delay_cnt  <= DELAY_WR_RECOV - 1;
+                        state      <= ST_WR_RECOVER;
+                    end
+                end
+
+                // WR# recovery, release bus
+                ST_WR_RECOVER: begin
+                    if (delay_cnt != 0)
+                        delay_cnt <= delay_cnt - 1;
+                    else begin
+                        data_oe <= 0;
+                        state   <= ST_IDLE;
+                    end
+                end
+
+                default: state <= ST_IDLE;
+            endcase
+        end
+    end
+
+endmodule

--- a/src/ft245.v
+++ b/src/ft245.v
@@ -48,7 +48,7 @@ module ft245(
     // -----------------------------------------------------------------
     localparam [3:0]
         DELAY_RD_DATA  = 4'd7,  // RD# active to data valid (~58ns, min 50ns)
-        DELAY_RD_RECOV = 4'd5,  // RD# recovery + sync pipeline (~42ns)
+        DELAY_RD_RECOV = 4'd10, // RD# recovery + sync pipeline (~83ns, extra margin)
         DELAY_WR_PULSE = 4'd7,  // WR# active pulse width (~58ns, min 50ns)
         DELAY_WR_RECOV = 4'd5;  // WR# recovery + sync pipeline (~42ns)
 
@@ -92,8 +92,9 @@ module ft245(
         ST_RD_STROBE  = 3'd1,   // RD# asserted, waiting for data valid
         ST_RD_SAMPLE  = 3'd2,   // Sample data, deassert RD#
         ST_RD_RECOVER = 3'd3,   // RD# recovery, check for more data
-        ST_WR_DRIVE   = 3'd4,   // Data driven, WR# asserted
-        ST_WR_RECOVER = 3'd5;   // WR# deasserted, recovery
+        ST_WR_SETUP   = 3'd4,   // Data driven, WR# not yet asserted (t8 setup)
+        ST_WR_DRIVE   = 3'd5,   // Data driven, WR# asserted
+        ST_WR_RECOVER = 3'd6;   // WR# deasserted, recovery
 
     reg [2:0] state;
 
@@ -131,12 +132,11 @@ module ft245(
                         state     <= ST_RD_STROBE;
                     end
                     else if (tx_pending && txe_low) begin
-                        // Start write: drive data + assert WR#
+                        // Start write: drive data FIRST, WR# stays high
+                        // (satisfies t8: data setup before WR# active)
                         data_out  <= tx_byte;
                         data_oe   <= 1;
-                        ft_wr_n   <= 0;
-                        delay_cnt <= DELAY_WR_PULSE - 1;
-                        state     <= ST_WR_DRIVE;
+                        state     <= ST_WR_SETUP;
                     end
                 end
 
@@ -179,8 +179,17 @@ module ft245(
                 end
 
                 // ---------------------------------------------------
-                // WRITE path: drive data + WR# -> latch -> release
+                // WRITE path: setup -> WR# pulse -> release
                 // ---------------------------------------------------
+
+                // Data is being driven on bus, now assert WR#.
+                // One cycle of data setup (~8.3ns at 120MHz) satisfies
+                // FT2232H t8 requirement (5ns data setup before WR#).
+                ST_WR_SETUP: begin
+                    ft_wr_n   <= 0;
+                    delay_cnt <= DELAY_WR_PULSE - 1;
+                    state     <= ST_WR_DRIVE;
+                end
 
                 // WR# asserted with data, holding for pulse width
                 ST_WR_DRIVE: begin

--- a/src/glue.v
+++ b/src/glue.v
@@ -3,6 +3,10 @@
 //
 // Ported for Tang Primer 25K with 64MB external SDRAM (23-bit burst addresses)
 // Serial path uses 25-bit access_addr = {chip, row[12:0], bank[1:0], col[8:0]}
+//
+// Accepts bytes from EITHER UART or FT245.  When idle (no active command),
+// whichever port delivers a byte first becomes the "active port" for that
+// entire command.  Responses are routed back to the same port.
 
 `default_nettype none
 
@@ -10,12 +14,21 @@ module glue(
     input wire clk,
     input wire reset,
 
+    // UART byte interface
     input wire rxd_strobe,
     input wire [7:0] rxd_data,
 
     input wire txd_ready,
     output reg txd_strobe,
     output reg [7:0] txd_data,
+
+    // FT245 byte interface (accent identical to UART)
+    input wire ft_rxd_strobe,
+    input wire [7:0] ft_rxd_data,
+
+    input wire ft_txd_ready,
+    output reg ft_txd_strobe,
+    output reg [7:0] ft_txd_data,
 
     // SDRAM control signals
     output reg [1:0] sdram_access_cmd, // 00=nop 01=read 10=write 11=activate
@@ -108,6 +121,15 @@ module glue(
     
     reg [1:0] spi_csel_buf;
     
+    // Active port selection: 0 = UART, 1 = FT245
+    // Latched when a command byte arrives while idle.
+    reg active_port;
+
+    // Muxed RX/TX signals based on active port
+    wire mux_rxd_strobe = active_port ? ft_rxd_strobe : rxd_strobe;
+    wire [7:0] mux_rxd_data = active_port ? ft_rxd_data : rxd_data;
+    wire mux_txd_ready = active_port ? ft_txd_ready : txd_ready;
+
     // Heartbeat counter
     reg [25:0] heartbeat;
     
@@ -168,6 +190,10 @@ module glue(
             rxd_strobe_buf <= 0;
             rxd_data_buf <= 0;
             
+            active_port <= 0;
+            ft_txd_strobe <= 0;
+            ft_txd_data <= 0;
+            
             led <= 0;
             log_ack <= 0;
             
@@ -200,11 +226,21 @@ module glue(
         end
         else begin
             txd_strobe_buf <= 0;
-            txd_strobe <= txd_strobe_buf;
-            txd_data <= txd_data_buf;
-            
-            rxd_strobe_buf <= rxd_strobe;
-            rxd_data_buf <= rxd_data;
+
+            // Route TX to the active port
+            if (active_port) begin
+                ft_txd_strobe <= txd_strobe_buf;
+                ft_txd_data   <= txd_data_buf;
+                txd_strobe    <= 0;
+            end else begin
+                txd_strobe    <= txd_strobe_buf;
+                txd_data      <= txd_data_buf;
+                ft_txd_strobe <= 0;
+            end
+
+            // Mux RX from the active port (or either when idle)
+            rxd_strobe_buf <= mux_rxd_strobe;
+            rxd_data_buf   <= mux_rxd_data;
             
             sdram_access_addr <= addr_to_access;
             sdram_write_buffer <= write_buffer;
@@ -333,6 +369,15 @@ module glue(
                 serial_idle_count <= 0;
             end
             
+            // Port selection: when idle, latch which port delivered
+            // the first byte of a new command.
+            if (cmd == CMD_NOP && in_count == 0 && !read_state && !write_state) begin
+                if (ft_rxd_strobe)
+                    active_port <= 1;
+                else if (rxd_strobe)
+                    active_port <= 0;
+            end
+
             // Serial protocol handling
             if ((spi_reset || spi_csel_buf[1]) && !spi_writing) begin
                 
@@ -464,7 +509,7 @@ module glue(
                             sdram_access_cmd <= 2'b01;
                             read_state <= 3;
                         end
-                        else if ((read_state == 3) && !sdram_busy && txd_ready) begin
+                        else if ((read_state == 3) && !sdram_busy && mux_txd_ready) begin
                             txd_strobe_buf <= 1;
                             txd_data_buf <= sdram_read_buffer[read_pos*8 +: 8];
 
@@ -499,7 +544,7 @@ module glue(
                         end
                         else if ((write_state == 3) && !sdram_busy) begin
                             if (len == 1) begin
-                                if (txd_ready) begin
+                                if (mux_txd_ready) begin
                                     txd_strobe_buf <= 1;
                                     txd_data_buf <= 8'h01;
                                     write_state <= 0;

--- a/src/glue.v
+++ b/src/glue.v
@@ -22,9 +22,10 @@ module glue(
     output reg txd_strobe,
     output reg [7:0] txd_data,
 
-    // FT245 byte interface (accent identical to UART)
-    input wire ft_rxd_strobe,
-    input wire [7:0] ft_rxd_data,
+    // FT245 byte interface (pull-based via RX FIFO)
+    input wire ft_rx_data_available,
+    input wire [7:0] ft_rx_data,
+    output reg ft_rx_pop,
 
     input wire ft_txd_ready,
     output reg ft_txd_strobe,
@@ -83,17 +84,11 @@ module glue(
     reg [7:0] cmd;
     reg [7:0] in_count;
     
-    // Idle timeout: reset serial parser if no byte received within ~137us
-    // while in middle of a multi-byte command. Handles spurious bytes
+    // Idle timeout: reset serial parser if no byte received within ~546us
+    // while in middle of a multi-byte command.  Handles spurious bytes
     // from USB-UART bridge on port open/close.
-    // At 120MHz, 2^14 = 16384 cycles = ~137us
-    // This is long enough for back-to-back UART bytes within a USB
-    // transfer (~3.3us per byte at 3Mbaud) but short enough to recover
-    // quickly from spurious bytes before the tool's real command arrives
-    // via USB (~125us for high-speed, ~1ms for full-speed).
-    // The tool should combine command headers and data into single
-    // write() calls to avoid mid-command USB transfer gaps.
-    reg [14:0] serial_idle_count;
+    // At 120MHz, 2^16 = 65536 cycles = ~546us
+    reg [16:0] serial_idle_count;
 
     reg [22:0] addr;       // 23-bit burst address
     reg [7:0] len;
@@ -110,10 +105,11 @@ module glue(
     reg rxd_strobe_buf;
     reg [7:0] rxd_data_buf;
 
-    wire sdram_busy = (sdram_access_cmd != 0) || sdram_cmd_busy;
+    wire sdram_busy = (sdram_access_cmd != 0) || sdram_cmd_busy || sdram_read_busy;
     
     reg [63:0] write_buffer;
     reg write_strobe;
+    reg write_strobe_r;  // delayed copy for rising-edge detection
     
     reg [1:0] log_strobe_buf;
     always @(posedge clk) log_strobe_buf <= {log_strobe_buf[0], log_strobe};
@@ -125,10 +121,32 @@ module glue(
     // Latched when a command byte arrives while idle.
     reg active_port;
 
-    // Muxed RX/TX signals based on active port
-    wire mux_rxd_strobe = active_port ? ft_rxd_strobe : rxd_strobe;
-    wire [7:0] mux_rxd_data = active_port ? ft_rxd_data : rxd_data;
+    wire cmd_idle = (cmd == CMD_NOP) && (in_count == 0) && !read_state && !write_state;
     wire mux_txd_ready = active_port ? ft_txd_ready : txd_ready;
+
+    // Serial handler gate: only consume FIFO bytes when SPI is inactive.
+    // This prevents popping bytes that the serial handler would ignore,
+    // which is the root cause of the ACK corruption (0x00 instead of 0x01).
+    wire serial_gate = (spi_reset || spi_csel_buf[1]) && !spi_writing;
+
+    // Hold flag: prevent double-consume from FIFO.  Set for 1 cycle
+    // after popping a byte, cleared the next cycle.  Gives a 2-cycle
+    // cadence (consume, process, consume, ...) which is well within
+    // the FT245's ~12-cycle byte delivery rate.
+    reg ft_rx_hold;
+
+    // Pipeline-aware TX flow control.
+    // After txd_strobe_buf fires, it takes 2 cycles for ft245 to latch
+    // tx_pending and for ft_txd_ready to go low.  During those 2 cycles
+    // mux_txd_ready is stale (still high), so glue would over-send.
+    // tx_wait counts down to block sends until back-pressure propagates.
+    // The !txd_strobe_buf term blocks the cycle immediately after the
+    // send (when txd_strobe_buf is visible but tx_wait hasn't loaded yet).
+    // UART is unaffected: its 256-byte FIFO keeps txd_ready high, so the
+    // only overhead is a 2-cycle gap between bytes (~17ns, negligible at
+    // 2 Mbaud = ~5µs/byte).
+    reg [1:0] tx_wait;
+    wire can_send = mux_txd_ready && (tx_wait == 0) && !txd_strobe_buf;
 
     // Heartbeat counter
     reg [25:0] heartbeat;
@@ -183,6 +201,7 @@ module glue(
             sdram_inhibit_refresh <= 0;
 
             write_strobe <= 0;
+            write_strobe_r <= 0;
 
             txd_strobe_buf <= 0;
             txd_data_buf <= 0;
@@ -191,6 +210,8 @@ module glue(
             rxd_data_buf <= 0;
             
             active_port <= 0;
+            ft_rx_pop <= 0;
+            ft_rx_hold <= 0;
             ft_txd_strobe <= 0;
             ft_txd_data <= 0;
             
@@ -221,11 +242,19 @@ module glue(
             for (i = 0; i < 256; i = i + 1)
                 i_spi_write_data[i][8] <= 0;
             
+            tx_wait <= 0;
+
             for (i = 0; i < 128; i = i + 1)
                 sfdp_mem[i] <= 8'hFF;
         end
         else begin
             txd_strobe_buf <= 0;
+
+            // TX pipeline cooldown
+            if (txd_strobe_buf)
+                tx_wait <= 2'd2;
+            else if (tx_wait != 0)
+                tx_wait <= tx_wait - 1;
 
             // Route TX to the active port
             if (active_port) begin
@@ -238,12 +267,44 @@ module glue(
                 ft_txd_strobe <= 0;
             end
 
-            // Mux RX from the active port (or either when idle)
-            rxd_strobe_buf <= mux_rxd_strobe;
-            rxd_data_buf   <= mux_rxd_data;
+            // Pull-based RX mux: FT245 FIFO has priority over UART.
+            // Only pop from FIFO when the serial handler gate is open,
+            // preventing byte loss during SPI CS noise or spi_writing.
+            ft_rx_pop <= 0;
+            if (ft_rx_data_available && !ft_rx_hold && serial_gate) begin
+                rxd_strobe_buf <= 1;
+                rxd_data_buf <= ft_rx_data;
+                ft_rx_pop <= 1;
+                ft_rx_hold <= 1;
+                if (cmd_idle) active_port <= 1;
+            end else if (rxd_strobe) begin
+                rxd_strobe_buf <= 1;
+                rxd_data_buf <= rxd_data;
+                if (cmd_idle) active_port <= 0;
+            end else begin
+                rxd_strobe_buf <= 0;
+                if (ft_rx_hold) ft_rx_hold <= 0;
+            end
             
             sdram_access_addr <= addr_to_access;
-            sdram_write_buffer <= write_buffer;
+            // Snapshot write_buffer into sdram_write_buffer.
+            //
+            // Problem: FT245 delivers bytes ~12 cycles apart.  After byte 7
+            // sets write_strobe, byte 0 of the NEXT burst can arrive and
+            // overwrite write_buffer[0] before the SDRAM controller reads
+            // sdram_write_buffer.  Continuous mirroring would propagate the
+            // corruption.
+            //
+            // Solution: detect the rising edge of write_strobe (one cycle
+            // after byte 7 arrives, so write_buffer has all 8 bytes) and
+            // do one final mirror.  After that, freeze until both
+            // write_strobe and write_state are clear (write complete).
+            // SPI writes don't use write_strobe/write_state, so they
+            // get continuous mirroring as before.
+            write_strobe_r <= write_strobe;
+            if ((write_strobe && !write_strobe_r) ||
+                (!write_strobe && !write_state))
+                sdram_write_buffer <= write_buffer;
             
             // Inhibit SDRAM refresh while a serial-path operation is active.
             // We inhibit for ANY non-zero read/write state (not just 1-2)
@@ -269,8 +330,10 @@ module glue(
             led[3] <= !spi_csel_buf[1];
             led[0] <= heartbeat[25];                    // Heartbeat ~2Hz at 132MHz
             
-            // Log strobe handling
-            if (log_strobe_buf[1] && !log_ack) begin
+            // Log strobe handling -- only forward to UART (active_port=0).
+            // SPI noise can trigger spurious log bytes; sending them on
+            // FT245 would corrupt the binary command stream.
+            if (log_strobe_buf[1] && !log_ack && !active_port) begin
                 txd_strobe_buf <= 1;
                 txd_data_buf <= log_val;
                 log_ack <= 1;
@@ -360,7 +423,7 @@ module glue(
             // idle counter would fire and kill the transfer.
             if (in_count != 0 && !rxd_strobe_buf && !read_state && !write_state) begin
                 serial_idle_count <= serial_idle_count + 1;
-                if (serial_idle_count[14]) begin
+                if (serial_idle_count[16]) begin
                     in_count <= 0;
                     cmd <= CMD_NOP;
                 end
@@ -369,15 +432,6 @@ module glue(
                 serial_idle_count <= 0;
             end
             
-            // Port selection: when idle, latch which port delivered
-            // the first byte of a new command.
-            if (cmd == CMD_NOP && in_count == 0 && !read_state && !write_state) begin
-                if (ft_rxd_strobe)
-                    active_port <= 1;
-                else if (rxd_strobe)
-                    active_port <= 0;
-            end
-
             // Serial protocol handling
             if ((spi_reset || spi_csel_buf[1]) && !spi_writing) begin
                 
@@ -509,7 +563,7 @@ module glue(
                             sdram_access_cmd <= 2'b01;
                             read_state <= 3;
                         end
-                        else if ((read_state == 3) && !sdram_busy && mux_txd_ready) begin
+                        else if ((read_state == 3) && !sdram_busy && can_send) begin
                             txd_strobe_buf <= 1;
                             txd_data_buf <= sdram_read_buffer[read_pos*8 +: 8];
 
@@ -544,7 +598,7 @@ module glue(
                         end
                         else if ((write_state == 3) && !sdram_busy) begin
                             if (len == 1) begin
-                                if (mux_txd_ready) begin
+                                if (can_send) begin
                                     txd_strobe_buf <= 1;
                                     txd_data_buf <= 8'h01;
                                     write_state <= 0;

--- a/src/glue.v
+++ b/src/glue.v
@@ -79,7 +79,7 @@ module glue(
         CMD_RAMWRITE     = 8'h32,
         CMD_CHIPCONFIG   = 8'h33;
 
-    localparam VERSION = 8'h02;  // Version 2 for Tang Primer 25K port
+    localparam VERSION = 8'h03;  // Version 3: 16-bit burst length
 
     reg [7:0] cmd;
     reg [7:0] in_count;
@@ -91,7 +91,7 @@ module glue(
     reg [16:0] serial_idle_count;
 
     reg [22:0] addr;       // 23-bit burst address
-    reg [7:0] len;
+    reg [15:0] len;        // 16-bit burst count (v3: 2 header bytes)
 
     reg [2:0] read_state;
     reg [2:0] read_pos;
@@ -522,18 +522,19 @@ module glue(
                         end
                     end
                     else begin
-                        // RAMREAD / RAMWRITE handling
-                        // Address bytes: 3 bytes for 23-bit burst address
-                        // (shifted in MSB first)
+                        // RAMREAD / RAMWRITE handling (v3: 6-byte header)
+                        // Header: cmd, addr[2], addr[1], addr[0], len_hi, len_lo
                         if (in_count <= 3)
                             addr <= {addr[14:0], rxd_data_buf};
                         else if (in_count == 4)
-                            len <= rxd_data_buf;
+                            len[15:8] <= rxd_data_buf;
+                        else if (in_count == 5)
+                            len[7:0] <= rxd_data_buf;
 
-                        if (cmd == CMD_RAMREAD && in_count == 4) begin
+                        if (cmd == CMD_RAMREAD && in_count == 5) begin
                             read_state <= 1;
                         end
-                        if (cmd == CMD_RAMWRITE && in_count > 4) begin
+                        if (cmd == CMD_RAMWRITE && in_count > 5) begin
                             write_buffer[write_pos*8 +: 8] <= rxd_data_buf;
                             
                             if (write_pos == 7) begin
@@ -542,7 +543,7 @@ module glue(
                             write_pos <= write_pos + 1;
                         end
 
-                        if (in_count <= 4)
+                        if (in_count <= 5)
                             in_count <= in_count + 1;
                     end
 

--- a/src/top.v
+++ b/src/top.v
@@ -4,15 +4,15 @@
  * Ported from Tang Nano 20K version. Uses external SDRAM module on dock
  * with two W9825G6KH chips (64MB total) via 16-bit shared bus.
  *
- * SPI wiring on dock PMOD connector (bank 6):
- *   A11 = CS
- *   E11 = CLK  
- *   C11 = IO0 (MOSI / bidirectional in dual/quad mode)
- *   D11 = IO1 (MISO / bidirectional in dual/quad mode)
- *   B11 = IO2 (/WP / bidirectional in quad mode)
- *   C10 = IO3 (/HOLD / bidirectional in quad mode)
- *   A10 = POWER detection (active high)
- *   E10 = Debug output
+ * SPI wiring on dock PMOD J5 (all on bank 6):
+ *   A11 = CS          E11 = CLK
+ *   C11 = IO0 (MOSI)  D11 = IO1 (MISO)
+ *   G11 = IO2 (/WP)   B11 = IO3 (/HOLD)
+ *   A10 = POWER det    E10 = Debug
+ *
+ * FT245 wiring (FT2232H async FIFO, EEPROM set to "245 FIFO"):
+ *   Data D[7:0] on right PMOD J7: H5 H8 G7 F5 H7 G8 G5 F3
+ *   RXF#=D10  TXE#=G10  RD#=B10  WR#=H11
  *
  * Emulated flash chip is configured at runtime via the serial
  * CHIPCONFIG command (defaults to Winbond W25Q64FV 8MB).
@@ -25,15 +25,11 @@ module top(
     // LED
     output wire led,              // Active low LED (single LED on core board)
     
-    // User buttons
-    input wire btn_s1,
-    input wire btn_s2,
-    
     // UART via FTDI debugger on dock
     input wire uart_rx,           // FPGA receives from FTDI
     output wire uart_tx,          // FPGA transmits to FTDI
     
-    // SPI flash emulation interface (on dock GPIO header)
+    // SPI flash emulation interface (PMOD J5)
     input wire spi_cs_pin,        // Active low chip select
     input wire spi_clk_pin,       // SPI clock from master
     inout wire spi_mosi_pin,      // IO0: MOSI / bidirectional in dual/quad mode
@@ -42,6 +38,13 @@ module top(
     inout wire spi_io3_pin,       // IO3: /HOLD / bidirectional in quad mode
     input wire spi_power_pin,     // Power detection
     output wire spi_debug_pin,    // Debug output
+    
+    // FT245 asynchronous FIFO interface (FT2232H Channel A)
+    inout wire [7:0] ft_data,     // Bidirectional data bus D[7:0]
+    input wire ft_rxf_n,          // RX FIFO not empty (active low)
+    input wire ft_txe_n,          // TX FIFO not full  (active low)
+    output wire ft_rd_n,          // Read strobe  (active low)
+    output wire ft_wr_n,          // Write strobe (active low)
     
     // External SDRAM interface (via dock 40-pin connector)
     output wire        O_sdram_clk,
@@ -340,6 +343,31 @@ module top(
     );
     
     // -----------------------------------------------------------
+    // FT245 Interface (FT2232H async FIFO)
+    // -----------------------------------------------------------
+    
+    wire ft_txd_ready;
+    wire [7:0] ft_txd;
+    wire ft_txd_strobe;
+    wire ft_rxd_strobe;
+    wire [7:0] ft_rxd;
+    
+    ft245 ft245_i(
+        .clk(clk),
+        .reset(reset),
+        .ft_data(ft_data),
+        .ft_rxf_n(ft_rxf_n),
+        .ft_txe_n(ft_txe_n),
+        .ft_rd_n(ft_rd_n),
+        .ft_wr_n(ft_wr_n),
+        .rxd(ft_rxd),
+        .rxd_strobe(ft_rxd_strobe),
+        .txd(ft_txd),
+        .txd_strobe(ft_txd_strobe),
+        .txd_ready(ft_txd_ready)
+    );
+    
+    // -----------------------------------------------------------
     // Glue Logic
     // -----------------------------------------------------------
     
@@ -349,12 +377,21 @@ module top(
         .clk(clk),
         .reset(reset),
         
+        // UART byte interface
         .rxd_strobe(uart_rxd_strobe),
         .rxd_data(uart_rxd),
         
         .txd_ready(uart_txd_ready),
         .txd_strobe(uart_txd_strobe),
         .txd_data(uart_txd),
+        
+        // FT245 byte interface
+        .ft_rxd_strobe(ft_rxd_strobe),
+        .ft_rxd_data(ft_rxd),
+        
+        .ft_txd_ready(ft_txd_ready),
+        .ft_txd_strobe(ft_txd_strobe),
+        .ft_txd_data(ft_txd),
         
         .sdram_access_cmd(sdram_access_cmd),
         .sdram_access_addr(sdram_access_addr),

--- a/src/top.v
+++ b/src/top.v
@@ -349,8 +349,8 @@ module top(
     wire ft_txd_ready;
     wire [7:0] ft_txd;
     wire ft_txd_strobe;
-    wire ft_rxd_strobe;
-    wire [7:0] ft_rxd;
+    wire ft_rxd_strobe_raw;
+    wire [7:0] ft_rxd_raw;
     
     ft245 ft245_i(
         .clk(clk),
@@ -360,11 +360,43 @@ module top(
         .ft_txe_n(ft_txe_n),
         .ft_rd_n(ft_rd_n),
         .ft_wr_n(ft_wr_n),
-        .rxd(ft_rxd),
-        .rxd_strobe(ft_rxd_strobe),
+        .rxd(ft_rxd_raw),
+        .rxd_strobe(ft_rxd_strobe_raw),
         .txd(ft_txd),
         .txd_strobe(ft_txd_strobe),
         .txd_ready(ft_txd_ready)
+    );
+    
+    // -----------------------------------------------------------
+    // FT245 RX FIFO: decouple ft245 byte delivery from glue
+    //
+    // Without this FIFO, glue.v must consume each byte in the
+    // exact cycle ft245 asserts rxd_strobe.  A single missed
+    // cycle (due to timing, routing delay, or synthesis artefacts)
+    // drops a byte and hangs the protocol.  The FIFO lets ft245
+    // write at its own pace and glue read when ready.
+    //
+    // Pull-based design: glue sees data_available + read_data from
+    // the FWFT FIFO, and asserts ft_rx_pop only after it has
+    // actually consumed the byte.  This prevents byte loss when
+    // the serial handler gate is momentarily closed (e.g. SPI CS
+    // noise setting spi_csel_buf low, or spi_writing being set).
+    // -----------------------------------------------------------
+    
+    wire ft_rxfifo_data_available;
+    wire [7:0] ft_rxfifo_data;
+    wire ft_rx_pop;
+    
+    fifo #(.WIDTH(8), .NUM(16), .FREESPACE(1)) ft_rx_fifo(
+        .clk(clk),
+        .reset(reset),
+        .write_data(ft_rxd_raw),
+        .write_strobe(ft_rxd_strobe_raw),
+        .space_available(),      // ft245 never overflows 16-deep FIFO
+        .data_available(ft_rxfifo_data_available),
+        .more_available(),
+        .read_data(ft_rxfifo_data),
+        .read_strobe(ft_rx_pop)
     );
     
     // -----------------------------------------------------------
@@ -385,9 +417,10 @@ module top(
         .txd_strobe(uart_txd_strobe),
         .txd_data(uart_txd),
         
-        // FT245 byte interface
-        .ft_rxd_strobe(ft_rxd_strobe),
-        .ft_rxd_data(ft_rxd),
+        // FT245 byte interface (pull-based via RX FIFO)
+        .ft_rx_data_available(ft_rxfifo_data_available),
+        .ft_rx_data(ft_rxfifo_data),
+        .ft_rx_pop(ft_rx_pop),
         
         .ft_txd_ready(ft_txd_ready),
         .ft_txd_strobe(ft_txd_strobe),
@@ -430,7 +463,6 @@ module top(
     );
     
     // Single LED on Tang Primer 25K (active low)
-    // Use heartbeat (bit 0) as primary indicator
     assign led = ~led_out[0];
 
 endmodule

--- a/tangprimer25k.cst
+++ b/tangprimer25k.cst
@@ -22,12 +22,8 @@ IO_LOC "led" E8;
 IO_PORT "led" IO_TYPE=LVCMOS33 PULL_MODE=UP DRIVE=8;
 
 // ============================================================
-// User Buttons (on core board)
+// User Buttons (on core board) -- REMOVED: H11/H10 repurposed for FT245
 // ============================================================
-IO_LOC "btn_s1" H11;
-IO_LOC "btn_s2" H10;
-IO_PORT "btn_s1" IO_TYPE=LVCMOS33 PULL_MODE=DOWN;
-IO_PORT "btn_s2" IO_TYPE=LVCMOS33 PULL_MODE=DOWN;
 
 // ============================================================
 // UART via FTDI debugger on dock
@@ -39,13 +35,11 @@ IO_PORT "uart_rx" IO_TYPE=LVCMOS33 PULL_MODE=UP;
 
 // ============================================================
 // SPI Flash Emulation Interface
-// Using PMOD connector pins on the dock board (active tested,
-// directly accessible). Using bank 6 IOL pins (left PMOD).
+// All 8 signals on PMOD J5 (left top, bank 6 IOL pins).
 //
 // PMOD J5 connector (left side of dock):
-//   Top row:    A11  E11  C11  D11  (active I/O bank 6)
-//   Bottom row: A10  E10  C10  D10  (active I/O bank 6)
-//   + VCC, GND
+//   Top row:    G11  D11  C11  B11  GND  3V3
+//   Bottom row: A11  E11  E10  A10  GND  3V3
 // ============================================================
 
 // SPI Chip Select (active low)
@@ -64,8 +58,8 @@ IO_PORT "spi_mosi_pin" IO_TYPE=LVCMOS33 PULL_MODE=NONE DRIVE=8;
 IO_LOC "spi_miso_pin" D11;
 IO_PORT "spi_miso_pin" IO_TYPE=LVCMOS33 DRIVE=8;
 
-// SPI IO2 (/WP / bidirectional in quad mode)
-IO_LOC "spi_io2_pin" C10;
+// SPI IO2 (/WP / bidirectional in quad mode) -- moved to G11 (J5 top row)
+IO_LOC "spi_io2_pin" G11;
 IO_PORT "spi_io2_pin" IO_TYPE=LVCMOS33 PULL_MODE=UP DRIVE=8;
 
 // SPI IO3 (/HOLD / bidirectional in quad mode)
@@ -79,6 +73,55 @@ IO_PORT "spi_power_pin" IO_TYPE=LVCMOS33 PULL_MODE=DOWN;
 // Debug output
 IO_LOC "spi_debug_pin" E10;
 IO_PORT "spi_debug_pin" IO_TYPE=LVCMOS33 DRIVE=8;
+
+// ============================================================
+// FT245 Asynchronous FIFO Interface (FT2232H Channel A)
+// Used for high-speed SDRAM read/write (replaces UART path).
+// FT2232H EEPROM must be configured for "245 FIFO" on Channel A
+// (one-time setup via FT_PROG).  No CLKOUT or OE# in async mode.
+//
+// Data bus on right PMOD J7:
+//   Top row:    H5   H8   G7   F5   GND  3V3
+//   Bottom row: H7   G8   G5   F3   GND  3V3
+//
+// Control on left PMOD J6 top row + repurposed button pin:
+//   J6 top:     D10  G10  B10
+//   Button:     H11
+// ============================================================
+
+// FT245 bidirectional data bus D[7:0]
+IO_LOC "ft_data[0]" H5;
+IO_LOC "ft_data[1]" H8;
+IO_LOC "ft_data[2]" G7;
+IO_LOC "ft_data[3]" F5;
+IO_LOC "ft_data[4]" H7;
+IO_LOC "ft_data[5]" G8;
+IO_LOC "ft_data[6]" G5;
+IO_LOC "ft_data[7]" F3;
+IO_PORT "ft_data[0]" IO_TYPE=LVCMOS33 DRIVE=8;
+IO_PORT "ft_data[1]" IO_TYPE=LVCMOS33 DRIVE=8;
+IO_PORT "ft_data[2]" IO_TYPE=LVCMOS33 DRIVE=8;
+IO_PORT "ft_data[3]" IO_TYPE=LVCMOS33 DRIVE=8;
+IO_PORT "ft_data[4]" IO_TYPE=LVCMOS33 DRIVE=8;
+IO_PORT "ft_data[5]" IO_TYPE=LVCMOS33 DRIVE=8;
+IO_PORT "ft_data[6]" IO_TYPE=LVCMOS33 DRIVE=8;
+IO_PORT "ft_data[7]" IO_TYPE=LVCMOS33 DRIVE=8;
+
+// FT245 RXF# -- data available (active low, output from FT2232H)
+IO_LOC "ft_rxf_n" D10;
+IO_PORT "ft_rxf_n" IO_TYPE=LVCMOS33 PULL_MODE=UP;
+
+// FT245 TXE# -- transmit buffer not full (active low, output from FT2232H)
+IO_LOC "ft_txe_n" G10;
+IO_PORT "ft_txe_n" IO_TYPE=LVCMOS33 PULL_MODE=UP;
+
+// FT245 RD# -- read strobe (active low, output from FPGA)
+IO_LOC "ft_rd_n" B10;
+IO_PORT "ft_rd_n" IO_TYPE=LVCMOS33 DRIVE=8;
+
+// FT245 WR# -- write strobe (active low, output from FPGA)
+IO_LOC "ft_wr_n" H11;
+IO_PORT "ft_wr_n" IO_TYPE=LVCMOS33 DRIVE=8;
 
 // ============================================================
 // External SDRAM Module (via 40-pin connector on dock)

--- a/tangprimer25k.cst
+++ b/tangprimer25k.cst
@@ -22,7 +22,7 @@ IO_LOC "led" E8;
 IO_PORT "led" IO_TYPE=LVCMOS33 PULL_MODE=UP DRIVE=8;
 
 // ============================================================
-// User Buttons (on core board) -- REMOVED: H11/H10 repurposed for FT245
+// User Buttons (on core board) -- H11/H10 no longer used
 // ============================================================
 
 // ============================================================
@@ -34,94 +34,111 @@ IO_PORT "uart_tx" IO_TYPE=LVCMOS33 DRIVE=8;
 IO_PORT "uart_rx" IO_TYPE=LVCMOS33 PULL_MODE=UP;
 
 // ============================================================
-// SPI Flash Emulation Interface
-// All 8 signals on PMOD J5 (left top, bank 6 IOL pins).
+// PMOD 1 -- SPI Flash Emulation Interface (all 8 signals)
 //
-// PMOD J5 connector (left side of dock):
-//   Top row:    G11  D11  C11  B11  GND  3V3
-//   Bottom row: A11  E11  E10  A10  GND  3V3
+//   Top row:    G11  D11  B11  C11  GND  3V3
+//   Bottom row: G10  D10  B10  C10  GND  3V3
 // ============================================================
 
+// --- PMOD 1 top row: SPI core signals ---
+
 // SPI Chip Select (active low)
-IO_LOC "spi_cs_pin" A11;
+IO_LOC "spi_cs_pin" G11;
 IO_PORT "spi_cs_pin" IO_TYPE=LVCMOS33 PULL_MODE=UP;
 
 // SPI Clock (pull-down prevents floating noise when no SPI master connected)
-IO_LOC "spi_clk_pin" E11;
+IO_LOC "spi_clk_pin" D11;
 IO_PORT "spi_clk_pin" IO_TYPE=LVCMOS33 PULL_MODE=DOWN;
 
 // SPI IO0 (MOSI / bidirectional in dual/quad mode)
-IO_LOC "spi_mosi_pin" C11;
+IO_LOC "spi_mosi_pin" B11;
 IO_PORT "spi_mosi_pin" IO_TYPE=LVCMOS33 PULL_MODE=NONE DRIVE=8;
 
 // SPI IO1 (MISO / bidirectional in dual/quad mode)
-IO_LOC "spi_miso_pin" D11;
+IO_LOC "spi_miso_pin" C11;
 IO_PORT "spi_miso_pin" IO_TYPE=LVCMOS33 DRIVE=8;
 
-// SPI IO2 (/WP / bidirectional in quad mode) -- moved to G11 (J5 top row)
-IO_LOC "spi_io2_pin" G11;
+// --- PMOD 1 bottom row: SPI extended + aux ---
+
+// SPI IO2 (/WP / bidirectional in quad mode)
+IO_LOC "spi_io2_pin" G10;
 IO_PORT "spi_io2_pin" IO_TYPE=LVCMOS33 PULL_MODE=UP DRIVE=8;
 
 // SPI IO3 (/HOLD / bidirectional in quad mode)
-IO_LOC "spi_io3_pin" B11;
+IO_LOC "spi_io3_pin" D10;
 IO_PORT "spi_io3_pin" IO_TYPE=LVCMOS33 PULL_MODE=UP DRIVE=8;
 
 // SPI Power Detection (active high when SPI master is powered)
-IO_LOC "spi_power_pin" A10;
+IO_LOC "spi_power_pin" B10;
 IO_PORT "spi_power_pin" IO_TYPE=LVCMOS33 PULL_MODE=DOWN;
 
 // Debug output
-IO_LOC "spi_debug_pin" E10;
+IO_LOC "spi_debug_pin" C10;
 IO_PORT "spi_debug_pin" IO_TYPE=LVCMOS33 DRIVE=8;
 
 // ============================================================
-// FT245 Asynchronous FIFO Interface (FT2232H Channel A)
-// Used for high-speed SDRAM read/write (replaces UART path).
+// PMOD 2 -- FT245 control signals (top row) + 4 spare (bottom)
+//
+// FT2232H Channel A in async 245 FIFO mode.
 // FT2232H EEPROM must be configured for "245 FIFO" on Channel A
-// (one-time setup via FT_PROG).  No CLKOUT or OE# in async mode.
+// (one-time setup via FT_PROG).
 //
-// Data bus on right PMOD J7:
-//   Top row:    H5   H8   G7   F5   GND  3V3
-//   Bottom row: H7   G8   G5   F3   GND  3V3
-//
-// Control on left PMOD J6 top row + repurposed button pin:
-//   J6 top:     D10  G10  B10
-//   Button:     H11
+//   Top row:    A11  E11  K11  L5   GND  3V3
+//   Bottom row: A10  E10  L11  K5   GND  3V3
 // ============================================================
 
-// FT245 bidirectional data bus D[7:0]
-IO_LOC "ft_data[0]" H5;
-IO_LOC "ft_data[1]" H8;
-IO_LOC "ft_data[2]" G7;
+// --- PMOD 2 top row: FT245 control ---
+
+// FT245 RXF# -- data available (active low, output from FT2232H)
+IO_LOC "ft_rxf_n" A11;
+IO_PORT "ft_rxf_n" IO_TYPE=LVCMOS33 PULL_MODE=UP;
+
+// FT245 TXE# -- transmit buffer not full (active low, output from FT2232H)
+IO_LOC "ft_txe_n" E11;
+IO_PORT "ft_txe_n" IO_TYPE=LVCMOS33 PULL_MODE=UP;
+
+// FT245 RD# -- read strobe (active low, output from FPGA)
+IO_LOC "ft_rd_n" K11;
+IO_PORT "ft_rd_n" IO_TYPE=LVCMOS33 DRIVE=8;
+
+// FT245 WR# -- write strobe (active low, output from FPGA)
+IO_LOC "ft_wr_n" L5;
+IO_PORT "ft_wr_n" IO_TYPE=LVCMOS33 DRIVE=8;
+
+// --- PMOD 2 bottom row: spare ---
+// (spare) A10
+// (spare) E10
+// (spare) L11
+// (spare) K5
+
+// ============================================================
+// PMOD 3 -- FT245 data bus D[7:0]
+//
+//   Top row:    F5   G7   H8   H5   GND  3V3
+//   Bottom row: G5   G8   H7   J5   GND  3V3
+// ============================================================
+
+// --- PMOD 3 top row: FT245 data[3:0] ---
+
 IO_LOC "ft_data[3]" F5;
-IO_LOC "ft_data[4]" H7;
-IO_LOC "ft_data[5]" G8;
-IO_LOC "ft_data[6]" G5;
-IO_LOC "ft_data[7]" F3;
+IO_LOC "ft_data[2]" G7;
+IO_LOC "ft_data[1]" H8;
+IO_LOC "ft_data[0]" H5;
 IO_PORT "ft_data[0]" IO_TYPE=LVCMOS33 DRIVE=8;
 IO_PORT "ft_data[1]" IO_TYPE=LVCMOS33 DRIVE=8;
 IO_PORT "ft_data[2]" IO_TYPE=LVCMOS33 DRIVE=8;
 IO_PORT "ft_data[3]" IO_TYPE=LVCMOS33 DRIVE=8;
+
+// --- PMOD 3 bottom row: FT245 data[7:4] ---
+
+IO_LOC "ft_data[6]" G5;
+IO_LOC "ft_data[5]" G8;
+IO_LOC "ft_data[4]" H7;
+IO_LOC "ft_data[7]" J5;
 IO_PORT "ft_data[4]" IO_TYPE=LVCMOS33 DRIVE=8;
 IO_PORT "ft_data[5]" IO_TYPE=LVCMOS33 DRIVE=8;
 IO_PORT "ft_data[6]" IO_TYPE=LVCMOS33 DRIVE=8;
 IO_PORT "ft_data[7]" IO_TYPE=LVCMOS33 DRIVE=8;
-
-// FT245 RXF# -- data available (active low, output from FT2232H)
-IO_LOC "ft_rxf_n" D10;
-IO_PORT "ft_rxf_n" IO_TYPE=LVCMOS33 PULL_MODE=UP;
-
-// FT245 TXE# -- transmit buffer not full (active low, output from FT2232H)
-IO_LOC "ft_txe_n" G10;
-IO_PORT "ft_txe_n" IO_TYPE=LVCMOS33 PULL_MODE=UP;
-
-// FT245 RD# -- read strobe (active low, output from FPGA)
-IO_LOC "ft_rd_n" B10;
-IO_PORT "ft_rd_n" IO_TYPE=LVCMOS33 DRIVE=8;
-
-// FT245 WR# -- write strobe (active low, output from FPGA)
-IO_LOC "ft_wr_n" H11;
-IO_PORT "ft_wr_n" IO_TYPE=LVCMOS33 DRIVE=8;
 
 // ============================================================
 // External SDRAM Module (via 40-pin connector on dock)

--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -173,6 +173,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "ftdi-mpsse"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd2c246fb727197d284bf7273718ed6b1c9a94a128bb618b97f13daec658a12"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +233,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libftd2xx"
+version = "0.32.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f20d68b3138aaabb97edc3db8ed8f418d60f8abd2a7d8220d562906fb38ff08e"
+dependencies = [
+ "ftdi-mpsse",
+ "libftd2xx-ffi",
+ "log",
+ "paste",
+ "static_assertions",
+]
+
+[[package]]
+name = "libftd2xx-ffi"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd82d23ae0cbbf0fb65ad0310b474e45ddfdece8aa03a34130c59c04333c701"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "libudev"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +273,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mach2"
@@ -280,6 +317,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pkg-config"
@@ -387,15 +430,22 @@ dependencies = [
 
 [[package]]
 name = "spi-flash-tool"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
  "indicatif",
+ "libftd2xx",
  "ron",
  "serde",
  "serialport",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -173,6 +179,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ftdi"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "maybe-async",
+ "nusb",
+ "thiserror",
+]
+
+[[package]]
 name = "ftdi-mpsse"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +206,12 @@ checksum = "5dd2c246fb727197d284bf7273718ed6b1c9a94a128bb618b97f13daec658a12"
 dependencies = [
  "static_assertions",
 ]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "heck"
@@ -228,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libftd2xx"
@@ -275,6 +307,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +331,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -307,6 +362,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "nusb"
+version = "0.2.1"
+source = "git+https://github.com/ArthurHeymans/nusb.git?branch=task%2Fwebusb-rebased#6df0c0d6c3a152ad4a9058fb6acfac423d6c61ea"
+dependencies = [
+ "atomic-waker",
+ "core-foundation",
+ "core-foundation-sys",
+ "futures-core",
+ "io-kit-sys",
+ "js-sys",
+ "linux-raw-sys 0.9.4",
+ "log",
+ "once_cell",
+ "rustix",
+ "slab",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +401,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -364,6 +448,19 @@ dependencies = [
  "bitflags 2.10.0",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -410,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.8.1"
+version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f60a586160667241d7702c420fc223939fb3c0bb8d3fac84f78768e8970dee"
+checksum = "a4d91116f97173694f1642263b2ff837f80d933aa837e2314969f6728f661df3"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -422,11 +519,16 @@ dependencies = [
  "libudev",
  "mach2",
  "nix",
- "quote",
  "scopeguard",
  "unescaper",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "spi-flash-tool"
@@ -434,6 +536,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
+ "ftdi",
  "indicatif",
  "libftd2xx",
  "ron",
@@ -485,6 +588,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "unescaper"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +659,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +704,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,7 +735,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -587,7 +744,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -605,14 +771,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -622,10 +805,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -634,10 +829,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -646,10 +853,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -658,7 +877,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"

--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
 [[package]]
 name = "ftdi"
 version = "0.1.0"
+source = "git+https://github.com/ArthurHeymans/rs-ftdi.git#2431a609de6ef82d8d5332e79e0b8db49dd8187b"
 dependencies = [
  "log",
  "maybe-async",

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "spi-flash-tool"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "Tool for loading data into the Tang Nano 20K SPI Flash Emulator"
+description = "Tool for loading data into the Tang Primer 25K SPI Flash Emulator (UART + FT245)"
 
 [dependencies]
 serialport = "4.3"
+libftd2xx = "0.32"
 clap = { version = "4.4", features = ["derive"] }
 anyhow = "1.0"
 indicatif = "0.17"

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -12,7 +12,7 @@ ftdi = ["dep:ftdi"]
 [dependencies]
 serialport = "4.3"
 libftd2xx = { version = "0.32", optional = true }
-ftdi = { path = "../../rs-ftdi", optional = true }
+ftdi = { git = "https://github.com/ArthurHeymans/rs-ftdi.git", optional = true }
 clap = { version = "4.4", features = ["derive"] }
 anyhow = "1.0"
 indicatif = "0.17"

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -4,9 +4,15 @@ version = "0.2.0"
 edition = "2021"
 description = "Tool for loading data into the Tang Primer 25K SPI Flash Emulator (UART + FT245)"
 
+[features]
+default = ["ftdi"]
+d2xx = ["libftd2xx"]
+ftdi = ["dep:ftdi"]
+
 [dependencies]
 serialport = "4.3"
-libftd2xx = "0.32"
+libftd2xx = { version = "0.32", optional = true }
+ftdi = { path = "../../rs-ftdi", optional = true }
 clap = { version = "4.4", features = ["derive"] }
 anyhow = "1.0"
 indicatif = "0.17"

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -9,25 +9,364 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const BAUD_RATE: u32 = 2_000_000;
 const BLOCK_SIZE: usize = 2048; // Max transfer size (256 * 8 bytes)
 const PROTOCOL_VERSION: u8 = 2;
 
-// Protocol commands
+// Protocol commands (shared between UART and FT245 transports)
 const CMD_VERSION: u8 = 0x30;
 const CMD_READ: u8 = 0x31;
 const CMD_WRITE: u8 = 0x32;
 const CMD_CHIPCONFIG: u8 = 0x33;
 
+// FT2232H USB identifiers
+const FTDI_VID: u16 = 0x0403;
+const FT2232H_PID: u16 = 0x6010;
+
+// ---------------------------------------------------------------------------
+// Transport trait -- abstracts UART serial vs FT245 FIFO
+// ---------------------------------------------------------------------------
+
+trait Transport {
+    fn write_all(&mut self, data: &[u8]) -> Result<()>;
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()>;
+}
+
+// ---------------------------------------------------------------------------
+// UART transport (existing serial port path)
+// ---------------------------------------------------------------------------
+
+struct SerialTransport {
+    port: Box<dyn SerialPort>,
+}
+
+impl SerialTransport {
+    fn open(port_name: &str) -> Result<Self> {
+        let mut port = serialport::new(port_name, BAUD_RATE)
+            .timeout(Duration::from_secs(2))
+            .open()
+            .with_context(|| format!("Failed to open serial port {}", port_name))?;
+
+        // Sync with FPGA: USB-UART bridges can send spurious bytes on
+        // port open (DTR/RTS toggling, line glitches). Wait for the
+        // FPGA's idle timeout to fire and reset the parser, then flush.
+        thread::sleep(Duration::from_millis(5));
+
+        let mut discard = [0u8; 256];
+        port.set_timeout(Duration::from_millis(1))?;
+        while port.read(&mut discard).unwrap_or(0) > 0 {}
+        port.set_timeout(Duration::from_secs(2))?;
+
+        Ok(Self { port })
+    }
+}
+
+impl Transport for SerialTransport {
+    fn write_all(&mut self, data: &[u8]) -> Result<()> {
+        self.port.write_all(data)?;
+        Ok(())
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+        self.port.read_exact(buf)?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FT245 transport (FT2232H synchronous FIFO via libftd2xx)
+// ---------------------------------------------------------------------------
+
+struct Ft245Transport {
+    ft: libftd2xx::Ft2232h,
+}
+
+impl Ft245Transport {
+    fn open(serial: Option<&str>) -> Result<Self> {
+        use libftd2xx::FtdiCommon;
+
+        // FT2232H EEPROM must be configured for "245 FIFO" on Channel A
+        // (one-time setup using FT_PROG).  No special BitMode is needed
+        // for async FIFO -- just open, reset, and read/write.
+        let mut ft = if let Some(sn) = serial {
+            libftd2xx::Ft2232h::with_serial_number(sn)
+                .with_context(|| format!("No FT2232H with serial '{}'", sn))?
+        } else {
+            // Default: open Channel A by its standard description.
+            // If EEPROM was reprogrammed with a custom description,
+            // use --ft-serial to select by serial number instead.
+            libftd2xx::Ft2232h::with_description("Dual RS232-HS A")
+                .context("No FT2232H found (looking for 'Dual RS232-HS A')")?
+        };
+
+        ft.reset().context("FT2232H reset failed")?;
+        ft.purge_all().context("FT2232H purge failed")?;
+
+        // Set USB transfer size for bulk throughput
+        ft.set_usb_parameters(65536)
+            .context("Failed to set USB parameters")?;
+
+        // Low latency for responsive transfers
+        ft.set_latency_timer(Duration::from_millis(2))
+            .context("Failed to set latency timer")?;
+
+        // Drain any stale data in the receive buffer
+        let mut trash = [0u8; 4096];
+        loop {
+            let n = ft.queue_status().context("Failed to query queue status")?;
+            if n == 0 {
+                break;
+            }
+            let to_read = std::cmp::min(n, trash.len());
+            let _ = ft.read(&mut trash[..to_read]);
+        }
+
+        Ok(Self { ft })
+    }
+}
+
+impl Transport for Ft245Transport {
+    fn write_all(&mut self, data: &[u8]) -> Result<()> {
+        use libftd2xx::FtdiCommon;
+        self.ft.write_all(data)?;
+        Ok(())
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+        use libftd2xx::FtdiCommon;
+        let mut pos = 0;
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while pos < buf.len() {
+            if Instant::now() > deadline {
+                bail!("FT245 read timeout: got {} of {} bytes", pos, buf.len());
+            }
+            let n = self.ft.read(&mut buf[pos..])?;
+            if n == 0 {
+                thread::sleep(Duration::from_micros(100));
+            }
+            pos += n;
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FlashDevice -- protocol implementation over any transport
+// ---------------------------------------------------------------------------
+
+struct FlashDevice {
+    transport: Box<dyn Transport>,
+}
+
+impl FlashDevice {
+    fn open_serial(port_name: &str) -> Result<Self> {
+        Ok(Self {
+            transport: Box::new(SerialTransport::open(port_name)?),
+        })
+    }
+
+    fn open_ft245(serial: Option<&str>) -> Result<Self> {
+        Ok(Self {
+            transport: Box::new(Ft245Transport::open(serial)?),
+        })
+    }
+
+    fn get_version(&mut self) -> Result<u8> {
+        self.transport.write_all(&[CMD_VERSION])?;
+        let mut buf = [0u8; 1];
+        self.transport.read_exact(&mut buf)?;
+        Ok(buf[0])
+    }
+
+    fn read_block(&mut self, address: u32, length: usize) -> Result<Vec<u8>> {
+        if length == 0 || length > BLOCK_SIZE {
+            bail!("Invalid length: must be 1-{}", BLOCK_SIZE);
+        }
+        if address % 8 != 0 {
+            bail!("Address must be 8-byte aligned");
+        }
+        if length % 8 != 0 {
+            bail!("Length must be a multiple of 8");
+        }
+
+        let addr_units = address / 8;
+        let len_units = length / 8;
+
+        let cmd = [
+            CMD_READ,
+            ((addr_units >> 16) & 0xFF) as u8,
+            ((addr_units >> 8) & 0xFF) as u8,
+            (addr_units & 0xFF) as u8,
+            len_units as u8,
+        ];
+
+        self.transport.write_all(&cmd)?;
+
+        let mut buf = vec![0u8; length];
+        self.transport.read_exact(&mut buf)?;
+        Ok(buf)
+    }
+
+    fn write_block(&mut self, address: u32, data: &[u8]) -> Result<()> {
+        if data.is_empty() || data.len() > BLOCK_SIZE {
+            bail!("Invalid data length: must be 1-{}", BLOCK_SIZE);
+        }
+        if address % 8 != 0 {
+            bail!("Address must be 8-byte aligned");
+        }
+        if data.len() % 8 != 0 {
+            bail!("Data length must be a multiple of 8");
+        }
+
+        let addr_units = address / 8;
+        let len_units = data.len() / 8;
+
+        // Combine header and data into a single write to avoid
+        // transfer gaps that could trigger the FPGA's idle timeout
+        let mut buf = Vec::with_capacity(5 + data.len());
+        buf.extend_from_slice(&[
+            CMD_WRITE,
+            ((addr_units >> 16) & 0xFF) as u8,
+            ((addr_units >> 8) & 0xFF) as u8,
+            (addr_units & 0xFF) as u8,
+            len_units as u8,
+        ]);
+        buf.extend_from_slice(data);
+        self.transport.write_all(&buf)?;
+
+        // Wait for completion byte
+        let mut resp = [0u8; 1];
+        self.transport.read_exact(&mut resp)?;
+        if resp[0] != 0x01 {
+            bail!("Unexpected response: 0x{:02x}", resp[0]);
+        }
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    fn read(&mut self, address: u32, length: u32) -> Result<Vec<u8>> {
+        let mut result = Vec::with_capacity(length as usize);
+        let mut addr = address;
+        let mut remaining = length as usize;
+
+        let start_offset = (addr % 8) as usize;
+        if start_offset != 0 {
+            let aligned_addr = addr - start_offset as u32;
+            let chunk_len = std::cmp::min(8 - start_offset, remaining);
+            let block = self.read_block(aligned_addr, 8)?;
+            result.extend_from_slice(&block[start_offset..start_offset + chunk_len]);
+            addr += chunk_len as u32;
+            remaining -= chunk_len;
+        }
+
+        while remaining >= 8 {
+            let chunk_len = std::cmp::min(BLOCK_SIZE, remaining / 8 * 8);
+            let block = self.read_block(addr, chunk_len)?;
+            result.extend_from_slice(&block);
+            addr += chunk_len as u32;
+            remaining -= chunk_len;
+        }
+
+        if remaining > 0 {
+            let block = self.read_block(addr, 8)?;
+            result.extend_from_slice(&block[..remaining]);
+        }
+
+        Ok(result)
+    }
+
+    /// Send chip configuration to the FPGA.
+    ///
+    /// Protocol (CMD_CHIPCONFIG = 0x33):
+    ///   Byte 0:    0x33
+    ///   Byte 1:    JEDEC manufacturer ID
+    ///   Byte 2:    JEDEC device ID high byte
+    ///   Byte 3:    JEDEC device ID low byte
+    ///   Byte 4:    Flags (bit 0 = supports 4-byte addressing)
+    ///   Byte 5-7:  Chip erase burst count (23-bit, MSB first)
+    ///              = (total_size / 8) - 1
+    ///   Byte 8:    SFDP table length (0-128)
+    ///   Byte 9+:   SFDP table data
+    ///
+    /// Response: 0x01 on success.
+    fn send_chip_config(&mut self, chip: &chip::FlashChip, sfdp_table: &[u8]) -> Result<()> {
+        let jedec = chip.jedec_id_bytes();
+        let erase_bursts = chip.chip_erase_bursts();
+        let flags: u8 = if chip.supports_4byte { 0x01 } else { 0x00 };
+
+        let sfdp_len = sfdp_table.len();
+        if sfdp_len > 128 {
+            bail!("SFDP table too large: {} bytes (max 128)", sfdp_len);
+        }
+
+        // Build the full command in one buffer to avoid USB transfer gaps
+        let mut buf = Vec::with_capacity(9 + sfdp_len);
+        buf.push(CMD_CHIPCONFIG);
+        buf.push(jedec[0]); // manufacturer
+        buf.push(jedec[1]); // device high
+        buf.push(jedec[2]); // device low
+        buf.push(flags);
+        buf.push(((erase_bursts >> 16) & 0x7F) as u8);
+        buf.push(((erase_bursts >> 8) & 0xFF) as u8);
+        buf.push((erase_bursts & 0xFF) as u8);
+        buf.push(sfdp_len as u8);
+        buf.extend_from_slice(sfdp_table);
+        self.transport.write_all(&buf)?;
+
+        // Wait for ack
+        let mut resp = [0u8; 1];
+        self.transport.read_exact(&mut resp)?;
+        if resp[0] != 0x01 {
+            bail!("Chip config failed: unexpected response 0x{:02x}", resp[0]);
+        }
+        Ok(())
+    }
+
+    fn write(&mut self, address: u32, data: &[u8]) -> Result<()> {
+        if address % 8 != 0 {
+            bail!("Address must be 8-byte aligned for writes");
+        }
+
+        let mut padded = data.to_vec();
+        if padded.len() % 8 != 0 {
+            padded.resize((padded.len() + 7) / 8 * 8, 0xFF);
+        }
+
+        let mut addr = address;
+        let mut offset = 0;
+
+        while offset < padded.len() {
+            let chunk_len = std::cmp::min(BLOCK_SIZE, padded.len() - offset);
+            self.write_block(addr, &padded[offset..offset + chunk_len])?;
+            addr += chunk_len as u32;
+            offset += chunk_len;
+        }
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CLI definition
+// ---------------------------------------------------------------------------
+
 #[derive(Parser)]
 #[command(name = "spi-flash-tool")]
-#[command(about = "Tool for the Tang Primer 25K SPI Flash Emulator", long_about = None)]
+#[command(about = "Tool for the Tang Primer 25K SPI Flash Emulator (UART + FT245)", long_about = None)]
 struct Cli {
-    /// Serial port device
+    /// Serial port device (ignored when --ft245 is used)
     #[arg(short, long, default_value = "/dev/ttyUSB0")]
     port: String,
+
+    /// Use FT2232H FT245 synchronous FIFO instead of UART
+    #[arg(long)]
+    ft245: bool,
+
+    /// FT2232H serial number (for --ft245, when multiple devices are connected)
+    #[arg(long)]
+    ft_serial: Option<String>,
 
     #[command(subcommand)]
     command: Commands,
@@ -104,6 +443,9 @@ enum Commands {
 
     /// List available serial ports
     Ports,
+
+    /// List connected FT2232H devices
+    FtList,
 }
 
 fn parse_address(s: &str) -> Result<u32, String> {
@@ -115,215 +457,21 @@ fn parse_address(s: &str) -> Result<u32, String> {
     }
 }
 
-struct FlashDevice {
-    port: Box<dyn SerialPort>,
-}
+// ---------------------------------------------------------------------------
+// Command implementations
+// ---------------------------------------------------------------------------
 
-impl FlashDevice {
-    fn open(port_name: &str) -> Result<Self> {
-        let mut port = serialport::new(port_name, BAUD_RATE)
-            .timeout(Duration::from_secs(2))
-            .open()
-            .with_context(|| format!("Failed to open serial port {}", port_name))?;
-
-        // Sync with FPGA: USB-UART bridges can send spurious bytes on
-        // port open (DTR/RTS toggling, line glitches). If a spurious
-        // byte matches CMD_READ/CMD_WRITE, the FPGA parser enters
-        // multi-byte command mode and our real command gets consumed as
-        // address bytes. Wait for the FPGA's idle timeout to fire and
-        // reset the parser, then flush any stale RX data.
-        thread::sleep(Duration::from_millis(5));
-
-        // Drain any bytes in the RX buffer (bridge noise, log bytes, etc.)
-        let mut discard = [0u8; 256];
-        port.set_timeout(Duration::from_millis(1))?;
-        while port.read(&mut discard).unwrap_or(0) > 0 {}
-        port.set_timeout(Duration::from_secs(2))?;
-
-        Ok(Self { port })
-    }
-
-    fn get_version(&mut self) -> Result<u8> {
-        self.port.write_all(&[CMD_VERSION])?;
-        let mut buf = [0u8; 1];
-        self.port.read_exact(&mut buf)?;
-        Ok(buf[0])
-    }
-
-    fn read_block(&mut self, address: u32, length: usize) -> Result<Vec<u8>> {
-        if length == 0 || length > BLOCK_SIZE {
-            bail!("Invalid length: must be 1-{}", BLOCK_SIZE);
-        }
-        if address % 8 != 0 {
-            bail!("Address must be 8-byte aligned");
-        }
-        if length % 8 != 0 {
-            bail!("Length must be a multiple of 8");
-        }
-
-        let addr_units = address / 8;
-        let len_units = length / 8; // Number of 8-byte bursts
-
-        let cmd = [
-            CMD_READ,
-            ((addr_units >> 16) & 0xFF) as u8,
-            ((addr_units >> 8) & 0xFF) as u8,
-            (addr_units & 0xFF) as u8,
-            len_units as u8,
-        ];
-
-        self.port.write_all(&cmd)?;
-
-        let mut buf = vec![0u8; length];
-        self.port.read_exact(&mut buf)?;
-        Ok(buf)
-    }
-
-    fn write_block(&mut self, address: u32, data: &[u8]) -> Result<()> {
-        if data.is_empty() || data.len() > BLOCK_SIZE {
-            bail!("Invalid data length: must be 1-{}", BLOCK_SIZE);
-        }
-        if address % 8 != 0 {
-            bail!("Address must be 8-byte aligned");
-        }
-        if data.len() % 8 != 0 {
-            bail!("Data length must be a multiple of 8");
-        }
-
-        let addr_units = address / 8;
-        let len_units = data.len() / 8; // Number of 8-byte bursts
-
-        // Combine header and data into a single write to avoid USB
-        // transfer gaps that could trigger the FPGA's idle timeout
-        let mut buf = Vec::with_capacity(5 + data.len());
-        buf.extend_from_slice(&[
-            CMD_WRITE,
-            ((addr_units >> 16) & 0xFF) as u8,
-            ((addr_units >> 8) & 0xFF) as u8,
-            (addr_units & 0xFF) as u8,
-            len_units as u8,
-        ]);
-        buf.extend_from_slice(data);
-        self.port.write_all(&buf)?;
-
-        // Wait for completion byte
-        let mut resp = [0u8; 1];
-        self.port.read_exact(&mut resp)?;
-        if resp[0] != 0x01 {
-            bail!("Unexpected response: 0x{:02x}", resp[0]);
-        }
-        Ok(())
-    }
-
-    #[allow(dead_code)]
-    fn read(&mut self, address: u32, length: u32) -> Result<Vec<u8>> {
-        let mut result = Vec::with_capacity(length as usize);
-        let mut addr = address;
-        let mut remaining = length as usize;
-
-        // Align to 8 bytes
-        let start_offset = (addr % 8) as usize;
-        if start_offset != 0 {
-            let aligned_addr = addr - start_offset as u32;
-            let chunk_len = std::cmp::min(8 - start_offset, remaining);
-            let block = self.read_block(aligned_addr, 8)?;
-            result.extend_from_slice(&block[start_offset..start_offset + chunk_len]);
-            addr += chunk_len as u32;
-            remaining -= chunk_len;
-        }
-
-        // Read full blocks
-        while remaining >= 8 {
-            let chunk_len = std::cmp::min(BLOCK_SIZE, remaining / 8 * 8);
-            let block = self.read_block(addr, chunk_len)?;
-            result.extend_from_slice(&block);
-            addr += chunk_len as u32;
-            remaining -= chunk_len;
-        }
-
-        // Read remaining bytes
-        if remaining > 0 {
-            let block = self.read_block(addr, 8)?;
-            result.extend_from_slice(&block[..remaining]);
-        }
-
-        Ok(result)
-    }
-
-    /// Send chip configuration to the FPGA.
-    ///
-    /// Protocol (CMD_CHIPCONFIG = 0x33):
-    ///   Byte 0:    0x33
-    ///   Byte 1:    JEDEC manufacturer ID
-    ///   Byte 2:    JEDEC device ID high byte
-    ///   Byte 3:    JEDEC device ID low byte
-    ///   Byte 4:    Flags (bit 0 = supports 4-byte addressing)
-    ///   Byte 5-7:  Chip erase burst count (23-bit, MSB first)
-    ///              = (total_size / 8) - 1
-    ///   Byte 8:    SFDP table length (0-128)
-    ///   Byte 9+:   SFDP table data
-    ///
-    /// Response: 0x01 on success.
-    fn send_chip_config(&mut self, chip: &chip::FlashChip, sfdp_table: &[u8]) -> Result<()> {
-        let jedec = chip.jedec_id_bytes();
-        let erase_bursts = chip.chip_erase_bursts();
-        let flags: u8 = if chip.supports_4byte { 0x01 } else { 0x00 };
-
-        let sfdp_len = sfdp_table.len();
-        if sfdp_len > 128 {
-            bail!("SFDP table too large: {} bytes (max 128)", sfdp_len);
-        }
-
-        // Build the full command in one buffer to avoid USB transfer gaps
-        let mut buf = Vec::with_capacity(9 + sfdp_len);
-        buf.push(CMD_CHIPCONFIG);
-        buf.push(jedec[0]); // manufacturer
-        buf.push(jedec[1]); // device high
-        buf.push(jedec[2]); // device low
-        buf.push(flags);
-        buf.push(((erase_bursts >> 16) & 0x7F) as u8);
-        buf.push(((erase_bursts >> 8) & 0xFF) as u8);
-        buf.push((erase_bursts & 0xFF) as u8);
-        buf.push(sfdp_len as u8);
-        buf.extend_from_slice(sfdp_table);
-        self.port.write_all(&buf)?;
-
-        // Wait for ack
-        let mut resp = [0u8; 1];
-        self.port.read_exact(&mut resp)?;
-        if resp[0] != 0x01 {
-            bail!("Chip config failed: unexpected response 0x{:02x}", resp[0]);
-        }
-        Ok(())
-    }
-
-    fn write(&mut self, address: u32, data: &[u8]) -> Result<()> {
-        if address % 8 != 0 {
-            bail!("Address must be 8-byte aligned for writes");
-        }
-
-        let mut padded = data.to_vec();
-        // Pad to 8-byte boundary
-        if padded.len() % 8 != 0 {
-            padded.resize((padded.len() + 7) / 8 * 8, 0xFF);
-        }
-
-        let mut addr = address;
-        let mut offset = 0;
-
-        while offset < padded.len() {
-            let chunk_len = std::cmp::min(BLOCK_SIZE, padded.len() - offset);
-            self.write_block(addr, &padded[offset..offset + chunk_len])?;
-            addr += chunk_len as u32;
-            offset += chunk_len;
-        }
-
-        Ok(())
+fn open_device(cli: &Cli) -> Result<FlashDevice> {
+    if cli.ft245 {
+        eprintln!("Opening FT2232H in sync FIFO mode...");
+        FlashDevice::open_ft245(cli.ft_serial.as_deref())
+    } else {
+        FlashDevice::open_serial(&cli.port)
     }
 }
 
-fn cmd_version(port: &str) -> Result<()> {
-    let mut device = FlashDevice::open(port)?;
+fn cmd_version(cli: &Cli) -> Result<()> {
+    let mut device = open_device(cli)?;
     let version = device.get_version()?;
     println!("Protocol version: {}", version);
     if version != PROTOCOL_VERSION {
@@ -335,8 +483,8 @@ fn cmd_version(port: &str) -> Result<()> {
     Ok(())
 }
 
-fn cmd_read(port: &str, address: u32, length: u32, output: Option<PathBuf>) -> Result<()> {
-    let mut device = FlashDevice::open(port)?;
+fn cmd_read(cli: &Cli, address: u32, length: u32, output: Option<PathBuf>) -> Result<()> {
+    let mut device = open_device(cli)?;
 
     let pb = ProgressBar::new(length as u64);
     pb.set_style(
@@ -349,7 +497,6 @@ fn cmd_read(port: &str, address: u32, length: u32, output: Option<PathBuf>) -> R
     let mut addr = address;
     let mut remaining = length as usize;
 
-    // Align to 8 bytes
     let start_offset = (addr % 8) as usize;
     if start_offset != 0 {
         let aligned_addr = addr - start_offset as u32;
@@ -385,13 +532,11 @@ fn cmd_read(port: &str, address: u32, length: u32, output: Option<PathBuf>) -> R
             println!("Wrote {} bytes to {}", result.len(), path.display());
         }
         None => {
-            // Print as hex dump
             for (i, chunk) in result.chunks(16).enumerate() {
                 print!("{:08x}: ", address as usize + i * 16);
                 for b in chunk {
                     print!("{:02x} ", b);
                 }
-                // Pad if less than 16 bytes
                 for _ in chunk.len()..16 {
                     print!("   ");
                 }
@@ -412,7 +557,7 @@ fn cmd_read(port: &str, address: u32, length: u32, output: Option<PathBuf>) -> R
     Ok(())
 }
 
-fn cmd_write(port: &str, address: u32, data_hex: &str) -> Result<()> {
+fn cmd_write(cli: &Cli, address: u32, data_hex: &str) -> Result<()> {
     let data =
         hex::decode(data_hex.replace(' ', "")).map_err(|e| anyhow!("Invalid hex string: {}", e))?;
 
@@ -420,9 +565,8 @@ fn cmd_write(port: &str, address: u32, data_hex: &str) -> Result<()> {
         bail!("No data to write");
     }
 
-    let mut device = FlashDevice::open(port)?;
+    let mut device = open_device(cli)?;
 
-    // Pad to 8-byte boundary
     let mut padded = data.clone();
     if padded.len() % 8 != 0 {
         padded.resize((padded.len() + 7) / 8 * 8, 0xFF);
@@ -433,7 +577,7 @@ fn cmd_write(port: &str, address: u32, data_hex: &str) -> Result<()> {
     Ok(())
 }
 
-fn cmd_load(port: &str, file: &PathBuf, address: u32, verify: bool) -> Result<()> {
+fn cmd_load(cli: &Cli, file: &PathBuf, address: u32, verify: bool) -> Result<()> {
     let mut f = File::open(file).with_context(|| format!("Failed to open {}", file.display()))?;
     let mut data = Vec::new();
     f.read_to_end(&mut data)?;
@@ -442,16 +586,17 @@ fn cmd_load(port: &str, file: &PathBuf, address: u32, verify: bool) -> Result<()
         bail!("File is empty");
     }
 
+    let transport_name = if cli.ft245 { "FT245" } else { "UART" };
     println!(
-        "Loading {} ({} bytes) to 0x{:08x}",
+        "Loading {} ({} bytes) to 0x{:08x} via {}",
         file.display(),
         data.len(),
-        address
+        address,
+        transport_name
     );
 
-    let mut device = FlashDevice::open(port)?;
+    let mut device = open_device(cli)?;
 
-    // Pad to 8-byte boundary
     let mut padded = data.clone();
     if padded.len() % 8 != 0 {
         padded.resize((padded.len() + 7) / 8 * 8, 0xFF);
@@ -531,11 +676,11 @@ fn cmd_load(port: &str, file: &PathBuf, address: u32, verify: bool) -> Result<()
     Ok(())
 }
 
-fn cmd_dump(port: &str, file: &PathBuf, address: u32, length: u32) -> Result<()> {
-    cmd_read(port, address, length, Some(file.clone()))
+fn cmd_dump(cli: &Cli, file: &PathBuf, address: u32, length: u32) -> Result<()> {
+    cmd_read(cli, address, length, Some(file.clone()))
 }
 
-fn cmd_configure(port: &str, chip_db_path: &str, chip_name: &str) -> Result<()> {
+fn cmd_configure(cli: &Cli, chip_db_path: &str, chip_name: &str) -> Result<()> {
     // Expand ~ in path
     let expanded = if chip_db_path.starts_with("~/") {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
@@ -581,7 +726,7 @@ fn cmd_configure(port: &str, chip_db_path: &str, chip_name: &str) -> Result<()> 
     eprintln!("  SFDP table: {} bytes", sfdp_table.len());
 
     // Send to FPGA
-    let mut device = FlashDevice::open(port)?;
+    let mut device = open_device(cli)?;
     device.send_chip_config(chip, &sfdp_table)?;
 
     eprintln!("Configuration applied successfully.");
@@ -615,29 +760,56 @@ fn cmd_ports() -> Result<()> {
     Ok(())
 }
 
+fn cmd_ft_list() -> Result<()> {
+    let devices = libftd2xx::list_devices().context("Failed to enumerate FTDI devices")?;
+
+    if devices.is_empty() {
+        println!("No FTDI devices found");
+        println!(
+            "Hint: FT2232H has VID:PID {:04x}:{:04x}",
+            FTDI_VID, FT2232H_PID
+        );
+        return Ok(());
+    }
+
+    println!("FTDI devices ({} found):", devices.len());
+    for (i, dev) in devices.iter().enumerate() {
+        println!("  [{}] {:?}", i, dev);
+    }
+    println!();
+    println!("Use --ft-serial <SERIAL> to select a specific device.");
+    println!("Channel A (\"Dual RS232-HS A\") is used by default for sync FIFO.");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    match cli.command {
-        Commands::Version => cmd_version(&cli.port),
+    match &cli.command {
+        Commands::Version => cmd_version(&cli),
         Commands::Read {
             address,
             length,
             output,
-        } => cmd_read(&cli.port, address, length, output),
-        Commands::Write { address, data } => cmd_write(&cli.port, address, &data),
+        } => cmd_read(&cli, *address, *length, output.clone()),
+        Commands::Write { address, data } => cmd_write(&cli, *address, data),
         Commands::Load {
             file,
             address,
             verify,
-        } => cmd_load(&cli.port, &file, address, verify),
+        } => cmd_load(&cli, file, *address, *verify),
         Commands::Dump {
             file,
             address,
             length,
-        } => cmd_dump(&cli.port, &file, address, length),
-        Commands::Configure { chip_db, chip } => cmd_configure(&cli.port, &chip_db, &chip),
+        } => cmd_dump(&cli, file, *address, *length),
+        Commands::Configure { chip_db, chip } => cmd_configure(&cli, chip_db, chip),
         Commands::Ports => cmd_ports(),
+        Commands::FtList => cmd_ft_list(),
     }
 }
 

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -9,7 +9,9 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(any(feature = "d2xx", feature = "ftdi"))]
+use std::time::Instant;
 
 const BAUD_RATE: u32 = 2_000_000;
 const BLOCK_SIZE: usize = 2048; // 256 bursts * 8 bytes
@@ -22,7 +24,9 @@ const CMD_WRITE: u8 = 0x32;
 const CMD_CHIPCONFIG: u8 = 0x33;
 
 // FT2232H USB identifiers
+#[cfg(any(feature = "d2xx", feature = "ftdi"))]
 const FTDI_VID: u16 = 0x0403;
+#[cfg(any(feature = "d2xx", feature = "ftdi"))]
 const FT2232H_PID: u16 = 0x6010;
 
 // ---------------------------------------------------------------------------
@@ -76,13 +80,15 @@ impl Transport for SerialTransport {
 }
 
 // ---------------------------------------------------------------------------
-// FT245 transport (FT2232H synchronous FIFO via libftd2xx)
+// FT245 transport -- D2XX backend (FTDI's proprietary driver)
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "d2xx")]
 struct Ft245Transport {
     ft: libftd2xx::Ft2232h,
 }
 
+#[cfg(feature = "d2xx")]
 impl Ft245Transport {
     fn open(serial: Option<&str>) -> Result<Self> {
         use libftd2xx::FtdiCommon;
@@ -131,6 +137,7 @@ impl Ft245Transport {
     }
 }
 
+#[cfg(feature = "d2xx")]
 impl Transport for Ft245Transport {
     fn write_all(&mut self, data: &[u8]) -> Result<()> {
         use libftd2xx::FtdiCommon;
@@ -157,6 +164,93 @@ impl Transport for Ft245Transport {
 }
 
 // ---------------------------------------------------------------------------
+// FT245 transport -- rs-ftdi backend (pure Rust, nusb)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "ftdi")]
+struct Ft245Transport {
+    dev: ftdi::FtdiDevice,
+}
+
+#[cfg(feature = "ftdi")]
+impl Ft245Transport {
+    fn open(serial: Option<&str>) -> Result<Self> {
+        // Open the FT2232H Channel A.  The EEPROM must already be
+        // configured for "245 FIFO" mode (same as the D2XX path).
+        let mut dev = if let Some(sn) = serial {
+            let filter = ftdi::DeviceFilter::new(FTDI_VID, FT2232H_PID).serial(sn);
+            ftdi::FtdiDevice::open_with_filter(&filter, ftdi::Interface::A)
+                .with_context(|| format!("No FT2232H with serial '{}'", sn))?
+        } else {
+            // Try to find by description first
+            let filter =
+                ftdi::DeviceFilter::new(FTDI_VID, FT2232H_PID).description("NORbert FT245");
+            ftdi::FtdiDevice::open_with_filter(&filter, ftdi::Interface::A)
+                .or_else(|_| {
+                    // Fall back to opening any FT2232H on interface A
+                    ftdi::FtdiDevice::open_with_interface(FTDI_VID, FT2232H_PID, ftdi::Interface::A)
+                })
+                .context("No FT2232H found")?
+        };
+
+        // Reset and flush
+        dev.usb_reset().context("FT2232H reset failed")?;
+        dev.flush_all().context("FT2232H flush failed")?;
+
+        // Low latency for responsive transfers
+        dev.set_latency_timer(2)
+            .context("Failed to set latency timer")?;
+
+        // Configure timeouts
+        dev.set_read_timeout(Duration::from_secs(5));
+        dev.set_write_timeout(Duration::from_secs(5));
+
+        // Use large read chunks for throughput
+        dev.set_read_chunksize(65536);
+        dev.set_write_chunksize(65536);
+
+        // Drain stale data from the read buffer
+        let mut trash = [0u8; 4096];
+        loop {
+            match dev.read_data(&mut trash) {
+                Ok(0) => break,
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
+
+        Ok(Self { dev })
+    }
+}
+
+#[cfg(feature = "ftdi")]
+impl Transport for Ft245Transport {
+    fn write_all(&mut self, data: &[u8]) -> Result<()> {
+        self.dev.write_all(data).map_err(|e| anyhow!(e))?;
+        Ok(())
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+        let mut pos = 0;
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while pos < buf.len() {
+            if Instant::now() > deadline {
+                bail!("FT245 read timeout: got {} of {} bytes", pos, buf.len());
+            }
+            let n = self
+                .dev
+                .read_data(&mut buf[pos..])
+                .map_err(|e| anyhow!(e))?;
+            if n == 0 {
+                thread::sleep(Duration::from_micros(100));
+            }
+            pos += n;
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // FlashDevice -- protocol implementation over any transport
 // ---------------------------------------------------------------------------
 
@@ -171,6 +265,7 @@ impl FlashDevice {
         })
     }
 
+    #[cfg(any(feature = "d2xx", feature = "ftdi"))]
     fn open_ft245(serial: Option<&str>) -> Result<Self> {
         Ok(Self {
             transport: Box::new(Ft245Transport::open(serial)?),
@@ -338,10 +433,15 @@ impl FlashDevice {
 
         // Wait for ack (skip modem status bytes, see write_block)
         let mut resp = [0u8; 1];
+        let mut skipped = 0u32;
         loop {
             self.transport.read_exact(&mut resp)?;
             if resp[0] != 0x00 {
                 break;
+            }
+            skipped += 1;
+            if skipped > 8 {
+                bail!("Chip config: too many 0x00 bytes before ACK");
             }
         }
         if resp[0] != 0x01 {
@@ -350,6 +450,7 @@ impl FlashDevice {
         Ok(())
     }
 
+    #[allow(dead_code)]
     fn write(&mut self, address: u32, data: &[u8]) -> Result<()> {
         if address % 8 != 0 {
             bail!("Address must be 8-byte aligned for writes");
@@ -395,7 +496,7 @@ struct Cli {
     #[arg(short, long, default_value = "/dev/ttyUSB0")]
     port: String,
 
-    /// Use FT2232H FT245 synchronous FIFO instead of UART
+    /// Use FT2232H FT245 async FIFO instead of UART
     #[arg(long)]
     ft245: bool,
 
@@ -501,11 +602,20 @@ fn parse_address(s: &str) -> Result<u32, String> {
 
 fn open_device(cli: &Cli) -> Result<FlashDevice> {
     if cli.ft245 {
-        eprintln!("Opening FT2232H in async FIFO mode...");
-        FlashDevice::open_ft245(cli.ft_serial.as_deref())
-    } else {
-        FlashDevice::open_serial(&cli.port)
+        #[cfg(any(feature = "d2xx", feature = "ftdi"))]
+        {
+            let backend = if cfg!(feature = "d2xx") {
+                "D2XX"
+            } else {
+                "rs-ftdi"
+            };
+            eprintln!("Opening FT2232H in async FIFO mode ({})...", backend);
+            return FlashDevice::open_ft245(cli.ft_serial.as_deref());
+        }
+        #[cfg(not(any(feature = "d2xx", feature = "ftdi")))]
+        bail!("--ft245 requires the 'd2xx' or 'ftdi' feature (build with --features d2xx or --features ftdi)");
     }
+    FlashDevice::open_serial(&cli.port)
 }
 
 fn cmd_version(cli: &Cli) -> Result<()> {
@@ -781,12 +891,17 @@ fn cmd_configure(cli: &Cli, chip_db_path: &str, chip_name: &str) -> Result<()> {
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Probe command -- D2XX backend
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "d2xx")]
 fn cmd_probe(cli: &Cli) -> Result<()> {
     use libftd2xx::FtdiCommon;
 
     // We need raw access to the FT2232H, not the Transport abstraction,
     // because we want short timeouts per-probe and queue_status checks.
-    eprintln!("Opening FT2232H for probe...");
+    eprintln!("Opening FT2232H for probe (D2XX)...");
     let serial = cli.ft_serial.as_deref();
     let mut ft = if let Some(sn) = serial {
         libftd2xx::Ft2232h::with_serial_number(sn)
@@ -822,7 +937,7 @@ fn cmd_probe(cli: &Cli) -> Result<()> {
         (0xFF, "non-command 0xFF", None),
     ];
 
-    println!("FT245 probe: send 1 byte, wait 200ms, read back\n");
+    println!("FT245 probe (D2XX): send 1 byte, wait 200ms, read back\n");
     println!(
         "{:<30} {:>4}   {:>8}  {}",
         "Test", "Sent", "Expected", "Response"
@@ -928,6 +1043,224 @@ fn cmd_probe(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Probe command -- rs-ftdi backend
+// ---------------------------------------------------------------------------
+
+#[cfg(all(feature = "ftdi", not(feature = "d2xx")))]
+fn cmd_probe(cli: &Cli) -> Result<()> {
+    // Open FT2232H via rs-ftdi
+    eprintln!("Opening FT2232H for probe (rs-ftdi)...");
+    let serial = cli.ft_serial.as_deref();
+    let mut dev = if let Some(sn) = serial {
+        let filter = ftdi::DeviceFilter::new(FTDI_VID, FT2232H_PID).serial(sn);
+        ftdi::FtdiDevice::open_with_filter(&filter, ftdi::Interface::A)
+            .with_context(|| format!("No FT2232H with serial '{}'", sn))?
+    } else {
+        let filter = ftdi::DeviceFilter::new(FTDI_VID, FT2232H_PID).description("NORbert FT245");
+        ftdi::FtdiDevice::open_with_filter(&filter, ftdi::Interface::A)
+            .or_else(|_| {
+                ftdi::FtdiDevice::open_with_interface(FTDI_VID, FT2232H_PID, ftdi::Interface::A)
+            })
+            .context("No FT2232H found")?
+    };
+
+    dev.usb_reset().context("FT2232H reset failed")?;
+    dev.flush_all().context("FT2232H flush failed")?;
+    dev.set_latency_timer(2)?;
+    dev.set_read_timeout(Duration::from_millis(500));
+    dev.set_write_timeout(Duration::from_secs(5));
+
+    // Drain stale data
+    let mut trash = [0u8; 4096];
+    loop {
+        match dev.read_data(&mut trash) {
+            Ok(0) => break,
+            Ok(_) => continue,
+            Err(_) => break,
+        }
+    }
+
+    // Test bytes
+    let probes: Vec<(u8, &str, Option<u8>)> = vec![
+        (0x30, "CMD_VERSION", Some(0x02)),
+        (0x00, "NOP / zero", None),
+        (0x55, "non-command 0x55", None),
+        (0xAA, "non-command 0xAA", None),
+        (0xFF, "non-command 0xFF", None),
+    ];
+
+    println!("FT245 probe (rs-ftdi): send 1 byte, wait 200ms, read back\n");
+    println!(
+        "{:<30} {:>4}   {:>8}  {}",
+        "Test", "Sent", "Expected", "Response"
+    );
+    println!("{}", "-".repeat(70));
+
+    for (byte, label, expected) in &probes {
+        // Flush before each probe
+        dev.flush_all().ok();
+        thread::sleep(Duration::from_millis(50));
+
+        // Drain
+        loop {
+            match dev.read_data(&mut trash) {
+                Ok(0) => break,
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
+
+        // Send the byte
+        dev.write_all(&[*byte]).map_err(|e| anyhow!(e))?;
+
+        // Wait for response
+        thread::sleep(Duration::from_millis(200));
+
+        // Check what came back
+        let mut buf = [0u8; 32];
+        let got = dev.read_data(&mut buf).unwrap_or(0);
+        let exp_str = match expected {
+            Some(v) => format!("0x{:02X}", v),
+            None => "none".to_string(),
+        };
+        if got == 0 {
+            let status = if expected.is_none() {
+                "OK"
+            } else {
+                "FAIL(none)"
+            };
+            println!(
+                "{:<30} 0x{:02X}   {:>8}  (no response) {}",
+                label, byte, exp_str, status
+            );
+        } else {
+            let hex_str: Vec<String> = buf[..got].iter().map(|b| format!("0x{:02X}", b)).collect();
+            let status = match expected {
+                Some(v) if got == 1 && buf[0] == *v => "OK",
+                Some(_) if got == 1 && buf[0] == *byte => "FAIL(echo)",
+                _ => "FAIL",
+            };
+            println!(
+                "{:<30} 0x{:02X}   {:>8}  {} bytes: [{}] {}",
+                label,
+                byte,
+                exp_str,
+                got,
+                hex_str.join(", "),
+                status,
+            );
+        }
+    }
+
+    // Multi-byte test
+    println!("\n--- Multi-byte test ---");
+    dev.flush_all().ok();
+    thread::sleep(Duration::from_millis(50));
+    loop {
+        match dev.read_data(&mut trash) {
+            Ok(0) => break,
+            Ok(_) => continue,
+            Err(_) => break,
+        }
+    }
+
+    let multi = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+    dev.write_all(&multi).map_err(|e| anyhow!(e))?;
+    thread::sleep(Duration::from_millis(200));
+    let mut buf = [0u8; 64];
+    let got = dev.read_data(&mut buf).unwrap_or(0);
+    if got == 0 {
+        println!("Sent {:?}: (no response)", multi);
+    } else {
+        let hex_str: Vec<String> = buf[..got].iter().map(|b| format!("0x{:02X}", b)).collect();
+        let is_echo = &buf[..got] == &multi[..got];
+        println!(
+            "Sent {} bytes: {:02X?}\nGot  {} bytes: [{}]{}",
+            multi.len(),
+            multi,
+            got,
+            hex_str.join(", "),
+            if is_echo { " << EXACT ECHO" } else { "" },
+        );
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Probe command -- no FT245 backend
+// ---------------------------------------------------------------------------
+
+#[cfg(not(any(feature = "d2xx", feature = "ftdi")))]
+fn cmd_probe(_cli: &Cli) -> Result<()> {
+    bail!("Probe requires the 'd2xx' or 'ftdi' feature");
+}
+
+// ---------------------------------------------------------------------------
+// FT-list command
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "d2xx")]
+fn cmd_ft_list() -> Result<()> {
+    let devices = libftd2xx::list_devices().context("Failed to enumerate FTDI devices")?;
+
+    if devices.is_empty() {
+        println!("No FTDI devices found");
+        println!(
+            "Hint: FT2232H has VID:PID {:04x}:{:04x}",
+            FTDI_VID, FT2232H_PID
+        );
+        return Ok(());
+    }
+
+    println!("FTDI devices ({} found):", devices.len());
+    for (i, dev) in devices.iter().enumerate() {
+        println!("  [{}] {:?}", i, dev);
+    }
+    println!();
+    println!("Use --ft-serial <SERIAL> to select a specific device.");
+    println!("Channel A is used by default for async FIFO.");
+    Ok(())
+}
+
+#[cfg(all(feature = "ftdi", not(feature = "d2xx")))]
+fn cmd_ft_list() -> Result<()> {
+    let devices = ftdi::find_devices(FTDI_VID, FT2232H_PID)
+        .map_err(|e| anyhow!(e))
+        .context("Failed to enumerate FTDI devices")?;
+
+    if devices.is_empty() {
+        println!("No FT2232H devices found");
+        println!(
+            "Hint: FT2232H has VID:PID {:04x}:{:04x}",
+            FTDI_VID, FT2232H_PID
+        );
+        return Ok(());
+    }
+
+    println!("FT2232H devices ({} found):", devices.len());
+    for (i, dev) in devices.iter().enumerate() {
+        println!(
+            "  [{}] bus={} addr={} vid={:04x} pid={:04x}",
+            i,
+            dev.busnum(),
+            dev.device_address(),
+            dev.vendor_id(),
+            dev.product_id(),
+        );
+    }
+    println!();
+    println!("Use --ft-serial <SERIAL> to select a specific device.");
+    println!("Channel A is used by default for async FIFO.");
+    Ok(())
+}
+
+#[cfg(not(any(feature = "d2xx", feature = "ftdi")))]
+fn cmd_ft_list() -> Result<()> {
+    bail!("ft-list requires the 'd2xx' or 'ftdi' feature");
+}
+
 fn cmd_ports() -> Result<()> {
     let ports = serialport::available_ports()?;
     if ports.is_empty() {
@@ -952,28 +1285,6 @@ fn cmd_ports() -> Result<()> {
             println!();
         }
     }
-    Ok(())
-}
-
-fn cmd_ft_list() -> Result<()> {
-    let devices = libftd2xx::list_devices().context("Failed to enumerate FTDI devices")?;
-
-    if devices.is_empty() {
-        println!("No FTDI devices found");
-        println!(
-            "Hint: FT2232H has VID:PID {:04x}:{:04x}",
-            FTDI_VID, FT2232H_PID
-        );
-        return Ok(());
-    }
-
-    println!("FTDI devices ({} found):", devices.len());
-    for (i, dev) in devices.iter().enumerate() {
-        println!("  [{}] {:?}", i, dev);
-    }
-    println!();
-    println!("Use --ft-serial <SERIAL> to select a specific device.");
-    println!("Channel A (\"Dual RS232-HS A\") is used by default for sync FIFO.");
     Ok(())
 }
 

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -12,7 +12,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 const BAUD_RATE: u32 = 2_000_000;
-const BLOCK_SIZE: usize = 2048; // Max transfer size (256 * 8 bytes)
+const BLOCK_SIZE: usize = 2048; // 256 bursts * 8 bytes
 const PROTOCOL_VERSION: u8 = 2;
 
 // Protocol commands (shared between UART and FT245 transports)
@@ -97,8 +97,8 @@ impl Ft245Transport {
             // Default: open Channel A by its standard description.
             // If EEPROM was reprogrammed with a custom description,
             // use --ft-serial to select by serial number instead.
-            libftd2xx::Ft2232h::with_description("Dual RS232-HS A")
-                .context("No FT2232H found (looking for 'Dual RS232-HS A')")?
+            libftd2xx::Ft2232h::with_description("NORbert FT245 A")
+                .context("No FT2232H found (looking for 'NORbert FT245 A')")?
         };
 
         ft.reset().context("FT2232H reset failed")?;
@@ -111,6 +111,10 @@ impl Ft245Transport {
         // Low latency for responsive transfers
         ft.set_latency_timer(Duration::from_millis(2))
             .context("Failed to set latency timer")?;
+
+        // D2XX read/write timeouts (prevents infinite blocking)
+        ft.set_timeouts(Duration::from_secs(5), Duration::from_secs(5))
+            .context("Failed to set timeouts")?;
 
         // Drain any stale data in the receive buffer
         let mut trash = [0u8; 4096];
@@ -236,11 +240,28 @@ impl FlashDevice {
         buf.extend_from_slice(data);
         self.transport.write_all(&buf)?;
 
-        // Wait for completion byte
+        // Wait for completion byte.
+        // The FT2232H in 245 FIFO mode occasionally leaks modem status
+        // bytes (0x00) through D2XX into the data stream.  Skip any
+        // leading 0x00 bytes before the real ACK.
         let mut resp = [0u8; 1];
-        self.transport.read_exact(&mut resp)?;
+        let mut skipped = 0u32;
+        loop {
+            self.transport.read_exact(&mut resp)?;
+            if resp[0] != 0x00 {
+                break;
+            }
+            skipped += 1;
+            if skipped > 8 {
+                bail!("Too many 0x00 bytes before ACK");
+            }
+        }
         if resp[0] != 0x01 {
-            bail!("Unexpected response: 0x{:02x}", resp[0]);
+            bail!(
+                "Unexpected ACK: 0x{:02x} (expected 0x01, data[0..4]={:02x?})",
+                resp[0],
+                &data[..std::cmp::min(4, data.len())]
+            );
         }
         Ok(())
     }
@@ -315,9 +336,14 @@ impl FlashDevice {
         buf.extend_from_slice(sfdp_table);
         self.transport.write_all(&buf)?;
 
-        // Wait for ack
+        // Wait for ack (skip modem status bytes, see write_block)
         let mut resp = [0u8; 1];
-        self.transport.read_exact(&mut resp)?;
+        loop {
+            self.transport.read_exact(&mut resp)?;
+            if resp[0] != 0x00 {
+                break;
+            }
+        }
         if resp[0] != 0x01 {
             bail!("Chip config failed: unexpected response 0x{:02x}", resp[0]);
         }
@@ -337,11 +363,20 @@ impl FlashDevice {
         let mut addr = address;
         let mut offset = 0;
 
+        let total_blocks = (padded.len() + BLOCK_SIZE - 1) / BLOCK_SIZE;
+        let mut block_num = 0;
         while offset < padded.len() {
             let chunk_len = std::cmp::min(BLOCK_SIZE, padded.len() - offset);
-            self.write_block(addr, &padded[offset..offset + chunk_len])?;
+            self.write_block(addr, &padded[offset..offset + chunk_len])
+                .with_context(|| {
+                    format!(
+                        "Block {}/{} at addr 0x{:06x}",
+                        block_num, total_blocks, addr
+                    )
+                })?;
             addr += chunk_len as u32;
             offset += chunk_len;
+            block_num += 1;
         }
 
         Ok(())
@@ -446,6 +481,9 @@ enum Commands {
 
     /// List connected FT2232H devices
     FtList,
+
+    /// Diagnostic: send test bytes and report what comes back
+    Probe,
 }
 
 fn parse_address(s: &str) -> Result<u32, String> {
@@ -463,7 +501,7 @@ fn parse_address(s: &str) -> Result<u32, String> {
 
 fn open_device(cli: &Cli) -> Result<FlashDevice> {
     if cli.ft245 {
-        eprintln!("Opening FT2232H in sync FIFO mode...");
+        eprintln!("Opening FT2232H in async FIFO mode...");
         FlashDevice::open_ft245(cli.ft_serial.as_deref())
     } else {
         FlashDevice::open_serial(&cli.port)
@@ -611,17 +649,27 @@ fn cmd_load(cli: &Cli, file: &PathBuf, address: u32, verify: bool) -> Result<()>
 
     let mut addr = address;
     let mut offset = 0;
+    let total_blocks = (padded.len() + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    let mut block_num = 0;
 
     while offset < padded.len() {
         let chunk_len = std::cmp::min(BLOCK_SIZE, padded.len() - offset);
-        device.write_block(addr, &padded[offset..offset + chunk_len])?;
+        device
+            .write_block(addr, &padded[offset..offset + chunk_len])
+            .with_context(|| {
+                format!(
+                    "Block {}/{} at addr 0x{:06x}",
+                    block_num, total_blocks, addr
+                )
+            })?;
         addr += chunk_len as u32;
         offset += chunk_len;
+        block_num += 1;
         pb.inc(chunk_len as u64);
     }
 
     pb.finish_with_message("done");
-    println!("Loaded {} bytes", padded.len());
+    println!("Loaded {} bytes ({} blocks)", padded.len(), block_num);
 
     if verify {
         println!("Verifying...");
@@ -733,6 +781,153 @@ fn cmd_configure(cli: &Cli, chip_db_path: &str, chip_name: &str) -> Result<()> {
     Ok(())
 }
 
+fn cmd_probe(cli: &Cli) -> Result<()> {
+    use libftd2xx::FtdiCommon;
+
+    // We need raw access to the FT2232H, not the Transport abstraction,
+    // because we want short timeouts per-probe and queue_status checks.
+    eprintln!("Opening FT2232H for probe...");
+    let serial = cli.ft_serial.as_deref();
+    let mut ft = if let Some(sn) = serial {
+        libftd2xx::Ft2232h::with_serial_number(sn)
+            .with_context(|| format!("No FT2232H with serial '{}'", sn))?
+    } else {
+        libftd2xx::Ft2232h::with_description("NORbert FT245 A")
+            .context("No FT2232H found (looking for 'NORbert FT245 A')")?
+    };
+
+    ft.reset().context("FT2232H reset failed")?;
+    ft.purge_all().context("FT2232H purge failed")?;
+    ft.set_usb_parameters(65536)?;
+    ft.set_latency_timer(Duration::from_millis(2))?;
+    ft.set_timeouts(Duration::from_millis(500), Duration::from_secs(5))?;
+
+    // Drain stale data
+    let mut trash = [0u8; 4096];
+    loop {
+        let n = ft.queue_status()?;
+        if n == 0 {
+            break;
+        }
+        let to_read = std::cmp::min(n, trash.len());
+        let _ = ft.read(&mut trash[..to_read]);
+    }
+
+    // Test bytes: mix of valid commands, diagnostics, and non-commands
+    let probes: Vec<(u8, &str, Option<u8>)> = vec![
+        (0x30, "CMD_VERSION", Some(0x02)),
+        (0x00, "NOP / zero", None),
+        (0x55, "non-command 0x55", None),
+        (0xAA, "non-command 0xAA", None),
+        (0xFF, "non-command 0xFF", None),
+    ];
+
+    println!("FT245 probe: send 1 byte, wait 200ms, read back\n");
+    println!(
+        "{:<30} {:>4}   {:>8}  {}",
+        "Test", "Sent", "Expected", "Response"
+    );
+    println!("{}", "-".repeat(70));
+
+    for (byte, label, expected) in &probes {
+        // Purge before each probe
+        ft.purge_all()?;
+        thread::sleep(Duration::from_millis(50));
+
+        // Drain anything residual
+        loop {
+            let n = ft.queue_status()?;
+            if n == 0 {
+                break;
+            }
+            let to_read = std::cmp::min(n, trash.len());
+            let _ = ft.read(&mut trash[..to_read]);
+        }
+
+        // Send the byte
+        ft.write_all(&[*byte])?;
+
+        // Wait for response
+        thread::sleep(Duration::from_millis(200));
+
+        // Check what came back
+        let n = ft.queue_status()?;
+        let exp_str = match expected {
+            Some(v) => format!("0x{:02X}", v),
+            None => "none".to_string(),
+        };
+        if n == 0 {
+            let status = if expected.is_none() {
+                "OK"
+            } else {
+                "FAIL(none)"
+            };
+            println!(
+                "{:<30} 0x{:02X}   {:>8}  (no response) {}",
+                label, byte, exp_str, status
+            );
+        } else {
+            let to_read = std::cmp::min(n, 32);
+            let mut buf = vec![0u8; to_read];
+            let got = ft.read(&mut buf)?;
+            buf.truncate(got);
+            let hex_str: Vec<String> = buf.iter().map(|b| format!("0x{:02X}", b)).collect();
+            let status = match expected {
+                Some(v) if got == 1 && buf[0] == *v => "OK",
+                Some(_) if got == 1 && buf[0] == *byte => "FAIL(echo)",
+                _ => "FAIL",
+            };
+            println!(
+                "{:<30} 0x{:02X}   {:>8}  {} bytes: [{}] {}",
+                label,
+                byte,
+                exp_str,
+                got,
+                hex_str.join(", "),
+                status,
+            );
+        }
+    }
+
+    // Bonus: send multiple bytes at once and see what comes back
+    println!("\n--- Multi-byte test ---");
+    ft.purge_all()?;
+    thread::sleep(Duration::from_millis(50));
+    loop {
+        let n = ft.queue_status()?;
+        if n == 0 {
+            break;
+        }
+        let to_read = std::cmp::min(n, trash.len());
+        let _ = ft.read(&mut trash[..to_read]);
+    }
+
+    let multi = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+    ft.write_all(&multi)?;
+    thread::sleep(Duration::from_millis(200));
+    let n = ft.queue_status()?;
+    if n == 0 {
+        println!("Sent {:?}: (no response)", multi);
+    } else {
+        let to_read = std::cmp::min(n, 64);
+        let mut buf = vec![0u8; to_read];
+        let got = ft.read(&mut buf)?;
+        buf.truncate(got);
+        let hex_str: Vec<String> = buf.iter().map(|b| format!("0x{:02X}", b)).collect();
+        let is_echo = buf == multi[..got];
+        println!(
+            "Sent {} bytes: {:02X?}\nGot  {} bytes: [{}]{}",
+            multi.len(),
+            multi,
+            got,
+            hex_str.join(", "),
+            if is_echo { " << EXACT ECHO" } else { "" },
+        );
+    }
+
+    Ok(())
+}
+
 fn cmd_ports() -> Result<()> {
     let ports = serialport::available_ports()?;
     if ports.is_empty() {
@@ -810,6 +1005,7 @@ fn main() -> Result<()> {
         Commands::Configure { chip_db, chip } => cmd_configure(&cli, chip_db, chip),
         Commands::Ports => cmd_ports(),
         Commands::FtList => cmd_ft_list(),
+        Commands::Probe => cmd_probe(&cli),
     }
 }
 

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -15,7 +15,9 @@ use std::time::Instant;
 
 const BAUD_RATE: u32 = 2_000_000;
 // Max bursts per command: 16-bit len field (v3), 8 bytes per burst.
-// Tuned to balance throughput against FT2232H internal FIFO depth.
+// 64KB blocks are unreliable -- the FPGA loses a byte during sustained
+// 8192-burst writes (likely a glue/SDRAM timing race under refresh
+// pressure).  16KB is the largest size that passes 10/10 stress tests.
 const BLOCK_SIZE: usize = 16384; // 2048 bursts * 8 bytes
 const PROTOCOL_VERSION: u8 = 3;
 
@@ -126,8 +128,11 @@ impl Ft245Transport {
         ft.set_timeouts(Duration::from_secs(5), Duration::from_secs(5))
             .context("Failed to set timeouts")?;
 
-        // Wait for the FPGA's idle timeout (~546µs) then drain.
-        thread::sleep(Duration::from_millis(2));
+        // The USB reset can glitch the FT2232H data bus, injecting
+        // garbage bytes into the FPGA's protocol parser.  Wait 5ms
+        // (covers USB reset settling + FPGA idle timeout of ~546µs).
+        thread::sleep(Duration::from_millis(5));
+        ft.purge_all().ok();
 
         let mut trash = [0u8; 4096];
         loop {
@@ -199,7 +204,7 @@ impl Ft245Transport {
                 .context("No FT2232H found")?
         };
 
-        // Reset the FT2232H's internal FIFOs and state.
+        // Reset the FT2232H's internal state and flush FIFOs.
         dev.usb_reset().context("FT2232H reset failed")?;
         dev.flush_all().context("FT2232H flush failed")?;
 
@@ -217,10 +222,13 @@ impl Ft245Transport {
         dev.set_read_chunksize(65536);
         dev.set_write_chunksize(65536);
 
-        // Wait for the FPGA's idle timeout (~546µs at 120MHz) to reset
-        // its protocol parser in case the USB reset glitched the data
-        // bus and injected garbage bytes.  Then drain residual data.
-        thread::sleep(Duration::from_millis(2));
+        // The USB reset can glitch the FT2232H data bus, injecting
+        // garbage bytes into the FPGA's protocol parser.  Wait for the
+        // FPGA's idle timeout (~546µs at 120MHz) to reset the parser.
+        // Use 5ms for margin (covers USB reset settling + idle timeout).
+        // Then drain any residual response bytes.
+        thread::sleep(Duration::from_millis(5));
+        dev.flush_all().ok();
 
         let mut trash = [0u8; 4096];
         loop {

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -14,8 +14,10 @@ use std::time::Duration;
 use std::time::Instant;
 
 const BAUD_RATE: u32 = 2_000_000;
-const BLOCK_SIZE: usize = 2048; // 256 bursts * 8 bytes
-const PROTOCOL_VERSION: u8 = 2;
+// Max bursts per command: 16-bit len field (v3), 8 bytes per burst.
+// Tuned to balance throughput against FT2232H internal FIFO depth.
+const BLOCK_SIZE: usize = 16384; // 2048 bursts * 8 bytes
+const PROTOCOL_VERSION: u8 = 3;
 
 // Protocol commands (shared between UART and FT245 transports)
 const CMD_VERSION: u8 = 0x30;
@@ -114,15 +116,19 @@ impl Ft245Transport {
         ft.set_usb_parameters(65536)
             .context("Failed to set USB parameters")?;
 
-        // Low latency for responsive transfers
-        ft.set_latency_timer(Duration::from_millis(2))
+        // Minimum latency timer -- each ACK/response byte sits in the
+        // FT2232H TX FIFO until either a full USB packet fills or this
+        // timer fires.  1ms is the FT2232H minimum.
+        ft.set_latency_timer(Duration::from_millis(1))
             .context("Failed to set latency timer")?;
 
         // D2XX read/write timeouts (prevents infinite blocking)
         ft.set_timeouts(Duration::from_secs(5), Duration::from_secs(5))
             .context("Failed to set timeouts")?;
 
-        // Drain any stale data in the receive buffer
+        // Wait for the FPGA's idle timeout (~546µs) then drain.
+        thread::sleep(Duration::from_millis(2));
+
         let mut trash = [0u8; 4096];
         loop {
             let n = ft.queue_status().context("Failed to query queue status")?;
@@ -193,12 +199,14 @@ impl Ft245Transport {
                 .context("No FT2232H found")?
         };
 
-        // Reset and flush
+        // Reset the FT2232H's internal FIFOs and state.
         dev.usb_reset().context("FT2232H reset failed")?;
         dev.flush_all().context("FT2232H flush failed")?;
 
-        // Low latency for responsive transfers
-        dev.set_latency_timer(2)
+        // Minimum latency timer -- each ACK/response byte sits in the
+        // FT2232H TX FIFO until either a full USB packet fills or this
+        // timer fires.  1ms is the FT2232H minimum.
+        dev.set_latency_timer(1)
             .context("Failed to set latency timer")?;
 
         // Configure timeouts
@@ -209,7 +217,11 @@ impl Ft245Transport {
         dev.set_read_chunksize(65536);
         dev.set_write_chunksize(65536);
 
-        // Drain stale data from the read buffer
+        // Wait for the FPGA's idle timeout (~546µs at 120MHz) to reset
+        // its protocol parser in case the USB reset glitched the data
+        // bus and injected garbage bytes.  Then drain residual data.
+        thread::sleep(Duration::from_millis(2));
+
         let mut trash = [0u8; 4096];
         loop {
             match dev.read_data(&mut trash) {
@@ -293,12 +305,14 @@ impl FlashDevice {
         let addr_units = address / 8;
         let len_units = length / 8;
 
+        // v3 header: cmd + 3 addr bytes + 2 len bytes (big-endian)
         let cmd = [
             CMD_READ,
             ((addr_units >> 16) & 0xFF) as u8,
             ((addr_units >> 8) & 0xFF) as u8,
             (addr_units & 0xFF) as u8,
-            len_units as u8,
+            ((len_units >> 8) & 0xFF) as u8,
+            (len_units & 0xFF) as u8,
         ];
 
         self.transport.write_all(&cmd)?;
@@ -323,14 +337,16 @@ impl FlashDevice {
         let len_units = data.len() / 8;
 
         // Combine header and data into a single write to avoid
-        // transfer gaps that could trigger the FPGA's idle timeout
-        let mut buf = Vec::with_capacity(5 + data.len());
+        // transfer gaps that could trigger the FPGA's idle timeout.
+        // v3 header: cmd + 3 addr bytes + 2 len bytes (big-endian)
+        let mut buf = Vec::with_capacity(6 + data.len());
         buf.extend_from_slice(&[
             CMD_WRITE,
             ((addr_units >> 16) & 0xFF) as u8,
             ((addr_units >> 8) & 0xFF) as u8,
             (addr_units & 0xFF) as u8,
-            len_units as u8,
+            ((len_units >> 8) & 0xFF) as u8,
+            (len_units & 0xFF) as u8,
         ]);
         buf.extend_from_slice(data);
         self.transport.write_all(&buf)?;


### PR DESCRIPTION
## Summary

Adds an FT2232H asynchronous 245 FIFO interface as an optional high-speed transport alongside the existing 2 Mbaud UART. The FPGA glue logic now supports both transports simultaneously, selecting the active port based on whichever delivers the first byte of a command. The host tool gains `--ft245` flag support with two backend options: a pure-Rust `rs-ftdi` backend (default) and an optional D2XX backend using FTDI's proprietary library.

## FPGA Changes

- **`src/ft245.v`** (new): FT2232H async 245 FIFO state machine implementing the full read/write protocol with timing margins above FT2232H datasheet minimums (7-cycle RD# strobe, 10-cycle recovery, 7-cycle WR# pulse). Provides the same byte-level interface as `uart.v`.
- **`src/glue.v`**: Added dual-port arbitration — whichever port (UART or FT245) delivers the first byte of a command becomes the active port for that entire transaction; responses are routed back to the same port. Added `write_strobe_r` rising-edge detection to prevent `sdram_write_buffer` corruption when fast FT245 delivery causes the next burst's byte 0 to overwrite the buffer before the SDRAM controller reads it. Extended idle timeout from 2¹⁴ to 2¹⁶ cycles (~546µs). Suppressed log byte forwarding on FT245 to prevent binary stream corruption. Added `serial_gate` and `ft_rx_hold` to prevent double-consume from FIFO. Added TX pipeline cooldown (`tx_wait`) to handle back-pressure propagation latency.
- **`src/top.v`**: Wired in `ft245` module and a 16-deep FWFT RX FIFO to decouple ft245 byte delivery from glue. Added FT245 port signals. Removed unused button inputs (H11 repurposed for `ft_wr_n`).
- **`tangprimer25k.cst`**: Reassigned PMOD pins for SPI signals, added FT245 control pins on PMOD 2 (A11/E11/K11/L5) and 8-bit data bus on PMOD 3 (H5/H8/G7/F5/H7/G8/G5/J5).

## Host Tool Changes

- **Transport abstraction**: Introduced a `Transport` trait with `write_all`/`read_exact` methods, allowing `FlashDevice` protocol logic to be shared between UART, D2XX, and rs-ftdi backends.
- **`--ft245` flag**: Selects FT2232H transport; `--ft-serial` allows selecting a specific device by serial number.
- **`FtList` subcommand**: Lists connected FT2232H devices.
- **`Probe` subcommand**: Diagnostic tool that sends test bytes and reports responses.
- **Feature flags**: `ftdi` (default, pure Rust via `rs-ftdi`/`nusb`) and `d2xx` (proprietary FTDI library); `make tool` and `make tool-d2xx` build each.
- **ACK robustness**: Write and chip-config ACK paths now skip leading `0x00` modem-status bytes that FT2232H can inject into the D2XX data stream.

## Setup

- **`ft2232h.conf`** (new): `ftdi_eeprom` configuration to program FT2232H Channel A as "245 FIFO" mode (one-time setup).
- **`make ftdi-setup`**: Flashes the EEPROM configuration.
- **`flake.nix`**: Added `libftdi1` (provides `ftdi_eeprom`) to the Nix dev shell.