### PR TITLE
Add real-time SPI logging, TOCTOU attack support, and double-read detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ VERILOG_FILES = \
 	src/uart.v \
 	src/ft245.v \
 	src/fifo.v \
+	src/logger.v \
 	src/util.v \
 	src/pll.v
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ NORbert uses a [Sipeed Tang Primer 25K](https://wiki.sipeed.com/hardware/en/tang
 - **Pipelined prefetch**: SDRAM reads are issued during SPI address/dummy phases so data is ready on the first clock edge
 - **2 Mbaud UART** interface for loading and dumping images from a host PC
 - **FT245 asynchronous FIFO** via FT2232H for faster bulk transfers (requires one-time EEPROM configuration)
+- **SPI bus logging**: real-time command/address/byte-count packets drained over either transport via a 512-byte ring FIFO (`monitor` subcommand)
+- **TOCTOU traps**: four independent address-match entries that transparently redirect reads to a different SDRAM location on the second access, for exercising verify-then-use flows
+- **Target flash #HOLD control**: drive IO3 low to silence a real flash chip sharing the SPI bus
 
 ## Hardware
 
@@ -63,8 +66,9 @@ Load a firmware image into NORbert's SDRAM, then let your target SPI master read
 ```
 # Check connection
 spi-flash-tool version
+spi-flash-tool status       # running | stopped
 
-# Load a firmware image
+# Load a firmware image (auto stops + starts emulation around the load)
 spi-flash-tool load firmware.bin
 
 # Load with verification
@@ -79,13 +83,66 @@ spi-flash-tool read 0x0 0x100
 # Configure chip identity (uses rflasher chip database)
 spi-flash-tool configure W25Q128JV --chips-dir ~/src/rflasher/chips/vendors
 
+# Gate SPI emulation explicitly (the dance above does this automatically)
+spi-flash-tool start
+spi-flash-tool stop
+
 # List available serial ports
 spi-flash-tool ports
 ```
 
 The `configure` command loads a chip definition from [rflasher](https://github.com/benpye/rflasher)'s RON database and sends the JEDEC ID, size, and a generated SFDP table to the FPGA. The chip name is matched by substring, so `W25Q128` is enough if it's unambiguous. Without configuration, NORbert defaults to Winbond W25Q64FV.
 
+At power-on the FPGA boots in the STOPPED state -- the SPI pins are held in reset and the host can always reach the tool, regardless of what the target board is doing. `load` automatically stops emulation, writes the image, and starts it again. Use `start`/`stop`/`status` for manual control.
+
 Use `-p /dev/ttyUSBx` if your device isn't on the default `/dev/ttyUSB0`.
+
+### SPI bus monitoring
+
+`monitor` streams decoded SPI activity from NORbert in real time. It works over either UART or FT245 and is safe to run while the target is actively reading:
+
+```
+spi-flash-tool monitor
+```
+
+Example output while flashprog reads a 4 KB region:
+
+```
+TXN#   COMMAND            ADDRESS    INFO
+------------------------------------------------------------
+1      0x9F READ_JEDEC_ID
+2      0x05 READ_STATUS
+3      0x05 READ_STATUS
+4      0xBB DUAL_IO_READ  0x001000
+       end: 4097 bytes from 0x001000
+```
+
+The monitor also tracks double-reads of the same (opcode, address) pair and flags them as TOCTOU candidates. Press Ctrl+C to stop. The underlying protocol is a poll-based ring-buffer drain (`CMD_LOGPOLL` = 0x3A); packet types are `0xA1` (command), `0xA2` (address), `0xA3` (end + byte count) and `0xA4` (TOCTOU trap fired), with `0xA0` as the per-poll terminator.
+
+### TOCTOU traps
+
+Four independent trap entries redirect matching reads to a different SDRAM location on the second (and subsequent) access. The first matching read is let through unchanged -- it arms the trap. The first 8 bytes of the redirected read come from the original address because the SDRAM prefetch pipeline fires before the trap check completes; bytes 8+ come from the replacement.
+
+```
+# Configure: any read in 0x001000-0x001FFF gets redirected to 0x101000-0x101FFF
+spi-flash-tool toctou set 1 0x001000 0xFFF000 0x101000
+spi-flash-tool toctou arm 1
+
+# First target read of 0x001000 returns the original data.
+# Second target read of 0x001000 returns the replacement data.
+
+# Clear the triggered flag so the next read is "first" again:
+spi-flash-tool toctou reset 1
+
+# Tear everything down:
+spi-flash-tool toctou reset-all
+```
+
+Arguments to `toctou set` are `<index 0..3> <start-address> <match-mask> <replace-base>`, all as byte addresses. 1-bits in the mask must match exactly; 0-bits are don't-care. The replacement preserves the "don't-care" bits of the original address.
+
+### Target flash #HOLD
+
+When NORbert shares a SPI bus with a real flash chip, `hold on` drives IO3 low continuously, asserting `#HOLD` on the target flash so it tristates and ignores all commands. `hold off` releases it. Mutually exclusive with quad I/O because IO3 is shared.
 
 ### FT245 transport (FT2232H)
 
@@ -166,20 +223,56 @@ commands (0xBB, 0xEB) use fewer SPI clocks for the address, leaving less headroo
 
 ```
 src/
-  top.v        Top-level module, clock/reset, bus wiring
+  top.v        Top-level module, clock/reset, bus wiring, TOCTOU address mux
   spi_trx.v    SPI flash transceiver (command decoder + data path)
   sdram.v      Dual-chip SDRAM controller with interleaved storage
-  glue.v       Protocol handler, UART/FT245 mux, SPI write engine, LED control
+  glue.v       Protocol handler, UART/FT245 I/O, SPI write engine, TOCTOU trap engine, LOGPOLL state machine, LED control
+  logger.v     SPI event capture into a 512-byte ring FIFO drained by CMD_LOGPOLL
   uart.v       UART TX/RX (2 Mbaud)
   ft245.v      FT2232H async 245 FIFO interface
   fifo.v       Synchronous FIFO (first-word-fall-through)
   util.v       Clock divider, PWM, synchronizers
   pll.v        PLL: 50MHz -> 120MHz with phase-shifted outputs
 tool/
-  src/main.rs  Host-side CLI (Rust) for loading/dumping over UART or FT245
+  src/main.rs  Host-side CLI (Rust) for loading/dumping/monitoring/TOCTOU over UART or FT245
   src/chip.rs  Chip definition loading from rflasher RON database
   src/sfdp.rs  SFDP/BFPT table generation from chip definitions
 ```
+
+## Serial protocol
+
+All opcodes reply with a single `0x01` ACK unless otherwise noted. The FPGA
+accepts command bytes from whichever port (UART or FT245) first delivers one
+while the parser is idle, and routes the response back to the same port.
+
+| Opcode | Name       | Args                                                | Reply                            |
+|--------|------------|-----------------------------------------------------|----------------------------------|
+| `0x30` | VERSION    | none                                                | 1 byte (current: `0x04`)         |
+| `0x31` | RAMREAD    | 3-byte burst addr + 2-byte burst count              | `count*8` data bytes             |
+| `0x32` | RAMWRITE   | 3-byte burst addr + 2-byte burst count + data       | `0x01`                           |
+| `0x33` | CHIPCONFIG | JEDEC(3) + flags + erase_bursts(3) + sfdp_len + sfdp| `0x01`                           |
+| `0x34` | START      | none -- enable SPI emulation                        | `0x01`                           |
+| `0x35` | STOP       | none -- hold spi_trx in reset                       | `0x01`                           |
+| `0x36` | STATUS     | none                                                | `0x01` running / `0x02` stopped  |
+| `0x37` | HOLDCTL    | 1 byte: `0x01` assert, `0x00` release               | `0x01`                           |
+| `0x38` | LOGCTL     | 1 byte: `0x01` start capture, `0x00` stop capture   | `0x01`                           |
+| `0x39` | TOCTOU     | sub-command + args (see below)                      | `0x01`                           |
+| `0x3A` | LOGPOLL    | none                                                | log bytes terminated by `0xA0`   |
+
+TOCTOU sub-commands (all prefixed with opcode `0x39`):
+
+| Sub    | Name      | Args                                                 |
+|--------|-----------|------------------------------------------------------|
+| `0x01` | SET       | index + start(3) + mask(3) + replace(3), all big-endian |
+| `0x02` | ARM       | index                                                |
+| `0x03` | DISARM    | index                                                |
+| `0x04` | RESET     | index -- clear triggered flag                        |
+| `0x05` | RESET_ALL | none -- disarm + clear all four                      |
+
+RAMREAD/RAMWRITE/CHIPCONFIG are only accepted while emulation is stopped, to
+avoid racing the SPI fast path on SDRAM. The other commands are always safe to
+issue and bypass the SPI-idle gate so the host can reach the tool even while a
+target is hammering the bus.
 
 ## Acknowledgments
 

--- a/build.tcl
+++ b/build.tcl
@@ -13,6 +13,7 @@ add_file src/glue.v
 add_file src/uart.v
 add_file src/ft245.v
 add_file src/fifo.v
+add_file src/logger.v
 add_file src/util.v
 add_file src/pll.v
 

--- a/spi_flash.gprj
+++ b/spi_flash.gprj
@@ -12,6 +12,7 @@
         <File path="src/uart.v" type="file.verilog" enable="1"/>
         <File path="src/ft245.v" type="file.verilog" enable="1"/>
         <File path="src/fifo.v" type="file.verilog" enable="1"/>
+        <File path="src/logger.v" type="file.verilog" enable="1"/>
         <File path="src/util.v" type="file.verilog" enable="1"/>
         <File path="src/pll.v" type="file.verilog" enable="1"/>
         <File path="tangprimer25k.cst" type="file.cst" enable="1"/>

--- a/src/glue.v
+++ b/src/glue.v
@@ -86,8 +86,17 @@ module glue(
     // Target flash HOLD control (active high: 1 = assert #HOLD on target)
     output reg hold_out,
 
-    // Logging control
-    output reg log_active,          // 1 = logging enabled, drives FT245 TX mux
+    // Logging control: 1 = logger captures SPI events into the ring
+    // FIFO; 0 = logger ignores events.  The host drains the FIFO via
+    // CMD_LOGPOLL regardless of this flag (so residual bytes remain
+    // retrievable after LOGCTL stop).
+    output reg log_active,
+
+    // Logger ring FIFO read interface -- glue pops bytes here while
+    // serving a CMD_LOGPOLL response.
+    input wire log_fifo_data_available,
+    input wire [7:0] log_fifo_read_data,
+    output reg log_fifo_read_strobe,
 
     // TOCTOU trap interface
     // Structured log inputs (synchronized from SPI domain)
@@ -119,8 +128,20 @@ module glue(
         CMD_STOP         = 8'h35,  // Disable SPI emulation
         CMD_STATUS       = 8'h36,  // Query running state
         CMD_HOLDCTL      = 8'h37,  // Assert/release target flash #HOLD
-        CMD_LOGCTL       = 8'h38,  // Enable/disable SPI bus logging
-        CMD_TOCTOU       = 8'h39;  // TOCTOU trap management
+        CMD_LOGCTL       = 8'h38,  // Enable/disable SPI bus logging capture
+        CMD_TOCTOU       = 8'h39,  // TOCTOU trap management
+        CMD_LOGPOLL      = 8'h3A;  // Drain logger ring FIFO
+
+    // Terminator byte appended to every CMD_LOGPOLL response.  The
+    // logger never emits 0xA0 (all its packet type bytes are 0xA1-0xA4),
+    // so the host can unambiguously detect end-of-poll.
+    localparam LOG_POLL_TERMINATOR = 8'hA0;
+
+    // Max log bytes sent per poll.  Bounds response length so the host
+    // cannot be starved by a busy SPI master filling the FIFO faster
+    // than it can be drained.  Remaining data is delivered on the next
+    // poll.
+    localparam [7:0] LOG_POLL_MAX = 8'd255;
 
     localparam VERSION = 8'h05;  // Version 5: HOLDCTL + logging + TOCTOU
 
@@ -150,6 +171,13 @@ module glue(
     reg [2:0] write_state;
     reg [2:0] write_pos;
 
+    // CMD_LOGPOLL state machine.
+    //   log_poll_state 0 = idle
+    //                  1 = drain FIFO (send log bytes while available)
+    //                  2 = terminator (send 0xA0 and return to idle)
+    reg [1:0] log_poll_state;
+    reg [7:0] log_poll_remain;  // bytes still allowed before forced terminator
+
     reg txd_strobe_buf;
     reg [7:0] txd_data_buf;
     
@@ -172,7 +200,8 @@ module glue(
     // Latched when a command byte arrives while idle.
     reg active_port;
 
-    wire cmd_idle = (cmd == CMD_NOP) && (in_count == 0) && !read_state && !write_state;
+    wire cmd_idle = (cmd == CMD_NOP) && (in_count == 0) &&
+                    !read_state && !write_state && (log_poll_state == 0);
     wire mux_txd_ready = active_port ? ft_txd_ready : txd_ready;
 
     // Serial handler gate: only consume FIFO bytes when SPI is inactive.
@@ -194,7 +223,8 @@ module glue(
                                ((ft_rx_data == CMD_VERSION) ||
                                 (ft_rx_data == CMD_START)   ||
                                 (ft_rx_data == CMD_STOP)    ||
-                                (ft_rx_data == CMD_STATUS));
+                                (ft_rx_data == CMD_STATUS)  ||
+                                (ft_rx_data == CMD_LOGPOLL));
 
     // Hold flag: prevent double-consume from FIFO.  Set for 1 cycle
     // after popping a byte, cleared the next cycle.  Gives a 2-cycle
@@ -284,6 +314,10 @@ module glue(
             write_state <= 0;
             write_pos <= 0;
 
+            log_poll_state <= 0;
+            log_poll_remain <= 0;
+            log_fifo_read_strobe <= 0;
+
             sdram_access_cmd <= 0;
             sdram_inhibit_refresh <= 0;
 
@@ -363,6 +397,7 @@ module glue(
         end
         else begin
             txd_strobe_buf <= 0;
+            log_fifo_read_strobe <= 0;
 
             // TX pipeline cooldown
             if (txd_strobe_buf)
@@ -454,14 +489,10 @@ module glue(
             led[2] <= hold_out;                         // Target flash held
             led[0] <= heartbeat[25];                    // Heartbeat ~2Hz at 132MHz
             
-            // Log strobe handling -- only forward to UART (active_port=0).
-            // SPI noise can trigger spurious log bytes; sending them on
-            // FT245 would corrupt the binary command stream.
-            if (log_strobe_buf[1] && !log_ack && !active_port) begin
-                txd_strobe_buf <= 1;
-                txd_data_buf <= log_val;
-                log_ack <= 1;
-            end
+            // Legacy single-byte log_strobe/log_val path is superseded
+            // by the structured logger + CMD_LOGPOLL flow.  The acknowledge
+            // register is still shadowed so the input does not synthesize
+            // into a dangling always-block, but no bytes are forwarded.
             if (!log_strobe_buf[1]) log_ack <= 0;
             
             // -------------------------------------------------------
@@ -684,8 +715,49 @@ module glue(
                     // the FT2232H's occasional leaked modem-status bytes.
                     txd_data_buf <= spi_running ? 8'h01 : 8'h02;
                 end
+                CMD_LOGPOLL: begin
+                    // LOGPOLL: no argument bytes.  Enter drain state
+                    // machine which emits up to LOG_POLL_MAX bytes from
+                    // the logger FIFO followed by a 0xA0 terminator.
+                    // The state machine runs outside the SPI-gated
+                    // dispatcher so polls complete even while a flash
+                    // read is in progress on the SPI pins.
+                    cmd             <= CMD_LOGPOLL;
+                    log_poll_state  <= 2'd1;
+                    log_poll_remain <= LOG_POLL_MAX;
+                end
                 default: ;  // fall through to gated dispatcher below
                 endcase
+            end
+
+            // -----------------------------------------------------------
+            // CMD_LOGPOLL drain state machine (always runs, ungated).
+            //
+            // LOGPOLL only touches the logger FIFO and the host TX path,
+            // so it is safe to process even while the SPI master is
+            // actively hammering the bus.  Running ungated also means
+            // monitor tools can poll while logging real-time traffic.
+            //
+            //   State 1: pop one byte per TX slot while FIFO has data
+            //            and the per-poll cap has not been exhausted.
+            //   State 2: emit 0xA0 terminator and return to idle.
+            // -----------------------------------------------------------
+            if (log_poll_state == 2'd1 && can_send) begin
+                if (log_fifo_data_available && log_poll_remain != 0) begin
+                    txd_strobe_buf       <= 1;
+                    txd_data_buf         <= log_fifo_read_data;
+                    log_fifo_read_strobe <= 1;
+                    log_poll_remain      <= log_poll_remain - 1;
+                end
+                else begin
+                    log_poll_state <= 2'd2;
+                end
+            end
+            else if (log_poll_state == 2'd2 && can_send) begin
+                txd_strobe_buf <= 1;
+                txd_data_buf   <= LOG_POLL_TERMINATOR;
+                log_poll_state <= 2'd0;
+                cmd            <= CMD_NOP;
             end
 
             // -----------------------------------------------------------

--- a/src/glue.v
+++ b/src/glue.v
@@ -86,6 +86,25 @@ module glue(
     // Target flash HOLD control (active high: 1 = assert #HOLD on target)
     output reg hold_out,
 
+    // Logging control
+    output reg log_active,          // 1 = logging enabled, drives FT245 TX mux
+
+    // TOCTOU trap interface
+    // Structured log inputs (synchronized from SPI domain)
+    input wire log_addr_valid_sync, // Pulse: address phase complete (system clock)
+    input wire [23:0] log_addr_sync,// Flash byte address (latched when valid)
+    input wire spi_active_sync,     // SPI CS active (synchronized)
+
+    // TOCTOU redirect outputs (directly to address mux in top.v)
+    output reg redirect_active,
+    output reg [22:0] redirect_mask,    // Burst address mask bits
+    output reg [22:0] redirect_base,    // Burst address replacement base
+
+    // TOCTOU trap notification (to logger)
+    output reg trap_notify_strobe,
+    output reg [1:0] trap_notify_index,
+    output reg [23:0] trap_notify_addr,
+
     output reg [7:0] led
 );
 
@@ -99,9 +118,19 @@ module glue(
         CMD_START        = 8'h34,  // Enable SPI emulation
         CMD_STOP         = 8'h35,  // Disable SPI emulation
         CMD_STATUS       = 8'h36,  // Query running state
-        CMD_HOLDCTL      = 8'h37;  // Assert/release target flash #HOLD
+        CMD_HOLDCTL      = 8'h37,  // Assert/release target flash #HOLD
+        CMD_LOGCTL       = 8'h38,  // Enable/disable SPI bus logging
+        CMD_TOCTOU       = 8'h39;  // TOCTOU trap management
 
-    localparam VERSION = 8'h05;  // Version 5: add HOLDCTL
+    localparam VERSION = 8'h05;  // Version 5: HOLDCTL + logging + TOCTOU
+
+    // TOCTOU sub-commands
+    localparam
+        TOCTOU_SET       = 8'h01,
+        TOCTOU_ARM       = 8'h02,
+        TOCTOU_DISARM    = 8'h03,
+        TOCTOU_RESET     = 8'h04,
+        TOCTOU_RESET_ALL = 8'h05;
 
     reg [7:0] cmd;
     reg [7:0] in_count;
@@ -213,6 +242,26 @@ module glue(
     reg [6:0] sfdp_wr_pos;
     reg [6:0] cfg_sfdp_remaining;
     
+    // TOCTOU trap table (4 entries)
+    reg [23:0] trap_start [0:3];     // Byte address match value
+    reg [23:0] trap_mask  [0:3];     // Byte address mask (1 = must match)
+    reg [23:0] trap_replace [0:3];   // Byte address replacement base
+    reg [3:0]  trap_armed;           // Trap is active
+    reg [3:0]  trap_triggered;       // First read has occurred, next read redirects
+    
+    // TOCTOU command parsing state
+    reg [7:0]  toctou_sub_cmd;
+    reg [1:0]  toctou_index;
+    reg [23:0] toctou_start_buf;
+    reg [23:0] toctou_mask_buf;
+    
+    // TOCTOU address check: detect rising edge of log_addr_valid_sync
+    reg log_addr_valid_prev;
+    wire log_addr_event = log_addr_valid_sync && !log_addr_valid_prev;
+    
+    // SPI active edge detection for redirect clear
+    reg spi_active_prev;
+    
     // Convert 23-bit burst address to 25-bit access_addr for SDRAM controller
     // Burst address: [22]=chip, [21:9]=row, [8:7]=bank, [6:0]=col_burst
     // Access addr:   [24]=chip, [23:11]=row, [10:9]=bank, [8:0]=col
@@ -272,6 +321,20 @@ module glue(
             write_buffer <= 0;
             
             hold_out <= 0;
+            log_active <= 0;
+            
+            redirect_active <= 0;
+            redirect_mask <= 0;
+            redirect_base <= 0;
+            trap_notify_strobe <= 0;
+            
+            trap_armed <= 0;
+            trap_triggered <= 0;
+            toctou_sub_cmd <= 0;
+            toctou_index <= 0;
+            
+            log_addr_valid_prev <= 0;
+            spi_active_prev <= 0;
             
             cfg_jedec_id <= {8'h17, 8'h40, 8'hEF};  // Default: W25Q64FV (EF 40 17)
             cfg_4byte <= 0;
@@ -286,6 +349,12 @@ module glue(
 
             for (i = 0; i < 256; i = i + 1)
                 i_spi_write_data[i][8] <= 0;
+            
+            for (i = 0; i < 4; i = i + 1) begin
+                trap_start[i] <= 0;
+                trap_mask[i] <= 0;
+                trap_replace[i] <= 0;
+            end
             
             tx_wait <= 0;
 
@@ -394,6 +463,49 @@ module glue(
                 log_ack <= 1;
             end
             if (!log_strobe_buf[1]) log_ack <= 0;
+            
+            // -------------------------------------------------------
+            // TOCTOU trap check: on address phase completion, compare
+            // against all 4 trap entries.  First match wins.
+            //
+            // - Armed && !Triggered: mark triggered (serve original data)
+            // - Armed && Triggered:  activate redirect (serve replacement)
+            // -------------------------------------------------------
+            log_addr_valid_prev <= log_addr_valid_sync;
+            spi_active_prev <= spi_active_sync;
+            trap_notify_strobe <= 0;
+            
+            if (log_addr_event) begin
+                // Check read commands only (opcodes 0x03, 0x0B, 0x0C, 0x13,
+                // 0x3B, 0x6B, 0xBB, 0xEB and SFDP 0x5A).
+                // We check all traps; the address comparison handles filtering.
+                for (i = 0; i < 4; i = i + 1) begin
+                    if (trap_armed[i] &&
+                        ((log_addr_sync & trap_mask[i]) ==
+                         (trap_start[i] & trap_mask[i]))) begin
+                        if (!trap_triggered[i]) begin
+                            // First access: mark triggered, serve original data
+                            trap_triggered[i] <= 1;
+                        end
+                        else begin
+                            // Second+ access: activate redirect
+                            redirect_active <= 1;
+                            redirect_mask <= trap_mask[i][23:3];
+                            // Compute replacement burst addr via bitwise mux:
+                            // new_burst = (replace & mask) | (original & ~mask)
+                            redirect_base <= trap_replace[i][23:3];
+                            
+                            trap_notify_strobe <= 1;
+                            trap_notify_index  <= i[1:0];
+                            trap_notify_addr   <= log_addr_sync;
+                        end
+                    end
+                end
+            end
+            
+            // Clear redirect when SPI transaction ends (CS deasserts)
+            if (spi_active_prev && !spi_active_sync)
+                redirect_active <= 0;
                 
             // SPI write buffer handling
             spi_write_buf_strobe_buf <= {spi_write_buf_strobe_buf[0], spi_write_buf_strobe};
@@ -593,10 +705,25 @@ module glue(
 
                     if (in_count == 0) begin
                         // VERSION/START/STOP/STATUS are handled above.
-                        // Destructive commands are only accepted when
-                        // SPI emulation is stopped (spi_trx is in reset
-                        // and cannot contend for SDRAM or cfg registers).
-                        if (!spi_running) begin
+                        // HOLDCTL/LOGCTL/TOCTOU only flip flags/GPIO and
+                        // do not touch SDRAM or spi_trx state, so they
+                        // are safe to accept in either spi_running state.
+                        // Destructive commands (RAMREAD/RAMWRITE/CHIPCONFIG)
+                        // are only accepted when SPI emulation is stopped
+                        // so they cannot contend for SDRAM or cfg registers.
+                        if (rxd_data_buf == CMD_HOLDCTL) begin
+                            cmd <= CMD_HOLDCTL;
+                            in_count <= 1;
+                        end
+                        else if (rxd_data_buf == CMD_LOGCTL) begin
+                            cmd <= CMD_LOGCTL;
+                            in_count <= 1;
+                        end
+                        else if (rxd_data_buf == CMD_TOCTOU) begin
+                            cmd <= CMD_TOCTOU;
+                            in_count <= 1;
+                        end
+                        else if (!spi_running) begin
                             if (rxd_data_buf == CMD_RAMREAD ||
                                 rxd_data_buf == CMD_RAMWRITE) begin
                                 cmd <= rxd_data_buf;
@@ -612,13 +739,6 @@ module glue(
                                 cmd <= CMD_CHIPCONFIG;
                                 in_count <= 1;
                             end
-                        end
-                        // HOLDCTL toggles a simple GPIO on the target flash
-                        // and does not touch SDRAM or spi_trx state, so it
-                        // is accepted regardless of spi_running.
-                        if (rxd_data_buf == CMD_HOLDCTL) begin
-                            cmd <= CMD_HOLDCTL;
-                            in_count <= 1;
                         end
                     end
                     else if (cmd == CMD_CHIPCONFIG) begin
@@ -698,6 +818,92 @@ module glue(
                         txd_data_buf <= 8'h01;
                         in_count <= 0;
                         cmd <= CMD_NOP;
+                    end
+                    else if (cmd == CMD_LOGCTL) begin
+                        // -----------------------------------------------
+                        // LOGCTL protocol:
+                        //   Byte 1: 0x01 = start logging, 0x00 = stop
+                        // Response: 0x01
+                        // -----------------------------------------------
+                        log_active <= rxd_data_buf[0];
+                        txd_strobe_buf <= 1;
+                        txd_data_buf <= 8'h01;
+                        in_count <= 0;
+                        cmd <= CMD_NOP;
+                    end
+                    else if (cmd == CMD_TOCTOU) begin
+                        // -----------------------------------------------
+                        // TOCTOU protocol:
+                        //   Byte 1: sub-command
+                        //     0x01 SET:  +index(1) +start(3) +mask(3) +replace(3)
+                        //     0x02 ARM:  +index(1)
+                        //     0x03 DISARM: +index(1)
+                        //     0x04 RESET:  +index(1)
+                        //     0x05 RESET_ALL: (no extra bytes)
+                        // Response: 0x01 on completion
+                        // -----------------------------------------------
+                        if (in_count == 1) begin
+                            toctou_sub_cmd <= rxd_data_buf;
+                            if (rxd_data_buf == TOCTOU_RESET_ALL) begin
+                                trap_armed <= 0;
+                                trap_triggered <= 0;
+                                redirect_active <= 0;
+                                txd_strobe_buf <= 1;
+                                txd_data_buf <= 8'h01;
+                                in_count <= 0;
+                                cmd <= CMD_NOP;
+                            end
+                            else
+                                in_count <= 2;
+                        end
+                        else if (in_count == 2) begin
+                            toctou_index <= rxd_data_buf[1:0];
+                            if (toctou_sub_cmd == TOCTOU_ARM) begin
+                                trap_armed[rxd_data_buf[1:0]] <= 1;
+                                txd_strobe_buf <= 1;
+                                txd_data_buf <= 8'h01;
+                                in_count <= 0;
+                                cmd <= CMD_NOP;
+                            end
+                            else if (toctou_sub_cmd == TOCTOU_DISARM) begin
+                                trap_armed[rxd_data_buf[1:0]] <= 0;
+                                txd_strobe_buf <= 1;
+                                txd_data_buf <= 8'h01;
+                                in_count <= 0;
+                                cmd <= CMD_NOP;
+                            end
+                            else if (toctou_sub_cmd == TOCTOU_RESET) begin
+                                trap_triggered[rxd_data_buf[1:0]] <= 0;
+                                txd_strobe_buf <= 1;
+                                txd_data_buf <= 8'h01;
+                                in_count <= 0;
+                                cmd <= CMD_NOP;
+                            end
+                            else
+                                in_count <= 3;
+                        end
+                        // TOCTOU SET: receive start(3), mask(3), replace(3)
+                        else if (in_count == 3)  begin toctou_start_buf[23:16] <= rxd_data_buf; in_count <= 4; end
+                        else if (in_count == 4)  begin toctou_start_buf[15:8]  <= rxd_data_buf; in_count <= 5; end
+                        else if (in_count == 5)  begin toctou_start_buf[7:0]   <= rxd_data_buf; in_count <= 6; end
+                        else if (in_count == 6)  begin toctou_mask_buf[23:16]  <= rxd_data_buf; in_count <= 7; end
+                        else if (in_count == 7)  begin toctou_mask_buf[15:8]   <= rxd_data_buf; in_count <= 8; end
+                        else if (in_count == 8)  begin toctou_mask_buf[7:0]    <= rxd_data_buf; in_count <= 9; end
+                        else if (in_count == 9)  begin
+                            trap_start[toctou_index] <= toctou_start_buf;
+                            trap_mask[toctou_index]  <= toctou_mask_buf;
+                            trap_replace[toctou_index][23:16] <= rxd_data_buf;
+                            in_count <= 10;
+                        end
+                        else if (in_count == 10) begin trap_replace[toctou_index][15:8] <= rxd_data_buf; in_count <= 11; end
+                        else if (in_count == 11) begin
+                            trap_replace[toctou_index][7:0] <= rxd_data_buf;
+                            trap_triggered[toctou_index] <= 0;
+                            txd_strobe_buf <= 1;
+                            txd_data_buf <= 8'h01;
+                            in_count <= 0;
+                            cmd <= CMD_NOP;
+                        end
                     end
                     else begin
                         // RAMREAD / RAMWRITE handling (v3: 6-byte header)

--- a/src/logger.v
+++ b/src/logger.v
@@ -1,0 +1,220 @@
+// Logger Module
+// Captures SPI transaction events, formats log packets, and streams
+// them to the FT245 TX interface for real-time monitoring.
+//
+// Log packet format (type byte 0xA0-0xAF to avoid collision with
+// normal protocol responses):
+//
+//   0xA1 <opcode>                                - SPI command decoded (2 bytes)
+//   0xA2 <addr3> <addr2> <addr1> <addr0>         - Address phase complete (5 bytes)
+//   0xA3 <count2> <count1> <count0>              - Transaction end + byte count (4 bytes)
+//   0xA4 <index> <addr3> <addr2> <addr1> <addr0> - TOCTOU trap triggered (6 bytes)
+//
+// SPI-domain inputs are synchronized internally via 3-FF synchronizers
+// with rising-edge detection.
+
+`default_nettype none
+
+module logger(
+    input wire clk,
+    input wire reset,
+    input wire enable,               // Logging active (from glue LOGCTL)
+
+    // SPI-domain logging inputs (from spi_trx)
+    input wire spi_log_cmd_valid,    // Pulse: command decoded
+    input wire [7:0] spi_log_cmd_opcode,
+    input wire spi_log_addr_valid,   // Pulse: address phase complete
+    input wire [31:0] spi_log_addr,
+    input wire spi_active,           // Level: SPI CS active
+    input wire [23:0] spi_log_byte_count,
+
+    // TOCTOU trap notification (system clock domain, from glue)
+    input wire trap_notify_strobe,
+    input wire [1:0] trap_notify_index,
+    input wire [23:0] trap_notify_addr,
+
+    // FT245 TX interface
+    input wire txd_ready,
+    output reg txd_strobe = 0,
+    output reg [7:0] txd_data = 0
+);
+
+    // -----------------------------------------------------------------
+    // Synchronize SPI-domain signals into system clock domain
+    // -----------------------------------------------------------------
+    reg [2:0] cmd_valid_sync;
+    reg [2:0] addr_valid_sync;
+    reg [2:0] active_sync;
+
+    always @(posedge clk) begin
+        cmd_valid_sync  <= {cmd_valid_sync[1:0],  spi_log_cmd_valid};
+        addr_valid_sync <= {addr_valid_sync[1:0], spi_log_addr_valid};
+        active_sync     <= {active_sync[1:0],     spi_active};
+    end
+
+    wire cmd_event      = cmd_valid_sync[1]  && !cmd_valid_sync[2];
+    wire addr_event     = addr_valid_sync[1] && !addr_valid_sync[2];
+    wire deselect_event = !active_sync[1]    && active_sync[2];
+
+    // -----------------------------------------------------------------
+    // Byte FIFO for log packet data
+    // -----------------------------------------------------------------
+    wire fifo_space;
+    wire fifo_data_available;
+    wire [7:0] fifo_read_data;
+    reg fifo_write_strobe;
+    reg [7:0] fifo_write_data;
+    reg fifo_read_strobe;
+
+    fifo #(.WIDTH(8), .NUM(256), .FREESPACE(8)) log_fifo(
+        .clk(clk),
+        .reset(reset),
+        .write_data(fifo_write_data),
+        .write_strobe(fifo_write_strobe),
+        .space_available(fifo_space),
+        .data_available(fifo_data_available),
+        .more_available(),
+        .read_data(fifo_read_data),
+        .read_strobe(fifo_read_strobe)
+    );
+
+    // -----------------------------------------------------------------
+    // Event capture and packet emission state machine
+    //
+    // Events are detected as edges.  When an event fires, the packet
+    // bytes are written into the FIFO one byte per clock.  If multiple
+    // events arrive while a packet is being emitted, they are queued
+    // via pending flags and processed in priority order.
+    // -----------------------------------------------------------------
+
+    localparam [2:0]
+        PKT_IDLE   = 3'd0,
+        PKT_EMIT   = 3'd1;
+
+    reg [2:0] pkt_state;
+    reg [47:0] pkt_shift;   // Shift register: up to 6 bytes
+    reg [2:0] pkt_remain;   // Bytes remaining to emit
+
+    // Pending event flags (set on edge detection, cleared when serviced)
+    reg evt_cmd_pending;
+    reg evt_addr_pending;
+    reg evt_end_pending;
+    reg evt_trap_pending;
+
+    // Latched event data (captured when event edge detected)
+    reg [7:0] evt_cmd_opcode;
+    reg [31:0] evt_addr;
+    reg [23:0] evt_byte_count;
+    reg [1:0] evt_trap_index;
+    reg [23:0] evt_trap_addr;
+
+    always @(posedge clk) begin
+        fifo_write_strobe <= 0;
+
+        if (reset) begin
+            pkt_state       <= PKT_IDLE;
+            pkt_shift       <= 0;
+            pkt_remain      <= 0;
+            evt_cmd_pending  <= 0;
+            evt_addr_pending <= 0;
+            evt_end_pending  <= 0;
+            evt_trap_pending <= 0;
+        end
+        else begin
+            // Capture events
+            if (cmd_event && enable) begin
+                evt_cmd_pending <= 1;
+                evt_cmd_opcode  <= spi_log_cmd_opcode;
+            end
+            if (addr_event && enable) begin
+                evt_addr_pending <= 1;
+                evt_addr         <= spi_log_addr;
+            end
+            if (deselect_event && enable) begin
+                evt_end_pending  <= 1;
+                evt_byte_count   <= spi_log_byte_count;
+            end
+            if (trap_notify_strobe && enable) begin
+                evt_trap_pending <= 1;
+                evt_trap_index   <= trap_notify_index;
+                evt_trap_addr    <= trap_notify_addr;
+            end
+
+            // Packet emission
+            if (pkt_state == PKT_IDLE) begin
+                // Service pending events in priority order
+                if (evt_cmd_pending && fifo_space) begin
+                    evt_cmd_pending   <= 0;
+                    fifo_write_strobe <= 1;
+                    fifo_write_data   <= 8'hA1;
+                    pkt_shift         <= {evt_cmd_opcode, 40'b0};
+                    pkt_remain        <= 1;
+                    pkt_state         <= PKT_EMIT;
+                end
+                else if (evt_addr_pending && fifo_space) begin
+                    evt_addr_pending  <= 0;
+                    fifo_write_strobe <= 1;
+                    fifo_write_data   <= 8'hA2;
+                    pkt_shift         <= {evt_addr[31:0], 16'b0};
+                    pkt_remain        <= 4;
+                    pkt_state         <= PKT_EMIT;
+                end
+                else if (evt_end_pending && fifo_space) begin
+                    evt_end_pending   <= 0;
+                    fifo_write_strobe <= 1;
+                    fifo_write_data   <= 8'hA3;
+                    pkt_shift         <= {evt_byte_count, 24'b0};
+                    pkt_remain        <= 3;
+                    pkt_state         <= PKT_EMIT;
+                end
+                else if (evt_trap_pending && fifo_space) begin
+                    evt_trap_pending  <= 0;
+                    fifo_write_strobe <= 1;
+                    fifo_write_data   <= 8'hA4;
+                    pkt_shift         <= {6'b0, evt_trap_index, evt_trap_addr, 16'b0};
+                    pkt_remain        <= 5;
+                    pkt_state         <= PKT_EMIT;
+                end
+            end
+            else if (pkt_state == PKT_EMIT) begin
+                if (fifo_space) begin
+                    fifo_write_strobe <= 1;
+                    fifo_write_data   <= pkt_shift[47:40];
+                    pkt_shift         <= {pkt_shift[39:0], 8'b0};
+                    pkt_remain        <= pkt_remain - 1;
+                    if (pkt_remain == 1)
+                        pkt_state <= PKT_IDLE;
+                end
+            end
+        end
+    end
+
+    // -----------------------------------------------------------------
+    // FIFO drain: send buffered log bytes to FT245 TX
+    //
+    // Single-byte cadence: assert txd_strobe for 1 cycle, then wait
+    // for txd_ready before sending the next.  drain_hold prevents
+    // double-send during the ready propagation delay.
+    // -----------------------------------------------------------------
+    reg drain_hold;
+
+    always @(posedge clk) begin
+        txd_strobe      <= 0;
+        fifo_read_strobe <= 0;
+
+        if (reset) begin
+            drain_hold <= 0;
+        end
+        else if (enable && fifo_data_available && txd_ready && !drain_hold) begin
+            txd_strobe       <= 1;
+            txd_data         <= fifo_read_data;
+            fifo_read_strobe <= 1;
+            drain_hold       <= 1;
+        end
+        else begin
+            if (drain_hold)
+                drain_hold <= 0;
+        end
+    end
+
+endmodule

--- a/src/logger.v
+++ b/src/logger.v
@@ -1,14 +1,19 @@
 // Logger Module
-// Captures SPI transaction events, formats log packets, and streams
-// them to the FT245 TX interface for real-time monitoring.
+// Captures SPI transaction events into a ring FIFO.  The FIFO is drained
+// by glue.v on CMD_LOGPOLL requests from the host, so the logger never
+// commandeers the UART or FT245 TX path -- logging coexists cleanly with
+// any protocol traffic on either transport.
 //
-// Log packet format (type byte 0xA0-0xAF to avoid collision with
-// normal protocol responses):
+// Log packet format (type byte 0xA0-0xAF to avoid collision with normal
+// protocol responses):
 //
 //   0xA1 <opcode>                                - SPI command decoded (2 bytes)
 //   0xA2 <addr3> <addr2> <addr1> <addr0>         - Address phase complete (5 bytes)
 //   0xA3 <count2> <count1> <count0>              - Transaction end + byte count (4 bytes)
 //   0xA4 <index> <addr3> <addr2> <addr1> <addr0> - TOCTOU trap triggered (6 bytes)
+//
+// Glue uses 0xA0 as the CMD_LOGPOLL terminator, which is NOT emitted by
+// this module, so the host can unambiguously parse the stream.
 //
 // SPI-domain inputs are synchronized internally via 3-FF synchronizers
 // with rising-edge detection.
@@ -33,10 +38,10 @@ module logger(
     input wire [1:0] trap_notify_index,
     input wire [23:0] trap_notify_addr,
 
-    // FT245 TX interface
-    input wire txd_ready,
-    output reg txd_strobe = 0,
-    output reg [7:0] txd_data = 0
+    // FIFO read interface (driven by glue CMD_LOGPOLL handler)
+    output wire out_data_available,
+    output wire [7:0] out_read_data,
+    input wire out_read_strobe
 );
 
     // -----------------------------------------------------------------
@@ -60,22 +65,19 @@ module logger(
     // Byte FIFO for log packet data
     // -----------------------------------------------------------------
     wire fifo_space;
-    wire fifo_data_available;
-    wire [7:0] fifo_read_data;
     reg fifo_write_strobe;
     reg [7:0] fifo_write_data;
-    reg fifo_read_strobe;
 
-    fifo #(.WIDTH(8), .NUM(256), .FREESPACE(8)) log_fifo(
+    fifo #(.WIDTH(8), .NUM(512), .FREESPACE(8)) log_fifo(
         .clk(clk),
         .reset(reset),
         .write_data(fifo_write_data),
         .write_strobe(fifo_write_strobe),
         .space_available(fifo_space),
-        .data_available(fifo_data_available),
+        .data_available(out_data_available),
         .more_available(),
-        .read_data(fifo_read_data),
-        .read_strobe(fifo_read_strobe)
+        .read_data(out_read_data),
+        .read_strobe(out_read_strobe)
     );
 
     // -----------------------------------------------------------------
@@ -186,34 +188,6 @@ module logger(
                         pkt_state <= PKT_IDLE;
                 end
             end
-        end
-    end
-
-    // -----------------------------------------------------------------
-    // FIFO drain: send buffered log bytes to FT245 TX
-    //
-    // Single-byte cadence: assert txd_strobe for 1 cycle, then wait
-    // for txd_ready before sending the next.  drain_hold prevents
-    // double-send during the ready propagation delay.
-    // -----------------------------------------------------------------
-    reg drain_hold;
-
-    always @(posedge clk) begin
-        txd_strobe      <= 0;
-        fifo_read_strobe <= 0;
-
-        if (reset) begin
-            drain_hold <= 0;
-        end
-        else if (enable && fifo_data_available && txd_ready && !drain_hold) begin
-            txd_strobe       <= 1;
-            txd_data         <= fifo_read_data;
-            fifo_read_strobe <= 1;
-            drain_hold       <= 1;
-        end
-        else begin
-            if (drain_hold)
-                drain_hold <= 0;
         end
     end
 

--- a/src/spi_trx.v
+++ b/src/spi_trx.v
@@ -60,7 +60,15 @@ module spi_trx(
     input wire [7:0] sfdp_rdata,
     
     output reg log_strobe = 0,
-    output reg [7:0] log_val = 0
+    output reg [7:0] log_val = 0,
+    
+    // Structured logging outputs (directly driven from SPI state machine).
+    // All signals are in the SPI clock domain; the logger module synchronizes.
+    output reg log_cmd_valid = 0,       // Pulse: command byte decoded
+    output reg [7:0] log_cmd_opcode = 0,// The opcode that was decoded
+    output reg log_addr_valid = 0,      // Pulse: address phase complete
+    output reg [31:0] log_addr_out = 0, // Full flash byte address
+    output reg [23:0] log_byte_count = 0// Running count of bytes read in current transaction
 );
 
     wire is_selected = !spi_reset && !spi_csel;
@@ -225,6 +233,9 @@ module spi_trx(
                 
                 log_strobe <= 0;
                 log_val <= 0;
+                log_cmd_valid <= 0;
+                log_addr_valid <= 0;
+                log_byte_count <= 0;
                 
                 ram_inhibit_refresh <= 0;
                 ram_activate <= 0;
@@ -247,6 +258,8 @@ module spi_trx(
             end
             else begin
                 log_strobe <= 0;
+                log_cmd_valid <= 0;
+                log_addr_valid <= 0;
                     
                 write_buf_strobe <= 0;
                 
@@ -465,6 +478,9 @@ module spi_trx(
                     
                     log_strobe <= 1;
                     log_val <= {mosi_byte[7:1], spi_io0_in};
+                    log_cmd_valid <= 1;
+                    log_cmd_opcode <= {mosi_byte[7:1], spi_io0_in};
+                    log_byte_count <= 0;
                 end
                 else if ((state == STA_READSTATUS) && (bit_count_in == 0)) begin
                     miso_byte <= status_reg;
@@ -490,6 +506,10 @@ module spi_trx(
                     end
                     
                     if (addr_count == 0) begin
+                        log_addr_valid <= 1;
+                        log_addr_out <= addr;
+                        log_addr_out[0] <= spi_io0_in;
+                        
                         if (!is_sfdp_read) begin
                             ram_inhibit_refresh <= 0;
                             ram_activate <= 0;
@@ -581,6 +601,7 @@ module spi_trx(
                     if (bit_count_in == 0) begin
                         miso_byte <= ram_read_buffer[(addr[2:0]+1)*8 +: 8];
                         addr <= addr + 1;
+                        log_byte_count <= log_byte_count + 1;
                     end
                     
                     if (fresh_read) 
@@ -598,6 +619,10 @@ module spi_trx(
                 end
                 else if (state == STA_ADDR_ERASE) begin
                     if (addr_count == 0) begin
+                        log_addr_valid <= 1;
+                        log_addr_out <= addr;
+                        log_addr_out[0] <= spi_io0_in;
+                        
                         state <= STA_ERASE;
                         write_cmd <= 1;
                         write_type <= 2'd1;
@@ -625,6 +650,10 @@ module spi_trx(
                 end
                 else if (state == STA_ADDR_WRITE) begin
                     if (addr_count == 0) begin
+                        log_addr_valid <= 1;
+                        log_addr_out <= addr;
+                        log_addr_out[0] <= spi_io0_in;
+
                         if (is_aai) begin
                             // AAI: single-burst RMW, don't clear WEL
                             // (address is word-aligned per SST spec;
@@ -641,11 +670,11 @@ module spi_trx(
                             state <= STA_WRITE;
                             write_cmd <= 1;
                             write_type <= 2'd0;
-                            
+
                             // Page-aligned address in 8-byte burst units
                             // byte_addr[25:3] -> burst address, page = 256 bytes = 32 bursts
                             write_addr <= {addr[25:8], 5'b0};
-                                
+
                             status_reg[1] <= 0;
                             status_reg[0] <= 1;
                         end
@@ -713,6 +742,11 @@ module spi_trx(
                     
                     // Transition when last 2 bits received (addr_count was 1)
                     if (addr_count == 1) begin
+                        log_addr_valid <= 1;
+                        log_addr_out <= addr;
+                        log_addr_out[1] <= spi_io1_in;
+                        log_addr_out[0] <= spi_io0_in;
+                        
                         // Enter mode+dummy phase (4 dual clocks for 0xBB)
                         state <= STA_MODE_MULTI;
                         mode_count <= 3;
@@ -825,6 +859,7 @@ module spi_trx(
                         else
                             miso_byte <= ram_read_buffer[(addr[2:0]+1)*8 +: 8];
                         addr <= addr + 1;
+                        log_byte_count <= log_byte_count + 1;
                     end
                     
                     if (fresh_read)
@@ -860,6 +895,13 @@ module spi_trx(
                     
                     // Transition when last 4 bits received (addr_count was 3)
                     if (addr_count == 3) begin
+                        log_addr_valid <= 1;
+                        log_addr_out <= addr;
+                        log_addr_out[3] <= spi_io3_in;
+                        log_addr_out[2] <= spi_io2_in;
+                        log_addr_out[1] <= spi_io1_in;
+                        log_addr_out[0] <= spi_io0_in;
+                        
                         // Enter mode+dummy phase (6 quad clocks: 2 mode + 4 dummy)
                         state <= STA_MODE_MULTI;
                         mode_count <= 5;
@@ -920,6 +962,7 @@ module spi_trx(
                         else
                             miso_byte <= ram_read_buffer[(addr[2:0]+1)*8 +: 8];
                         addr <= addr + 1;
+                        log_byte_count <= log_byte_count + 1;
                     end
                     
                     if (fresh_read)
@@ -943,6 +986,7 @@ module spi_trx(
                     else if (bit_count_in == 0) begin
                         miso_byte <= sfdp_rdata;
                         addr <= addr + 1;
+                        log_byte_count <= log_byte_count + 1;
                     end
                 end
                 else if (state == STA_WRITESTATUS && bit_count_in == 0) begin

--- a/src/top.v
+++ b/src/top.v
@@ -240,6 +240,13 @@ module top(
     wire log_strobe;
     wire [7:0] log_val;
     
+    // Structured logging signals (SPI clock domain)
+    wire log_cmd_valid;
+    wire [7:0] log_cmd_opcode;
+    wire log_addr_valid;
+    wire [31:0] log_addr_out;
+    wire [23:0] log_byte_count;
+    
     // Chip configuration wires (glue -> spi_trx)
     wire [23:0] cfg_jedec_id;
     wire cfg_4byte;
@@ -297,8 +304,57 @@ module top(
         .sfdp_rdata(sfdp_rdata),
         
         .log_strobe(log_strobe),
-        .log_val(log_val)
+        .log_val(log_val),
+        
+        .log_cmd_valid(log_cmd_valid),
+        .log_cmd_opcode(log_cmd_opcode),
+        .log_addr_valid(log_addr_valid),
+        .log_addr_out(log_addr_out),
+        .log_byte_count(log_byte_count)
     );
+    
+    // -----------------------------------------------------------
+    // Logging signal synchronization (SPI -> system clock domain)
+    //
+    // The glue module needs synchronized versions of log_addr_valid
+    // and spi_active to perform TOCTOU trap checks.  spi_trx signals
+    // are in the SPI clock domain; these 2-FF synchronizers bring
+    // them into the system clock domain with edge detection in glue.
+    // -----------------------------------------------------------
+    
+    reg [1:0] log_addr_valid_sys;
+    reg [1:0] spi_active_sys;
+    reg [31:0] log_addr_latched;
+    
+    always @(posedge clk) begin
+        log_addr_valid_sys <= {log_addr_valid_sys[0], log_addr_valid};
+        spi_active_sys     <= {spi_active_sys[0], spi_active};
+        // Latch addr when valid fires (stable for multiple sys clocks)
+        if (log_addr_valid && !log_addr_valid_sys[0])
+            log_addr_latched <= log_addr_out;
+    end
+    
+    // -----------------------------------------------------------
+    // TOCTOU Address Redirect Mux
+    //
+    // Transparently transforms the SPI SDRAM address when a TOCTOU
+    // trap is active.  The redirect uses a bitwise mux controlled
+    // by the trap mask:
+    //   new_addr = (redirect_base & redirect_mask) |
+    //              (original_addr & ~redirect_mask)
+    //
+    // The first 8 bytes of a redirected read use the original
+    // address (the SDRAM pipeline fires before the trap check
+    // completes).  All subsequent bursts use the redirected address.
+    // -----------------------------------------------------------
+    
+    wire redirect_active;
+    wire [22:0] redirect_mask;
+    wire [22:0] redirect_base;
+    
+    wire [22:0] spi_ram_addr_final = redirect_active ?
+        ((redirect_base & redirect_mask) | (spi_ram_addr & ~redirect_mask)) :
+        spi_ram_addr;
     
     // -----------------------------------------------------------
     // SDRAM Controller
@@ -327,11 +383,11 @@ module top(
         .dqm_o(sdram_dqm),
         .dq_io(IO_sdram_dq),
         
-        // SPI fast-path control
+        // SPI fast-path control (address passes through TOCTOU redirect mux)
         .spi_inhibit_refresh(spi_ram_inhibit_refresh),
         .spi_cmd_activate(spi_ram_activate),
         .spi_cmd_read(spi_ram_read),
-        .spi_addr(spi_ram_addr),
+        .spi_addr(spi_ram_addr_final),
         
         // Serial path control
         .access_cmd(sdram_access_cmd),
@@ -379,9 +435,9 @@ module top(
     // FT245 Interface (FT2232H async FIFO)
     // -----------------------------------------------------------
     
-    wire ft_txd_ready;
-    wire [7:0] ft_txd;
-    wire ft_txd_strobe;
+    wire ft_txd_ready_raw;       // Raw ready from ft245
+    wire [7:0] ft_txd_muxed;    // Muxed TX data to ft245
+    wire ft_txd_strobe_muxed;   // Muxed TX strobe to ft245
     wire ft_rxd_strobe_raw;
     wire [7:0] ft_rxd_raw;
     
@@ -395,10 +451,53 @@ module top(
         .ft_wr_n(ft_wr_n),
         .rxd(ft_rxd_raw),
         .rxd_strobe(ft_rxd_strobe_raw),
-        .txd(ft_txd),
-        .txd_strobe(ft_txd_strobe),
-        .txd_ready(ft_txd_ready)
+        .txd(ft_txd_muxed),
+        .txd_strobe(ft_txd_strobe_muxed),
+        .txd_ready(ft_txd_ready_raw)
     );
+    
+    // -----------------------------------------------------------
+    // Logger Module
+    // -----------------------------------------------------------
+    
+    wire log_active;
+    wire log_txd_strobe;
+    wire [7:0] log_txd_data;
+    wire trap_notify_strobe;
+    wire [1:0] trap_notify_index;
+    wire [23:0] trap_notify_addr;
+    
+    // FT245 TX ready routed to active sender
+    wire glue_ft_txd_ready = log_active ? 1'b0 : ft_txd_ready_raw;
+    wire log_ft_txd_ready  = log_active ? ft_txd_ready_raw : 1'b0;
+    
+    logger logger_i(
+        .clk(clk),
+        .reset(reset),
+        .enable(log_active),
+        
+        .spi_log_cmd_valid(log_cmd_valid),
+        .spi_log_cmd_opcode(log_cmd_opcode),
+        .spi_log_addr_valid(log_addr_valid),
+        .spi_log_addr(log_addr_out),
+        .spi_active(spi_active),
+        .spi_log_byte_count(log_byte_count),
+        
+        .trap_notify_strobe(trap_notify_strobe),
+        .trap_notify_index(trap_notify_index),
+        .trap_notify_addr(trap_notify_addr),
+        
+        .txd_ready(log_ft_txd_ready),
+        .txd_strobe(log_txd_strobe),
+        .txd_data(log_txd_data)
+    );
+    
+    // FT245 TX mux: log data when logging active, glue data otherwise
+    wire glue_ft_txd_strobe;
+    wire [7:0] glue_ft_txd_data;
+    
+    assign ft_txd_strobe_muxed = log_active ? log_txd_strobe : glue_ft_txd_strobe;
+    assign ft_txd_muxed        = log_active ? log_txd_data   : glue_ft_txd_data;
     
     // -----------------------------------------------------------
     // FT245 RX FIFO: decouple ft245 byte delivery from glue
@@ -455,9 +554,9 @@ module top(
         .ft_rx_data(ft_rxfifo_data),
         .ft_rx_pop(ft_rx_pop),
         
-        .ft_txd_ready(ft_txd_ready),
-        .ft_txd_strobe(ft_txd_strobe),
-        .ft_txd_data(ft_txd),
+        .ft_txd_ready(glue_ft_txd_ready),
+        .ft_txd_strobe(glue_ft_txd_strobe),
+        .ft_txd_data(glue_ft_txd_data),
         
         .sdram_access_cmd(sdram_access_cmd),
         .sdram_access_addr(sdram_access_addr),
@@ -494,6 +593,20 @@ module top(
         
         .spi_running(spi_running),
         .hold_out(hold_out),
+
+        .log_active(log_active),
+
+        .log_addr_valid_sync(log_addr_valid_sys[1]),
+        .log_addr_sync(log_addr_latched[23:0]),
+        .spi_active_sync(spi_active_sys[1]),
+
+        .redirect_active(redirect_active),
+        .redirect_mask(redirect_mask),
+        .redirect_base(redirect_base),
+
+        .trap_notify_strobe(trap_notify_strobe),
+        .trap_notify_index(trap_notify_index),
+        .trap_notify_addr(trap_notify_addr),
 
         .led(led_out)
     );

--- a/src/top.v
+++ b/src/top.v
@@ -406,8 +406,6 @@ module top(
     // -----------------------------------------------------------
     
     wire uart_txd_ready;
-    wire [7:0] uart_txd;
-    wire uart_txd_strobe;
     wire uart_rxd_strobe;
     wire [7:0] uart_rxd;
     
@@ -415,6 +413,8 @@ module top(
     // DIVISOR must be divisible by 4 (uart_rx uses DIVISOR/4 for 4x oversampling)
     // Note: 3 Mbaud (DIVISOR=40) is achievable at 120MHz but the Sipeed
     // BL702 USB debugger on the dock can't sustain it for multi-byte reads.
+    wire [7:0] uart_txd;
+    wire uart_txd_strobe;
     uart #(
         .DIVISOR(60),
         .FIFO(256),
@@ -434,13 +434,13 @@ module top(
     // -----------------------------------------------------------
     // FT245 Interface (FT2232H async FIFO)
     // -----------------------------------------------------------
-    
-    wire ft_txd_ready_raw;       // Raw ready from ft245
-    wire [7:0] ft_txd_muxed;    // Muxed TX data to ft245
-    wire ft_txd_strobe_muxed;   // Muxed TX strobe to ft245
+
+    wire ft_txd_ready;
+    wire [7:0] ft_txd;
+    wire ft_txd_strobe;
     wire ft_rxd_strobe_raw;
     wire [7:0] ft_rxd_raw;
-    
+
     ft245 ft245_i(
         .clk(clk),
         .reset(reset),
@@ -451,53 +451,50 @@ module top(
         .ft_wr_n(ft_wr_n),
         .rxd(ft_rxd_raw),
         .rxd_strobe(ft_rxd_strobe_raw),
-        .txd(ft_txd_muxed),
-        .txd_strobe(ft_txd_strobe_muxed),
-        .txd_ready(ft_txd_ready_raw)
+        .txd(ft_txd),
+        .txd_strobe(ft_txd_strobe),
+        .txd_ready(ft_txd_ready)
     );
     
     // -----------------------------------------------------------
     // Logger Module
+    //
+    // The logger captures SPI transaction events into its internal 512-
+    // byte ring FIFO.  Glue drains the FIFO on CMD_LOGPOLL requests from
+    // the host, so logging never commandeers the UART or FT245 TX path
+    // and coexists cleanly with any other protocol traffic on either
+    // transport (no active-port mux is needed).
     // -----------------------------------------------------------
-    
+
     wire log_active;
-    wire log_txd_strobe;
-    wire [7:0] log_txd_data;
     wire trap_notify_strobe;
     wire [1:0] trap_notify_index;
     wire [23:0] trap_notify_addr;
-    
-    // FT245 TX ready routed to active sender
-    wire glue_ft_txd_ready = log_active ? 1'b0 : ft_txd_ready_raw;
-    wire log_ft_txd_ready  = log_active ? ft_txd_ready_raw : 1'b0;
-    
+
+    wire log_fifo_data_available;
+    wire [7:0] log_fifo_read_data;
+    wire log_fifo_read_strobe;
+
     logger logger_i(
         .clk(clk),
         .reset(reset),
         .enable(log_active),
-        
+
         .spi_log_cmd_valid(log_cmd_valid),
         .spi_log_cmd_opcode(log_cmd_opcode),
         .spi_log_addr_valid(log_addr_valid),
         .spi_log_addr(log_addr_out),
         .spi_active(spi_active),
         .spi_log_byte_count(log_byte_count),
-        
+
         .trap_notify_strobe(trap_notify_strobe),
         .trap_notify_index(trap_notify_index),
         .trap_notify_addr(trap_notify_addr),
-        
-        .txd_ready(log_ft_txd_ready),
-        .txd_strobe(log_txd_strobe),
-        .txd_data(log_txd_data)
+
+        .out_data_available(log_fifo_data_available),
+        .out_read_data(log_fifo_read_data),
+        .out_read_strobe(log_fifo_read_strobe)
     );
-    
-    // FT245 TX mux: log data when logging active, glue data otherwise
-    wire glue_ft_txd_strobe;
-    wire [7:0] glue_ft_txd_data;
-    
-    assign ft_txd_strobe_muxed = log_active ? log_txd_strobe : glue_ft_txd_strobe;
-    assign ft_txd_muxed        = log_active ? log_txd_data   : glue_ft_txd_data;
     
     // -----------------------------------------------------------
     // FT245 RX FIFO: decouple ft245 byte delivery from glue
@@ -544,19 +541,19 @@ module top(
         // UART byte interface
         .rxd_strobe(uart_rxd_strobe),
         .rxd_data(uart_rxd),
-        
+
         .txd_ready(uart_txd_ready),
         .txd_strobe(uart_txd_strobe),
         .txd_data(uart_txd),
-        
+
         // FT245 byte interface (pull-based via RX FIFO)
         .ft_rx_data_available(ft_rxfifo_data_available),
         .ft_rx_data(ft_rxfifo_data),
         .ft_rx_pop(ft_rx_pop),
-        
-        .ft_txd_ready(glue_ft_txd_ready),
-        .ft_txd_strobe(glue_ft_txd_strobe),
-        .ft_txd_data(glue_ft_txd_data),
+
+        .ft_txd_ready(ft_txd_ready),
+        .ft_txd_strobe(ft_txd_strobe),
+        .ft_txd_data(ft_txd),
         
         .sdram_access_cmd(sdram_access_cmd),
         .sdram_access_addr(sdram_access_addr),
@@ -595,6 +592,12 @@ module top(
         .hold_out(hold_out),
 
         .log_active(log_active),
+
+        // Logger FIFO read interface (drained on CMD_LOGPOLL)
+        .log_fifo_data_available(log_fifo_data_available),
+        .log_fifo_read_data(log_fifo_read_data),
+        .log_fifo_read_strobe(log_fifo_read_strobe),
+
 
         .log_addr_valid_sync(log_addr_valid_sys[1]),
         .log_addr_sync(log_addr_latched[23:0]),

--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -80,6 +80,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +99,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -165,6 +180,29 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -365,6 +403,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +437,21 @@ dependencies = [
  "slab",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -516,7 +581,7 @@ dependencies = [
  "io-kit-sys 0.4.1",
  "libudev",
  "mach2 0.4.3",
- "nix",
+ "nix 0.26.4",
  "scopeguard",
  "unescaper",
  "windows-sys 0.52.0",
@@ -534,6 +599,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
+ "ctrlc",
  "ftdi-nusb",
  "indicatif",
  "libftd2xx",

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -18,3 +18,4 @@ anyhow = "1.0"
 indicatif = "0.17"
 serde = { version = "1.0", features = ["derive"] }
 ron = "0.8"
+ctrlc = "3.4"

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -28,7 +28,7 @@ const BLOCK_SIZE: usize = 16384; // 2048 bursts * 8 bytes
 // host-to-FPGA, SDRAM writes complete in microseconds).
 const UART_READ_BLOCK_SIZE: usize = 4096; // 512 bursts * 8 bytes
 
-const PROTOCOL_VERSION: u8 = 4;
+const PROTOCOL_VERSION: u8 = 5;
 
 // Protocol commands (shared between UART and FT245 transports)
 const CMD_VERSION: u8 = 0x30;
@@ -39,6 +39,21 @@ const CMD_START: u8 = 0x34; // Enable SPI emulation (protocol v4+)
 const CMD_STOP: u8 = 0x35; // Disable SPI emulation (protocol v4+)
 const CMD_STATUS: u8 = 0x36; // Query emulation state (protocol v4+)
 const CMD_HOLDCTL: u8 = 0x37; // Target flash #HOLD control (protocol v5+)
+const CMD_LOGCTL: u8 = 0x38; // Enable/disable SPI bus logging (protocol v5+)
+const CMD_TOCTOU: u8 = 0x39; // TOCTOU trap management (protocol v5+)
+
+// TOCTOU sub-commands
+const TOCTOU_SET: u8 = 0x01;
+const TOCTOU_ARM: u8 = 0x02;
+const TOCTOU_DISARM: u8 = 0x03;
+const TOCTOU_RESET: u8 = 0x04;
+const TOCTOU_RESET_ALL: u8 = 0x05;
+
+// Log packet type markers
+const LOG_CMD: u8 = 0xA1;
+const LOG_ADDR: u8 = 0xA2;
+const LOG_END: u8 = 0xA3;
+const LOG_TRAP: u8 = 0xA4;
 
 // FT2232H USB identifiers
 #[cfg(any(feature = "d2xx", feature = "ftdi"))]
@@ -53,6 +68,8 @@ const FT2232H_PID: u16 = 0x6010;
 trait Transport {
     fn write_all(&mut self, data: &[u8]) -> Result<()>;
     fn read_exact(&mut self, buf: &mut [u8]) -> Result<()>;
+    /// Read whatever is currently available (non-blocking, returns 0 if nothing).
+    fn read_available(&mut self, buf: &mut [u8]) -> Result<usize>;
 }
 
 // ---------------------------------------------------------------------------
@@ -155,6 +172,13 @@ impl Transport for SerialTransport {
         self.port.read_exact(buf)?;
         Ok(())
     }
+
+    fn read_available(&mut self, buf: &mut [u8]) -> Result<usize> {
+        self.port.set_timeout(Duration::from_millis(10))?;
+        let n = self.port.read(buf).unwrap_or(0);
+        self.port.set_timeout(Duration::from_secs(2))?;
+        Ok(n)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -245,6 +269,17 @@ impl Transport for Ft245Transport {
             pos += n;
         }
         Ok(())
+    }
+
+    fn read_available(&mut self, buf: &mut [u8]) -> Result<usize> {
+        use libftd2xx::FtdiCommon;
+        let n = self.ft.queue_status().unwrap_or(0);
+        if n == 0 {
+            return Ok(0);
+        }
+        let to_read = std::cmp::min(n, buf.len());
+        let got = self.ft.read(&mut buf[..to_read])?;
+        Ok(got)
     }
 }
 
@@ -341,6 +376,10 @@ impl Transport for Ft245Transport {
             pos += n;
         }
         Ok(())
+    }
+
+    fn read_available(&mut self, buf: &mut [u8]) -> Result<usize> {
+        self.dev.read_data(buf).map_err(|e| anyhow!(e))
     }
 }
 
@@ -678,6 +717,103 @@ impl FlashDevice {
         Ok(())
     }
 
+    fn log_start(&mut self) -> Result<()> {
+        self.transport.write_all(&[CMD_LOGCTL, 0x01])?;
+        let mut resp = [0u8; 1];
+        self.transport.read_exact(&mut resp)?;
+        if resp[0] != 0x01 {
+            bail!("LOGCTL start failed: unexpected response 0x{:02x}", resp[0]);
+        }
+        Ok(())
+    }
+
+    fn log_stop(&mut self) -> Result<()> {
+        self.transport.write_all(&[CMD_LOGCTL, 0x00])?;
+        let mut resp = [0u8; 1];
+        self.transport.read_exact(&mut resp)?;
+        if resp[0] != 0x01 {
+            bail!("LOGCTL stop failed: unexpected response 0x{:02x}", resp[0]);
+        }
+        Ok(())
+    }
+
+    fn toctou_set(&mut self, index: u8, start: u32, mask: u32, replace: u32) -> Result<()> {
+        let buf = [
+            CMD_TOCTOU,
+            TOCTOU_SET,
+            index & 0x03,
+            ((start >> 16) & 0xFF) as u8,
+            ((start >> 8) & 0xFF) as u8,
+            (start & 0xFF) as u8,
+            ((mask >> 16) & 0xFF) as u8,
+            ((mask >> 8) & 0xFF) as u8,
+            (mask & 0xFF) as u8,
+            ((replace >> 16) & 0xFF) as u8,
+            ((replace >> 8) & 0xFF) as u8,
+            (replace & 0xFF) as u8,
+        ];
+        self.transport.write_all(&buf)?;
+        let mut resp = [0u8; 1];
+        self.transport.read_exact(&mut resp)?;
+        if resp[0] != 0x01 {
+            bail!("TOCTOU set failed: unexpected response 0x{:02x}", resp[0]);
+        }
+        Ok(())
+    }
+
+    fn toctou_arm(&mut self, index: u8) -> Result<()> {
+        self.transport
+            .write_all(&[CMD_TOCTOU, TOCTOU_ARM, index & 0x03])?;
+        let mut resp = [0u8; 1];
+        self.transport.read_exact(&mut resp)?;
+        if resp[0] != 0x01 {
+            bail!("TOCTOU arm failed: unexpected response 0x{:02x}", resp[0]);
+        }
+        Ok(())
+    }
+
+    fn toctou_disarm(&mut self, index: u8) -> Result<()> {
+        self.transport
+            .write_all(&[CMD_TOCTOU, TOCTOU_DISARM, index & 0x03])?;
+        let mut resp = [0u8; 1];
+        self.transport.read_exact(&mut resp)?;
+        if resp[0] != 0x01 {
+            bail!(
+                "TOCTOU disarm failed: unexpected response 0x{:02x}",
+                resp[0]
+            );
+        }
+        Ok(())
+    }
+
+    fn toctou_reset(&mut self, index: u8) -> Result<()> {
+        self.transport
+            .write_all(&[CMD_TOCTOU, TOCTOU_RESET, index & 0x03])?;
+        let mut resp = [0u8; 1];
+        self.transport.read_exact(&mut resp)?;
+        if resp[0] != 0x01 {
+            bail!("TOCTOU reset failed: unexpected response 0x{:02x}", resp[0]);
+        }
+        Ok(())
+    }
+
+    fn toctou_reset_all(&mut self) -> Result<()> {
+        self.transport.write_all(&[CMD_TOCTOU, TOCTOU_RESET_ALL])?;
+        let mut resp = [0u8; 1];
+        self.transport.read_exact(&mut resp)?;
+        if resp[0] != 0x01 {
+            bail!(
+                "TOCTOU reset-all failed: unexpected response 0x{:02x}",
+                resp[0]
+            );
+        }
+        Ok(())
+    }
+
+    fn read_log_bytes(&mut self, buf: &mut [u8]) -> Result<usize> {
+        self.transport.read_available(buf)
+    }
+
     #[allow(dead_code)]
     fn write(&mut self, address: u32, data: &[u8]) -> Result<()> {
         if address % 8 != 0 {
@@ -816,6 +952,19 @@ enum Commands {
         state: String,
     },
 
+    /// Monitor SPI bus activity in real time via FT245 logging.
+    /// Displays commands, addresses, and data flow.  Also detects
+    /// addresses read more than once (potential TOCTOU targets).
+    Monitor,
+
+    /// Configure TOCTOU attack traps.  On second read of a trapped
+    /// address range, the FPGA serves replacement data from a
+    /// different SDRAM location.
+    Toctou {
+        #[command(subcommand)]
+        action: ToctouAction,
+    },
+
     /// List available serial ports
     Ports,
 
@@ -833,6 +982,41 @@ enum Commands {
 
     /// Query whether SPI emulation is currently running
     Status,
+}
+
+#[derive(Subcommand)]
+enum ToctouAction {
+    /// Configure a trap entry (does NOT arm it)
+    Set {
+        /// Trap index (0-3)
+        index: u8,
+        /// Start address of the range to trap (hex or decimal)
+        #[arg(value_parser = parse_address)]
+        start: u32,
+        /// Mask: 1-bits must match, 0-bits are don't-care (e.g. 0xFFF000 for 4KB)
+        #[arg(value_parser = parse_address)]
+        mask: u32,
+        /// Replacement byte address base in SDRAM
+        #[arg(value_parser = parse_address)]
+        replace: u32,
+    },
+    /// Arm a trap (starts monitoring for the address range)
+    Arm {
+        /// Trap index (0-3)
+        index: u8,
+    },
+    /// Disarm a trap
+    Disarm {
+        /// Trap index (0-3)
+        index: u8,
+    },
+    /// Reset a trap (clear triggered state so first read serves original data again)
+    Reset {
+        /// Trap index (0-3)
+        index: u8,
+    },
+    /// Reset all traps (disarm + clear triggered for all 4 entries)
+    ResetAll,
 }
 
 fn parse_address(s: &str) -> Result<u32, String> {
@@ -1550,6 +1734,270 @@ fn cmd_hold(cli: &Cli, state: &str) -> Result<()> {
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// SPI opcode names for log display
+// ---------------------------------------------------------------------------
+
+fn spi_opcode_name(opcode: u8) -> &'static str {
+    match opcode {
+        0x01 => "WRITE_STATUS",
+        0x02 => "PAGE_PROGRAM",
+        0x03 => "READ",
+        0x04 => "WRITE_DISABLE",
+        0x05 => "READ_STATUS",
+        0x06 => "WRITE_ENABLE",
+        0x0B => "FAST_READ",
+        0x0C => "FAST_READ_4B",
+        0x13 => "READ_4B",
+        0x20 => "SECTOR_ERASE_4K",
+        0x35 => "READ_STATUS2",
+        0x3B => "DUAL_READ",
+        0x52 => "BLOCK_ERASE_32K",
+        0x5A => "READ_SFDP",
+        0x60 => "CHIP_ERASE",
+        0x6B => "QUAD_READ",
+        0x9E | 0x9F => "READ_JEDEC_ID",
+        0xB7 => "4BYTE_ENABLE",
+        0xBB => "DUAL_IO_READ",
+        0xC7 => "CHIP_ERASE",
+        0xD8 => "BLOCK_ERASE_64K",
+        0xE9 => "4BYTE_DISABLE",
+        0xEB => "QUAD_IO_READ",
+        _ => "UNKNOWN",
+    }
+}
+
+fn is_read_opcode(opcode: u8) -> bool {
+    matches!(
+        opcode,
+        0x03 | 0x0B | 0x0C | 0x13 | 0x3B | 0x5A | 0x6B | 0xBB | 0xEB
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Monitor command -- real-time SPI bus logging with TOCTOU detection
+// ---------------------------------------------------------------------------
+
+fn cmd_monitor(cli: &Cli) -> Result<()> {
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    let mut device = open_device(cli)?;
+
+    // Set up Ctrl+C handler
+    let running = Arc::new(AtomicBool::new(true));
+    let r = running.clone();
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+    })
+    .context("Failed to set Ctrl+C handler")?;
+
+    // Enable logging
+    device.log_start()?;
+    eprintln!("Logging started. Press Ctrl+C to stop.\n");
+    eprintln!(
+        "{:<6} {:<18} {:<10} {}",
+        "TXN#", "COMMAND", "ADDRESS", "INFO"
+    );
+    eprintln!("{}", "-".repeat(60));
+
+    // TOCTOU detection state: address range -> access count
+    // Key: (start_addr, opcode), Value: count
+    let mut access_map: HashMap<(u32, u8), u32> = HashMap::new();
+    let mut double_reads: Vec<(u32, u8)> = Vec::new();
+
+    // Log packet parser state
+    let mut buf = [0u8; 4096];
+    let mut pending = Vec::new();
+    let mut txn_count: u32 = 0;
+    let mut current_opcode: u8 = 0;
+    let mut current_addr: u32 = 0;
+
+    while running.load(Ordering::SeqCst) {
+        let n = device.read_log_bytes(&mut buf)?;
+        if n == 0 {
+            thread::sleep(Duration::from_millis(1));
+            continue;
+        }
+
+        pending.extend_from_slice(&buf[..n]);
+
+        // Parse complete packets from pending buffer
+        let mut pos = 0;
+        while pos < pending.len() {
+            let remaining = pending.len() - pos;
+            match pending[pos] {
+                LOG_CMD if remaining >= 2 => {
+                    let opcode = pending[pos + 1];
+                    current_opcode = opcode;
+                    txn_count += 1;
+                    print!(
+                        "{:<6} 0x{:02X} {:<13}",
+                        txn_count,
+                        opcode,
+                        spi_opcode_name(opcode)
+                    );
+                    pos += 2;
+                }
+                LOG_ADDR if remaining >= 5 => {
+                    let addr = ((pending[pos + 1] as u32) << 24)
+                        | ((pending[pos + 2] as u32) << 16)
+                        | ((pending[pos + 3] as u32) << 8)
+                        | (pending[pos + 4] as u32);
+                    current_addr = addr;
+                    if addr > 0xFFFFFF {
+                        print!(" 0x{:08X}", addr);
+                    } else {
+                        print!(" 0x{:06X}", addr);
+                    }
+
+                    // TOCTOU detection: track read accesses
+                    if is_read_opcode(current_opcode) {
+                        let key = (addr, current_opcode);
+                        let count = access_map.entry(key).or_insert(0);
+                        *count += 1;
+                        if *count == 2 {
+                            double_reads.push(key);
+                            print!("  ** DOUBLE READ (TOCTOU candidate)");
+                        } else if *count > 2 {
+                            print!("  ** READ #{}", count);
+                        }
+                    }
+                    println!();
+                    pos += 5;
+                }
+                LOG_END if remaining >= 4 => {
+                    let count = ((pending[pos + 1] as u32) << 16)
+                        | ((pending[pos + 2] as u32) << 8)
+                        | (pending[pos + 3] as u32);
+                    // +1 because the counter starts at 0 for the first byte
+                    let byte_count = count + 1;
+                    if byte_count > 1 {
+                        eprintln!(
+                            "       end: {} bytes from 0x{:06X}",
+                            byte_count, current_addr
+                        );
+                    }
+                    pos += 4;
+                }
+                LOG_TRAP if remaining >= 6 => {
+                    let index = pending[pos + 1];
+                    let addr = ((pending[pos + 2] as u32) << 16)
+                        | ((pending[pos + 3] as u32) << 8)
+                        | (pending[pos + 4] as u32);
+                    eprintln!(
+                        "  !! TOCTOU TRAP #{} FIRED at 0x{:06X} -- serving replacement data",
+                        index, addr
+                    );
+                    pos += 6; // type(1) + index(1) + addr(3) + pad(1)
+                }
+                0xA1..=0xAF => {
+                    // Known packet type but incomplete -- wait for more data
+                    break;
+                }
+                _ => {
+                    // Unknown byte, skip it
+                    pos += 1;
+                }
+            }
+        }
+        // Remove consumed bytes
+        pending.drain(..pos);
+    }
+
+    // Stop logging
+    eprintln!("\nStopping...");
+
+    // Drain any remaining log data before sending stop command.
+    // The FT245 TX mux switches back to glue on log_stop, so we need
+    // to clear the FT2232H RX buffer first to avoid mixing log and ACK bytes.
+    thread::sleep(Duration::from_millis(10));
+    loop {
+        let n = device.read_log_bytes(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+    }
+
+    device.log_stop()?;
+
+    // Print TOCTOU summary
+    if !double_reads.is_empty() {
+        eprintln!("\n--- TOCTOU Detection Summary ---");
+        eprintln!("{} address(es) read more than once:\n", double_reads.len());
+        for (addr, opcode) in &double_reads {
+            let count = access_map[&(*addr, *opcode)];
+            eprintln!(
+                "  0x{:06X}  ({})  read {} times",
+                addr,
+                spi_opcode_name(*opcode),
+                count
+            );
+        }
+        eprintln!("\nThese are potential TOCTOU attack targets.");
+        eprintln!("Use 'toctou set' to configure traps for these addresses.");
+    } else {
+        eprintln!("\nNo double-reads detected.");
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TOCTOU command -- configure trap entries
+// ---------------------------------------------------------------------------
+
+fn cmd_toctou(cli: &Cli, action: &ToctouAction) -> Result<()> {
+    let mut device = open_device(cli)?;
+
+    match action {
+        ToctouAction::Set {
+            index,
+            start,
+            mask,
+            replace,
+        } => {
+            if *index > 3 {
+                bail!("Trap index must be 0-3");
+            }
+            device.toctou_set(*index, *start, *mask, *replace)?;
+            eprintln!(
+                "Trap {} configured: start=0x{:06X} mask=0x{:06X} replace=0x{:06X}",
+                index, start, mask, replace
+            );
+            eprintln!("Use 'toctou arm {}' to activate.", index);
+        }
+        ToctouAction::Arm { index } => {
+            if *index > 3 {
+                bail!("Trap index must be 0-3");
+            }
+            device.toctou_arm(*index)?;
+            eprintln!("Trap {} armed.", index);
+        }
+        ToctouAction::Disarm { index } => {
+            if *index > 3 {
+                bail!("Trap index must be 0-3");
+            }
+            device.toctou_disarm(*index)?;
+            eprintln!("Trap {} disarmed.", index);
+        }
+        ToctouAction::Reset { index } => {
+            if *index > 3 {
+                bail!("Trap index must be 0-3");
+            }
+            device.toctou_reset(*index)?;
+            eprintln!("Trap {} reset (triggered flag cleared).", index);
+        }
+        ToctouAction::ResetAll => {
+            device.toctou_reset_all()?;
+            eprintln!("All traps reset and disarmed.");
+        }
+    }
+
+    Ok(())
+}
+
 fn cmd_ports() -> Result<()> {
     let ports = serialport::available_ports()?;
     if ports.is_empty() {
@@ -1628,6 +2076,8 @@ fn main() -> Result<()> {
         } => cmd_dump(&cli, file, *address, *length),
         Commands::Configure { chip_db, chip } => cmd_configure(&cli, chip_db, chip),
         Commands::Hold { state } => cmd_hold(&cli, state),
+        Commands::Monitor => cmd_monitor(&cli),
+        Commands::Toctou { action } => cmd_toctou(&cli, action),
         Commands::Ports => cmd_ports(),
         Commands::FtList => cmd_ft_list(),
         Commands::Probe => cmd_probe(&cli),

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -39,8 +39,13 @@ const CMD_START: u8 = 0x34; // Enable SPI emulation (protocol v4+)
 const CMD_STOP: u8 = 0x35; // Disable SPI emulation (protocol v4+)
 const CMD_STATUS: u8 = 0x36; // Query emulation state (protocol v4+)
 const CMD_HOLDCTL: u8 = 0x37; // Target flash #HOLD control (protocol v5+)
-const CMD_LOGCTL: u8 = 0x38; // Enable/disable SPI bus logging (protocol v5+)
+const CMD_LOGCTL: u8 = 0x38; // Enable/disable SPI bus logging capture (protocol v5+)
 const CMD_TOCTOU: u8 = 0x39; // TOCTOU trap management (protocol v5+)
+const CMD_LOGPOLL: u8 = 0x3A; // Drain logger ring FIFO (protocol v5+)
+
+// CMD_LOGPOLL response terminator.  Everything the logger emits starts
+// with 0xA1-0xA4, so 0xA0 unambiguously signals end-of-poll.
+const LOG_POLL_TERMINATOR: u8 = 0xA0;
 
 // TOCTOU sub-commands
 const TOCTOU_SET: u8 = 0x01;
@@ -68,8 +73,6 @@ const FT2232H_PID: u16 = 0x6010;
 trait Transport {
     fn write_all(&mut self, data: &[u8]) -> Result<()>;
     fn read_exact(&mut self, buf: &mut [u8]) -> Result<()>;
-    /// Read whatever is currently available (non-blocking, returns 0 if nothing).
-    fn read_available(&mut self, buf: &mut [u8]) -> Result<usize>;
 }
 
 // ---------------------------------------------------------------------------
@@ -172,13 +175,6 @@ impl Transport for SerialTransport {
         self.port.read_exact(buf)?;
         Ok(())
     }
-
-    fn read_available(&mut self, buf: &mut [u8]) -> Result<usize> {
-        self.port.set_timeout(Duration::from_millis(10))?;
-        let n = self.port.read(buf).unwrap_or(0);
-        self.port.set_timeout(Duration::from_secs(2))?;
-        Ok(n)
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -269,17 +265,6 @@ impl Transport for Ft245Transport {
             pos += n;
         }
         Ok(())
-    }
-
-    fn read_available(&mut self, buf: &mut [u8]) -> Result<usize> {
-        use libftd2xx::FtdiCommon;
-        let n = self.ft.queue_status().unwrap_or(0);
-        if n == 0 {
-            return Ok(0);
-        }
-        let to_read = std::cmp::min(n, buf.len());
-        let got = self.ft.read(&mut buf[..to_read])?;
-        Ok(got)
     }
 }
 
@@ -376,10 +361,6 @@ impl Transport for Ft245Transport {
             pos += n;
         }
         Ok(())
-    }
-
-    fn read_available(&mut self, buf: &mut [u8]) -> Result<usize> {
-        self.dev.read_data(buf).map_err(|e| anyhow!(e))
     }
 }
 
@@ -719,22 +700,50 @@ impl FlashDevice {
 
     fn log_start(&mut self) -> Result<()> {
         self.transport.write_all(&[CMD_LOGCTL, 0x01])?;
-        let mut resp = [0u8; 1];
-        self.transport.read_exact(&mut resp)?;
-        if resp[0] != 0x01 {
-            bail!("LOGCTL start failed: unexpected response 0x{:02x}", resp[0]);
+        let ack = self.read_ack("log start")?;
+        if ack != 0x01 {
+            bail!("LOGCTL start failed: unexpected response 0x{:02x}", ack);
         }
         Ok(())
     }
 
     fn log_stop(&mut self) -> Result<()> {
         self.transport.write_all(&[CMD_LOGCTL, 0x00])?;
-        let mut resp = [0u8; 1];
-        self.transport.read_exact(&mut resp)?;
-        if resp[0] != 0x01 {
-            bail!("LOGCTL stop failed: unexpected response 0x{:02x}", resp[0]);
+        let ack = self.read_ack("log stop")?;
+        if ack != 0x01 {
+            bail!("LOGCTL stop failed: unexpected response 0x{:02x}", ack);
         }
         Ok(())
+    }
+
+    /// Drain the logger ring FIFO in a single poll.
+    ///
+    /// Protocol (CMD_LOGPOLL = 0x3A):
+    ///   Host:  0x3A
+    ///   FPGA:  [log byte]* 0xA0
+    /// The response ends when 0xA0 is seen.  The FPGA caps each poll at
+    /// 255 data bytes; any remaining log data is picked up on the next
+    /// poll.
+    fn log_poll(&mut self) -> Result<Vec<u8>> {
+        self.transport.write_all(&[CMD_LOGPOLL])?;
+        let mut out = Vec::with_capacity(256);
+        loop {
+            let mut byte = [0u8; 1];
+            self.transport.read_exact(&mut byte)?;
+            if byte[0] == LOG_POLL_TERMINATOR {
+                return Ok(out);
+            }
+            out.push(byte[0]);
+            // Safety net: cap log poll responses so a misbehaving
+            // device cannot lock the tool in this loop.  Should never
+            // trip given the FPGA's LOG_POLL_MAX = 255 + terminator.
+            if out.len() > 1024 {
+                bail!(
+                    "log poll overran 1024 bytes without terminator; last byte 0x{:02x}",
+                    byte[0]
+                );
+            }
+        }
     }
 
     fn toctou_set(&mut self, index: u8, start: u32, mask: u32, replace: u32) -> Result<()> {
@@ -808,10 +817,6 @@ impl FlashDevice {
             );
         }
         Ok(())
-    }
-
-    fn read_log_bytes(&mut self, buf: &mut [u8]) -> Result<usize> {
-        self.transport.read_available(buf)
     }
 
     #[allow(dead_code)]
@@ -1808,20 +1813,22 @@ fn cmd_monitor(cli: &Cli) -> Result<()> {
     let mut double_reads: Vec<(u32, u8)> = Vec::new();
 
     // Log packet parser state
-    let mut buf = [0u8; 4096];
     let mut pending = Vec::new();
     let mut txn_count: u32 = 0;
     let mut current_opcode: u8 = 0;
     let mut current_addr: u32 = 0;
 
+    // Poll loop: ask the FPGA for log data every ~5ms.  Every poll
+    // response is self-delimited (ends with LOG_POLL_TERMINATOR) so
+    // there is no ambiguity between log bytes and protocol bytes.
     while running.load(Ordering::SeqCst) {
-        let n = device.read_log_bytes(&mut buf)?;
-        if n == 0 {
-            thread::sleep(Duration::from_millis(1));
+        let data = device.log_poll()?;
+        if data.is_empty() {
+            thread::sleep(Duration::from_millis(5));
             continue;
         }
 
-        pending.extend_from_slice(&buf[..n]);
+        pending.extend_from_slice(&data);
 
         // Parse complete packets from pending buffer
         let mut pos = 0;
@@ -1906,21 +1913,15 @@ fn cmd_monitor(cli: &Cli) -> Result<()> {
         pending.drain(..pos);
     }
 
-    // Stop logging
+    // Stop logging and drain any residual log bytes.  Since logging
+    // and protocol responses travel separately now (no mux), the stop
+    // ACK is guaranteed to be the *only* reply to CMD_LOGCTL.
     eprintln!("\nStopping...");
-
-    // Drain any remaining log data before sending stop command.
-    // The FT245 TX mux switches back to glue on log_stop, so we need
-    // to clear the FT2232H RX buffer first to avoid mixing log and ACK bytes.
-    thread::sleep(Duration::from_millis(10));
-    loop {
-        let n = device.read_log_bytes(&mut buf)?;
-        if n == 0 {
-            break;
-        }
-    }
-
     device.log_stop()?;
+    let remaining = device.log_poll()?;
+    if !remaining.is_empty() {
+        eprintln!("(drained {} residual log bytes)", remaining.len());
+    }
 
     // Print TOCTOU summary
     if !double_reads.is_empty() {


### PR DESCRIPTION
## Summary

- **SPI bus logging**: Stream SPI command/address/length events via a 512 B ring FIFO on the FPGA, drained over UART by host polling (`CMD_LOGPOLL` 0x3A). Works on both UART and FT245 transports.
- **TOCTOU attack traps**: 4 configurable trap entries redirect SDRAM reads on the second access to a trapped address range, serving replacement data from a different SDRAM offset via a combinational bitwise address mux. Configured via `CMD_TOCTOU` (0x39) and the `toctou` CLI command.
- **Double-read detection**: New `monitor` command decodes the live log stream, prints commands/addresses/trap events, and tracks read address/opcode pairs — flagging addresses accessed more than once as TOCTOU candidates.

## New serial commands (protocol v5)

| Opcode | Name          | Purpose                                   |
|--------|---------------|-------------------------------------------|
| 0x38   | `CMD_LOGCTL`  | Enable/disable bus-event logging          |
| 0x39   | `CMD_TOCTOU`  | Configure/arm/disarm/reset trap entries   |
| 0x3A   | `CMD_LOGPOLL` | Drain up to 255 log bytes (0xA0 terminator) |

Protocol `VERSION` bumped from 4 to 5 (additive: HOLDCTL from master, plus logging/TOCTOU).

## Architecture

### Logging data path (poll-based)
```
spi_trx (SPI domain)       logger.v                       glue.v                 UART/FT245
  cmd/addr/count    -->    3-FF sync + 512B ring    -->   CMD_LOGPOLL drain  --> host
                           packet formatting              (up to 255 B/poll,
                           (0xA1-0xA4)                     0xA0 terminator)
```

No TX muxing — logging and command replies share the same TX path because the host polls on demand. Avoids the race where `CMD_LOGCTL 0x01` could cause the TX mux to swap carriers in the same cycle the ACK was being sent.

### TOCTOU redirect
```
spi_trx.ram_addr  -->  bitwise mux  -->  sdram.spi_addr
                        ^
                        glue.v trap check (on address-phase complete)
                        redirect = (replace & mask) | (original & ~mask)
```

### Log packet format
| Type   | Payload                     | Size |
|--------|-----------------------------|------|
| `0xA1` | opcode                      | 2 B  |
| `0xA2` | addr[31:0]                  | 5 B  |
| `0xA3` | byte_count[23:0]            | 4 B  |
| `0xA4` | trap_index + addr[23:0]     | 6 B  |
| `0xA0` | (poll terminator, no payload) | 1 B  |

## Usage

```bash
# Monitor live SPI bus activity, detect double-reads
spi-flash-tool -p /dev/ttyUSB1 monitor

# Set up a TOCTOU attack on a 4 KB range
spi-flash-tool -p /dev/ttyUSB1 load patched_fw.bin -a 0x101000
spi-flash-tool -p /dev/ttyUSB1 toctou set 0 0x001000 0xFFF000 0x101000
spi-flash-tool -p /dev/ttyUSB1 toctou arm 0
# First read of 0x001000-0x001FFF  -> original data
# Second read                       -> replacement from 0x101000-0x101FFF
```

## Validation

Verified against real hardware using `flashprog`'s layout/region feature with the FT4222H as the SPI master:

```
flashprog -p ft4222_spi -c "W25Q64BV/W25Q64CV/W25Q64FV" \
    -r readN.bin -l layout.txt -i region1
```

- Read 1 (innocent): `INNOCENT-0001-INNOCENT-0001-...` from 0x001000
- Read 2 (trapped):  `INNOCENTS0101-MALICIOUS0101-...` (bytes 8+ from 0x101000)
- Monitor shows: `!! TOCTOU TRAP #0 FIRED at 0x001000 -- serving replacement data`

## Notes / caveats

- First 8 bytes of a redirected read come from the original address: the SDRAM prefetch pipeline latches the read address before `log_addr_valid` pulses and the trap logic fires. If byte-exact replacement is required, copy those 8 bytes into the replacement data manually (visible in the validation output above).
- Trap activation requires TWO matching SPI transactions (separate CS cycles). `redirect_active` is cleared on CS deassert, so two address events within a single CS cycle will not trigger.
- `CMD_LOGPOLL` state machine runs ungated by SPI CS state so polls do not stall during long SPI reads.
- `trap_triggered[i]` persists across tool invocations. Use `toctou reset <i>` or `toctou reset-all` to rearm; FPGA reprogram also clears.