### PR TITLE
Add target flash #HOLD control for SPI bus sharing

### DIFF
--- a/src/glue.v
+++ b/src/glue.v
@@ -83,6 +83,9 @@ module glue(
     // are ignored and serial commands always have a clear path.
     output reg spi_running,
 
+    // Target flash HOLD control (active high: 1 = assert #HOLD on target)
+    output reg hold_out,
+
     output reg [7:0] led
 );
 
@@ -95,9 +98,10 @@ module glue(
         CMD_CHIPCONFIG   = 8'h33,
         CMD_START        = 8'h34,  // Enable SPI emulation
         CMD_STOP         = 8'h35,  // Disable SPI emulation
-        CMD_STATUS       = 8'h36;  // Query running state
+        CMD_STATUS       = 8'h36,  // Query running state
+        CMD_HOLDCTL      = 8'h37;  // Assert/release target flash #HOLD
 
-    localparam VERSION = 8'h04;  // Version 4: add START/STOP/STATUS
+    localparam VERSION = 8'h05;  // Version 5: add HOLDCTL
 
     reg [7:0] cmd;
     reg [7:0] in_count;
@@ -267,6 +271,8 @@ module glue(
             
             write_buffer <= 0;
             
+            hold_out <= 0;
+            
             cfg_jedec_id <= {8'h17, 8'h40, 8'hEF};  // Default: W25Q64FV (EF 40 17)
             cfg_4byte <= 0;
             cfg_chip_erase_bursts <= 23'h0FFFFF;     // 8MB = 1M bursts - 1
@@ -376,6 +382,7 @@ module glue(
             led[5] <= spi_writing;
             led[4] <= spi_reset;
             led[3] <= !spi_csel_buf[1];
+            led[2] <= hold_out;                         // Target flash held
             led[0] <= heartbeat[25];                    // Heartbeat ~2Hz at 132MHz
             
             // Log strobe handling -- only forward to UART (active_port=0).
@@ -606,6 +613,13 @@ module glue(
                                 in_count <= 1;
                             end
                         end
+                        // HOLDCTL toggles a simple GPIO on the target flash
+                        // and does not touch SDRAM or spi_trx state, so it
+                        // is accepted regardless of spi_running.
+                        if (rxd_data_buf == CMD_HOLDCTL) begin
+                            cmd <= CMD_HOLDCTL;
+                            in_count <= 1;
+                        end
                     end
                     else if (cmd == CMD_CHIPCONFIG) begin
                         // -----------------------------------------------
@@ -667,6 +681,23 @@ module glue(
                         else begin
                             in_count <= in_count + 1;
                         end
+                    end
+                    else if (cmd == CMD_HOLDCTL) begin
+                        // -----------------------------------------------
+                        // HOLDCTL protocol:
+                        //   Byte 1: 0x01 = assert #HOLD (silence target flash)
+                        //           0x00 = release #HOLD (target flash active)
+                        // Response: 0x01
+                        //
+                        // Mutually exclusive with quad I/O: when hold is
+                        // asserted, IO3 is driven low continuously to keep
+                        // the target flash in hold state.
+                        // -----------------------------------------------
+                        hold_out <= rxd_data_buf[0];
+                        txd_strobe_buf <= 1;
+                        txd_data_buf <= 8'h01;
+                        in_count <= 0;
+                        cmd <= CMD_NOP;
                     end
                     else begin
                         // RAMREAD / RAMWRITE handling (v3: 6-byte header)

--- a/src/top.v
+++ b/src/top.v
@@ -173,8 +173,12 @@ module top(
     assign spi_io2_pin = (spi_io2_oe && spi_active_out) ? spi_io2_out : 1'bz;
     wire spi_io2_in = spi_io2_pin;
     
-    // IO3 (/HOLD pin): input normally, output during quad read data phase
-    assign spi_io3_pin = (spi_io3_oe && spi_active_out) ? spi_io3_out : 1'bz;
+    // IO3 (/HOLD pin): input normally, output during quad read data phase.
+    // When hold_out is asserted, IO3 is driven LOW continuously to keep
+    // the target flash in hold state (mutually exclusive with quad I/O).
+    wire hold_out;
+    assign spi_io3_pin = hold_out ? 1'b0 :
+                         (spi_io3_oe && spi_active_out) ? spi_io3_out : 1'bz;
     wire spi_io3_in = spi_io3_pin;
     
     assign spi_debug_pin = spi_debug_out;
@@ -489,7 +493,8 @@ module top(
         .sfdp_rdata(sfdp_rdata),
         
         .spi_running(spi_running),
-        
+        .hold_out(hold_out),
+
         .led(led_out)
     );
     

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -38,6 +38,7 @@ const CMD_CHIPCONFIG: u8 = 0x33;
 const CMD_START: u8 = 0x34; // Enable SPI emulation (protocol v4+)
 const CMD_STOP: u8 = 0x35; // Disable SPI emulation (protocol v4+)
 const CMD_STATUS: u8 = 0x36; // Query emulation state (protocol v4+)
+const CMD_HOLDCTL: u8 = 0x37; // Target flash #HOLD control (protocol v5+)
 
 // FT2232H USB identifiers
 #[cfg(any(feature = "d2xx", feature = "ftdi"))]
@@ -644,6 +645,39 @@ impl FlashDevice {
         Ok(())
     }
 
+    /// Control the target flash #HOLD pin.
+    ///
+    /// When enabled, IO3 is driven LOW continuously, asserting #HOLD on
+    /// the target flash and silencing it so NORbert can respond instead.
+    /// Mutually exclusive with quad I/O.
+    ///
+    /// Protocol (CMD_HOLDCTL = 0x34):
+    ///   Byte 0: 0x34
+    ///   Byte 1: 0x01 = assert hold, 0x00 = release hold
+    ///   Response: 0x01 on success.
+    fn set_hold(&mut self, enable: bool) -> Result<()> {
+        let data = if enable { 0x01u8 } else { 0x00u8 };
+        self.transport.write_all(&[CMD_HOLDCTL, data])?;
+
+        // Wait for ack (skip modem status bytes, see write_block)
+        let mut resp = [0u8; 1];
+        let mut skipped = 0u32;
+        loop {
+            self.transport.read_exact(&mut resp)?;
+            if resp[0] != 0x00 {
+                break;
+            }
+            skipped += 1;
+            if skipped > 8 {
+                bail!("Hold control: too many 0x00 bytes before ACK");
+            }
+        }
+        if resp[0] != 0x01 {
+            bail!("Hold control failed: unexpected response 0x{:02x}", resp[0]);
+        }
+        Ok(())
+    }
+
     #[allow(dead_code)]
     fn write(&mut self, address: u32, data: &[u8]) -> Result<()> {
         if address % 8 != 0 {
@@ -769,6 +803,17 @@ enum Commands {
         /// Chip name to emulate (substring match, e.g. "W25Q128.V")
         #[arg(short, long)]
         chip: String,
+    },
+
+    /// Control target flash #HOLD pin for SPI bus sharing
+    ///
+    /// Asserts #HOLD on the existing SPI flash so NORbert can respond
+    /// instead.  The target flash tristates its outputs and ignores
+    /// all SPI commands while held.  Mutually exclusive with quad I/O.
+    Hold {
+        /// "on" to assert #HOLD (silence target flash),
+        /// "off" to release (target flash active)
+        state: String,
     },
 
     /// List available serial ports
@@ -1489,6 +1534,22 @@ fn cmd_ft_list() -> Result<()> {
     bail!("ft-list requires the 'd2xx' or 'ftdi' feature");
 }
 
+fn cmd_hold(cli: &Cli, state: &str) -> Result<()> {
+    let enable = match state.to_lowercase().as_str() {
+        "on" | "assert" | "1" => true,
+        "off" | "release" | "0" => false,
+        _ => bail!("Invalid hold state '{}': use 'on' or 'off'", state),
+    };
+    let mut device = open_device(cli)?;
+    device.set_hold(enable)?;
+    if enable {
+        eprintln!("HOLD asserted: target flash silenced");
+    } else {
+        eprintln!("HOLD released: target flash active");
+    }
+    Ok(())
+}
+
 fn cmd_ports() -> Result<()> {
     let ports = serialport::available_ports()?;
     if ports.is_empty() {
@@ -1566,6 +1627,7 @@ fn main() -> Result<()> {
             length,
         } => cmd_dump(&cli, file, *address, *length),
         Commands::Configure { chip_db, chip } => cmd_configure(&cli, chip_db, chip),
+        Commands::Hold { state } => cmd_hold(&cli, state),
         Commands::Ports => cmd_ports(),
         Commands::FtList => cmd_ft_list(),
         Commands::Probe => cmd_probe(&cli),


### PR DESCRIPTION
## Summary

- Adds `CMD_HOLDCTL` (0x34) serial command to assert/release #HOLD on an existing SPI flash, allowing NORbert to share the SPI bus without desoldering the original chip
- Drives IO3 LOW continuously when hold is asserted, keeping the target flash silent while NORbert responds to SPI transactions
- Adds `hold on`/`hold off` CLI subcommand to the tool, working over both UART and FT245

Mutually exclusive with quad I/O since IO3 doubles as the #HOLD line.

## Usage

```
spi-flash-tool --ft245 hold on     # silence target flash
spi-flash-tool --ft245 load fw.bin  # load firmware
spi-flash-tool --ft245 hold off    # release target flash
```