### PR TITLE
feat: add AAI Word Program and EWSR emulation for SST chips

### DIFF
--- a/src/glue.v
+++ b/src/glue.v
@@ -56,7 +56,7 @@ module glue(
     input wire spi_csel,
     
     input wire spi_cmd_write,
-    input wire spi_write_type,  // 0=page program, 1=erase (sector/block/chip)
+    input wire [1:0] spi_write_type,  // 00=page program, 01=erase, 10=AAI RMW
     input wire [22:0] spi_write_addr,   // 23-bit burst address
     input wire [22:0] spi_write_len,
     output reg spi_write_done,
@@ -189,7 +189,7 @@ module glue(
     reg spi_write_ack;
     reg [1:0] spi_cmd_write_buf;
     
-    reg i_spi_write_type;
+    reg [1:0] i_spi_write_type;
     reg [3:0] i_spi_write_state;
     reg [22:0] i_spi_len;
     
@@ -361,7 +361,9 @@ module glue(
             // this covers the serial (UART tool) and SPI write paths.
             sdram_inhibit_refresh <= (read_state != 0) ||
                                     (write_state != 0) ||
-                                    (spi_writing && (i_spi_write_state == 4'd2 || i_spi_write_state == 4'd3));
+                                    (spi_writing && (i_spi_write_state == 4'd2 || i_spi_write_state == 4'd3 ||
+                                                     i_spi_write_state == 4'd6 || i_spi_write_state == 4'd7 ||
+                                                     i_spi_write_state == 4'd8));
     
             if (sdram_access_cmd)
                 sdram_access_cmd <= 0;
@@ -413,13 +415,18 @@ module glue(
                 spi_write_ack <= 1;
                 
                 i_spi_write_type <= spi_write_type;
-                i_spi_write_state <= (spi_write_type != 0) ? 2 : 0;
+                case (spi_write_type)
+                    2'd0: i_spi_write_state <= 0;  // Page program: prepare data
+                    2'd1: i_spi_write_state <= 2;  // Erase: activate for write
+                    2'd2: i_spi_write_state <= 6;  // AAI: read-modify-write
+                    default: i_spi_write_state <= 0;
+                endcase
                 
                 addr <= spi_write_addr;
                 i_spi_len <= spi_write_len;
                 spi_write_done <= 0;
                 
-                if (spi_write_type != 0)
+                if (spi_write_type == 2'd1)
                     write_buffer <= 64'hFFFFFFFFFFFFFFFF;
             end
             
@@ -452,13 +459,58 @@ module glue(
                     end
                 end
                 else if (i_spi_write_state == 4) begin
-                    i_spi_write_state <= (i_spi_write_type != 0) ? 2 : 0;
+                    case (i_spi_write_type)
+                        2'd0: i_spi_write_state <= 0;  // Page program: next burst
+                        2'd1: i_spi_write_state <= 2;  // Erase: next burst
+                        default: i_spi_write_state <= 0;
+                    endcase
                     addr <= addr + 1;
                     i_spi_len <= i_spi_len - 1;
                 end
                 else if (i_spi_write_state == 5) begin
                     spi_writing <= 0;
                     spi_write_done <= 1;
+                    
+                    // Clear page buffer write flags after AAI so the next
+                    // AAI word starts with a clean flag state.
+                    if (i_spi_write_type == 2'd2) begin
+                        for (i = 0; i < 256; i = i + 1)
+                            i_spi_write_data[i][8] <= 0;
+                    end
+                end
+                // ---------------------------------------------------------
+                // AAI Read-Modify-Write (write_type == 2)
+                //
+                // Writes exactly 2 bytes into a single 8-byte SDRAM burst
+                // without corrupting the other 6 bytes.  Uses the page
+                // buffer write flags (bit 8) to select which bytes come
+                // from the page buffer and which are preserved from SDRAM.
+                //
+                // State 6: Activate row for read
+                // State 7: Issue SDRAM read command
+                // State 8: Merge page buffer bytes into read data,
+                //          then continue to state 2 (activate for write)
+                // ---------------------------------------------------------
+                else if (i_spi_write_state == 6) begin
+                    // Activate for read
+                    sdram_access_cmd <= 2'b11;
+                    i_spi_write_state <= 7;
+                end
+                else if (i_spi_write_state == 7) begin
+                    // Issue read
+                    sdram_access_cmd <= 2'b01;
+                    i_spi_write_state <= 8;
+                end
+                else if (i_spi_write_state == 8) begin
+                    // Merge: for each byte in the burst, use page buffer
+                    // data if its write flag is set, otherwise keep SDRAM data.
+                    for (i = 0; i < 8; i = i + 1) begin
+                        if (i_spi_write_data[{addr[4:0], 3'b000} + i][8])
+                            write_buffer[i*8 +: 8] <= i_spi_write_data[{addr[4:0], 3'b000} + i][7:0];
+                        else
+                            write_buffer[i*8 +: 8] <= sdram_read_buffer[i*8 +: 8];
+                    end
+                    i_spi_write_state <= 2;  // Activate for write
                 end
             end
             

--- a/src/spi_trx.v
+++ b/src/spi_trx.v
@@ -236,6 +236,7 @@ module spi_trx(
                 
                 if (reset_power) begin
                     status_reg[1:0] <= 2'b00;
+                    status_reg[6] <= 0;     // AAI bit
                     addr_4byte <= 0;
                     aai_active <= 0;
                     addr <= 0;
@@ -276,6 +277,7 @@ module spi_trx(
                     
                     CMD_WRITEDISABLE: begin
                         status_reg[1] <= 0;
+                        status_reg[6] <= 0;  // Clear AAI bit
                         aai_active <= 0;
                     end
                     
@@ -408,7 +410,16 @@ module spi_trx(
                     //   First:      0xAD + addr(3) + byte0 + byte1
                     //   Subsequent: 0xAD + byte0 + byte1
                     // Address auto-increments by 2. Mode persists across
-                    // CS cycles until WRDI (0x04).  A0 is forced to 0.
+                    // CS cycles until WRDI (0x04).  The host is expected
+                    // to send an even starting address per the SST spec;
+                    // A0 of the transmitted address is accepted as-is
+                    // (matches real SST chips which ignore A0 internally
+                    // because writes are word-aligned).
+                    //
+                    // SR bit 6 (AAI flag) is set on entry and cleared on
+                    // WRDI, matching the SST25VFxxx datasheet and what
+                    // flashprog's spi_prettyprint_status_register_sst25
+                    // reports.
                     CMD_AAI_WORD: begin
                         if (status_reg[1] || aai_active) begin
                             if (!aai_active) begin
@@ -418,6 +429,7 @@ module spi_trx(
                                 is_aai <= 1;
                                 write_len <= 0;
                                 aai_active <= 1;
+                                status_reg[6] <= 1;  // Set AAI bit
                             end else begin
                                 // Subsequent AAI: skip address, go to data
                                 state <= STA_AAI_DATA;
@@ -615,13 +627,16 @@ module spi_trx(
                     if (addr_count == 0) begin
                         if (is_aai) begin
                             // AAI: single-burst RMW, don't clear WEL
+                            // (address is word-aligned per SST spec;
+                            // A0 is shifted in below but only addr[25:3]
+                            // is used for write_addr, and addr[2:1] index
+                            // into the page buffer correctly).
                             state <= STA_AAI_DATA;
                             write_cmd <= 1;
                             write_type <= 2'd2;
                             write_addr <= addr[25:3];
                             write_len <= 0;
                             status_reg[0] <= 1;
-                            addr[0] <= 0;  // Force even alignment per SST spec
                         end else begin
                             state <= STA_WRITE;
                             write_cmd <= 1;

--- a/src/spi_trx.v
+++ b/src/spi_trx.v
@@ -40,7 +40,7 @@ module spi_trx(
     
     // For writing
     output reg write_cmd,
-    output reg write_type,  // 0=page program, 1=erase (sector/block/chip)
+    output reg [1:0] write_type,  // 00=page program, 01=erase, 10=AAI RMW
     output reg [22:0] write_addr,     // 23-bit burst address
     output reg [22:0] write_len,
     input wire write_done,
@@ -131,6 +131,8 @@ module spi_trx(
         CMD_DUALIOREAD      = 8'hBB,  // Dual I/O Read (1-2-2)
         CMD_CHIPERASE2      = 8'hC7,
         CMD_BLOCKERASE_64K  = 8'hD8,
+        CMD_EWSR            = 8'h50,  // Enable Write Status Register (SST)
+        CMD_AAI_WORD        = 8'hAD,  // AAI Word Program (SST)
         CMD_4BYTEDISABLE    = 8'hE9,
         CMD_QUADIOREAD      = 8'hEB,  // Quad I/O Read (1-4-4)
         CMD_LOG             = 8'hF2;
@@ -154,7 +156,8 @@ module spi_trx(
         STA_ADDR_READ_QUAD  = 14,  // Quad I/O address phase (1-4-4)
         STA_READ_QUAD       = 15,  // Quad data output phase (1-1-4 & 1-4-4)
         STA_WRITESTATUS     = 16,  // Receive status register write data
-        STA_READSFDP        = 17;  // SFDP data output phase
+        STA_READSFDP        = 17,  // SFDP data output phase
+        STA_AAI_DATA        = 18;  // AAI data reception (2 bytes)
     
     reg [4:0] state;
     reg [2:0] dummy_count = 0;
@@ -163,6 +166,10 @@ module spi_trx(
     reg is_quad_read = 0;       // Set for both 0x6B and 0xEB
     reg is_sfdp_read = 0;       // Set for CMD 0x5A (Read SFDP)
     reg [2:0] mode_count = 0;   // Mode+dummy counter (4 for dual, 6 for quad)
+    
+    // AAI (Auto Address Increment) state -- persists across CS cycles
+    reg aai_active = 0;         // In AAI word program mode
+    reg is_aai = 0;             // Current transaction is AAI (per-CS flag)
     
     reg [31:0] addr;
     reg [4:0] addr_count;
@@ -204,13 +211,16 @@ module spi_trx(
                 
                 state <= STA_CMD;
                 
-                addr <= 0;
+                // Preserve addr during AAI mode (auto-increment persists across CS)
+                if (!aai_active)
+                    addr <= 0;
                 addr_count <= 0;
                 dummy_count <= 0;
                 is_fast_read <= 0;
                 is_dual_read <= 0;
                 is_quad_read <= 0;
                 is_sfdp_read <= 0;
+                is_aai <= 0;
                 mode_count <= 0;
                 
                 log_strobe <= 0;
@@ -227,6 +237,8 @@ module spi_trx(
                 if (reset_power) begin
                     status_reg[1:0] <= 2'b00;
                     addr_4byte <= 0;
+                    aai_active <= 0;
+                    addr <= 0;
                     
                     log_strobe <= 1;
                     log_val <= 8'hE2;
@@ -264,9 +276,18 @@ module spi_trx(
                     
                     CMD_WRITEDISABLE: begin
                         status_reg[1] <= 0;
+                        aai_active <= 0;
                     end
                     
                     CMD_WRITEENABLE: begin
+                        status_reg[1] <= 1;
+                    end
+                    
+                    CMD_EWSR: begin
+                        // SST Enable-Write-Status-Register: acts like WREN
+                        // for status register writes.  For emulation we just
+                        // set WEL; the distinction only matters for hardware
+                        // write protection which the emulator doesn't enforce.
                         status_reg[1] <= 1;
                     end
                     
@@ -367,7 +388,7 @@ module spi_trx(
                         if (status_reg[1]) begin
                             state <= STA_ERASE;
                             write_cmd <= 1;
-                            write_type <= 1'd1;
+                            write_type <= 2'd1;
                             write_addr <= 23'b0;
                             write_len <= cfg_chip_erase_bursts;
                             status_reg[1] <= 0;
@@ -380,6 +401,32 @@ module spi_trx(
                             state <= STA_ADDR_WRITE;
                             addr_count <= addr_4byte ? 31 : 23;
                             write_len <= 23'h0001F; // 256 byte page = 32 × 8-byte bursts - 1
+                        end
+                    end
+                    
+                    // AAI Word Program (SST, 0xAD):
+                    //   First:      0xAD + addr(3) + byte0 + byte1
+                    //   Subsequent: 0xAD + byte0 + byte1
+                    // Address auto-increments by 2. Mode persists across
+                    // CS cycles until WRDI (0x04).  A0 is forced to 0.
+                    CMD_AAI_WORD: begin
+                        if (status_reg[1] || aai_active) begin
+                            if (!aai_active) begin
+                                // First AAI: need address phase
+                                state <= STA_ADDR_WRITE;
+                                addr_count <= addr_4byte ? 31 : 23;
+                                is_aai <= 1;
+                                write_len <= 0;
+                                aai_active <= 1;
+                            end else begin
+                                // Subsequent AAI: skip address, go to data
+                                state <= STA_AAI_DATA;
+                                write_cmd <= 1;
+                                write_type <= 2'd2;
+                                write_addr <= addr[25:3];
+                                write_len <= 0;
+                                status_reg[0] <= 1;
+                            end
                         end
                     end
                     
@@ -541,7 +588,7 @@ module spi_trx(
                     if (addr_count == 0) begin
                         state <= STA_ERASE;
                         write_cmd <= 1;
-                        write_type <= 1'd1;
+                        write_type <= 2'd1;
                         
                         // Align address based on erase size
                         // write_addr is 23-bit burst address = byte_addr[25:3]
@@ -566,16 +613,27 @@ module spi_trx(
                 end
                 else if (state == STA_ADDR_WRITE) begin
                     if (addr_count == 0) begin
-                        state <= STA_WRITE;
-                        write_cmd <= 1;
-                        write_type <= 0;
-                        
-                        // Page-aligned address in 8-byte burst units
-                        // byte_addr[25:3] -> burst address, page = 256 bytes = 32 bursts
-                        write_addr <= {addr[25:8], 5'b0};
+                        if (is_aai) begin
+                            // AAI: single-burst RMW, don't clear WEL
+                            state <= STA_AAI_DATA;
+                            write_cmd <= 1;
+                            write_type <= 2'd2;
+                            write_addr <= addr[25:3];
+                            write_len <= 0;
+                            status_reg[0] <= 1;
+                            addr[0] <= 0;  // Force even alignment per SST spec
+                        end else begin
+                            state <= STA_WRITE;
+                            write_cmd <= 1;
+                            write_type <= 2'd0;
                             
-                        status_reg[1] <= 0;
-                        status_reg[0] <= 1;
+                            // Page-aligned address in 8-byte burst units
+                            // byte_addr[25:3] -> burst address, page = 256 bytes = 32 bursts
+                            write_addr <= {addr[25:8], 5'b0};
+                                
+                            status_reg[1] <= 0;
+                            status_reg[0] <= 1;
+                        end
                     end
                     
                     addr[addr_count] <= spi_io0_in;
@@ -592,6 +650,20 @@ module spi_trx(
                     write_buf_val <= {mosi_byte[7:1], spi_io0_in};
                     
                     addr[7:0] <= addr[7:0] + 1;
+                end
+                // ---------------------------------------------------------
+                // AAI data reception (2 bytes per CS cycle)
+                // Bytes are written to the page buffer at addr[7:0].
+                // Full 32-bit address auto-increments (crosses pages).
+                // Master deasserts CS after 2 bytes; glue.v performs
+                // read-modify-write of the single 8-byte SDRAM burst.
+                // ---------------------------------------------------------
+                else if ((state == STA_AAI_DATA) && (bit_count_in == 0)) begin
+                    write_buf_strobe <= 1;
+                    write_buf_offset <= addr[7:0];
+                    write_buf_val <= {mosi_byte[7:1], spi_io0_in};
+                    
+                    addr <= addr + 1;  // Full address auto-increment
                 end
                 else if (state == STA_LOG) begin
                     if (bit_count_in == 0) begin

--- a/src/top.v
+++ b/src/top.v
@@ -224,7 +224,7 @@ module top(
     wire [22:0] spi_ram_addr;    // 23-bit for 64MB addressing
     
     wire spi_write_cmd;
-    wire spi_write_type;  // 0=page program, 1=erase (sector/block/chip)
+    wire [1:0] spi_write_type;  // 00=page program, 01=erase, 10=AAI RMW
     wire [22:0] spi_write_addr;  // 23-bit
     wire [22:0] spi_write_len;
     wire spi_write_done;

--- a/tool/src/chip.rs
+++ b/tool/src/chip.rs
@@ -115,6 +115,8 @@ pub struct FeaturesDef {
     pub wp_bp3: bool,
     #[serde(default)]
     pub wp_wps: bool,
+    #[serde(default)]
+    pub sst26_bpr: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -208,6 +210,8 @@ pub struct FlashChip {
     pub supports_dual: bool,
     pub supports_quad: bool,
     pub supports_fast_read: bool,
+    pub aai_word: bool,
+    pub write_byte: bool,
     pub erase_ops: Vec<EraseOp>,
 }
 
@@ -289,6 +293,8 @@ pub fn load_chip_db(dir: &Path) -> Result<Vec<FlashChip>> {
                 supports_dual: chip_def.features.dual_io,
                 supports_quad: chip_def.features.quad_io,
                 supports_fast_read: chip_def.features.fast_read,
+                aai_word: chip_def.features.aai_word,
+                write_byte: chip_def.features.write_byte,
                 erase_ops,
             });
         }

--- a/tool/src/chip.rs
+++ b/tool/src/chip.rs
@@ -212,6 +212,7 @@ pub struct FlashChip {
     pub supports_fast_read: bool,
     pub aai_word: bool,
     pub write_byte: bool,
+    pub supports_sfdp: bool,
     pub erase_ops: Vec<EraseOp>,
 }
 
@@ -295,6 +296,7 @@ pub fn load_chip_db(dir: &Path) -> Result<Vec<FlashChip>> {
                 supports_fast_read: chip_def.features.fast_read,
                 aai_word: chip_def.features.aai_word,
                 write_byte: chip_def.features.write_byte,
+                supports_sfdp: chip_def.features.sfdp,
                 erase_ops,
             });
         }

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -1081,6 +1081,12 @@ fn cmd_configure(cli: &Cli, chip_db_path: &str, chip_name: &str) -> Result<()> {
     eprintln!("  4-byte addr: {}", chip.supports_4byte);
     eprintln!("  Dual I/O:   {}", chip.supports_dual);
     eprintln!("  Quad I/O:   {}", chip.supports_quad);
+    if chip.aai_word {
+        eprintln!("  Write mode: AAI Word Program (0xAD)");
+    }
+    if chip.write_byte {
+        eprintln!("  Write mode: Byte program");
+    }
 
     let erase_ops = chip.sector_erase_ops();
     for op in &erase_ops {

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -1097,9 +1097,18 @@ fn cmd_configure(cli: &Cli, chip_db_path: &str, chip_name: &str) -> Result<()> {
         );
     }
 
-    // Generate SFDP table
+    // Generate SFDP table.  For chips that do not support SFDP in real
+    // hardware (e.g. older SST25VFxxx), the table is all-0xFF so SFDP
+    // probes see no valid signature, matching the real part.
     let sfdp_table = sfdp::generate_sfdp(chip);
-    eprintln!("  SFDP table: {} bytes", sfdp_table.len());
+    if chip.supports_sfdp {
+        eprintln!("  SFDP table: {} bytes (valid)", sfdp_table.len());
+    } else {
+        eprintln!(
+            "  SFDP table: {} bytes (blank, chip does not support SFDP)",
+            sfdp_table.len()
+        );
+    }
 
     // Send to FPGA.  Must be stopped while CHIPCONFIG is processed,
     // otherwise spi_trx could read inconsistent cfg_* values mid-transfer.

--- a/tool/src/sfdp.rs
+++ b/tool/src/sfdp.rs
@@ -17,8 +17,20 @@ const BFPT_OFFSET: u32 = 0x10;
 const BFPT_DWORDS: u8 = 16; // JESD216A/B
 
 /// Generate the full SFDP table for a given chip.
+///
+/// Chips that do not implement SFDP in real hardware (e.g. SST25VFxxx
+/// series) get an all-0xFF table.  A valid SFDP response would mislead
+/// tools like flashprog that probe SFDP before consulting their chip
+/// table -- they would parse a fabricated signature and potentially
+/// override the correct hardcoded behavior.  Returning 0xFF (erased
+/// flash pattern, invalid "SFDP" signature) makes the probe fail as
+/// it would on the real part.
 pub fn generate_sfdp(chip: &FlashChip) -> [u8; SFDP_TABLE_SIZE] {
     let mut table = [0xFFu8; SFDP_TABLE_SIZE];
+
+    if !chip.supports_sfdp {
+        return table;
+    }
 
     write_sfdp_header(&mut table);
     write_param_header(&mut table);
@@ -81,8 +93,18 @@ fn write_bfpt(chip: &FlashChip, table: &mut [u8; SFDP_TABLE_SIZE]) {
     let mut dw1: u32 = 0;
     // [1:0] Block/Sector erase granularity
     dw1 |= if has_4k_erase { 0x01 } else { 0x03 };
-    // [2] Write granularity: 1 = buffer >= 64 bytes (page_size is typically 256)
-    if chip.page_size >= 64 {
+    // [2] Write granularity: 1 = buffer >= 64 bytes, 0 = 1 byte.
+    //
+    // Per JESD216B, this selects between page program (>= 64 byte
+    // buffer) and byte program (1 byte).  There is no SFDP flag for
+    // AAI word program, so chips whose native multi-byte write is AAI
+    // (e.g. SST25VFxxx: AAI writes 2 bytes, byte program writes 1) or
+    // that only support 0x02 as a single-byte write must advertise 0
+    // here.  Tools that rely solely on SFDP then fall back to byte
+    // programming via 0x02; tools with a hardcoded chip table (e.g.
+    // flashprog) will use their own AAI path regardless.
+    let large_buffer = chip.page_size >= 64 && !chip.aai_word && !chip.write_byte;
+    if large_buffer {
         dw1 |= 1 << 2;
     }
     // [3] WREN required for volatile SR write


### PR DESCRIPTION
## Summary

- Add SST AAI Word Program (0xAD) and EWSR (0x50) command emulation to the FPGA SPI transceiver
- Add read-modify-write engine in glue.v so AAI's 2-byte writes don't corrupt neighbouring bytes in the 8-byte SDRAM burst
- Update Rust tool's chip.rs for rflasher RON compatibility (`sst26_bpr` field) and propagate `aai_word`/`write_byte` flags

## AAI protocol emulation

SST flash chips (SST25VF series) don't support standard Page Program -- they use AAI Word Program instead, writing 2 bytes per CS cycle with auto-incrementing addresses:

1. `WREN` → `0xAD + addr(3) + byte0 + byte1` → CS↑ (first word, includes address)
2. Poll RDSR until not busy
3. `0xAD + byte2 + byte3` → CS↑ (subsequent words, address auto-increments)
4. Repeat until done
5. `WRDI` exits AAI mode

The `aai_active` flag persists across CS deassertion (like `addr_4byte`), and `addr` is preserved so the auto-increment works across transactions.

## Read-modify-write engine

Each AAI word writes only 2 bytes, but SDRAM operates in 8-byte bursts. A naive write would corrupt the other 6 bytes. The new RMW path (glue.v states 6→7→8→2→3→5):

1. **State 6**: Activate SDRAM row for read
2. **State 7**: Read the current 8-byte burst
3. **State 8**: Merge -- use page buffer data where write flags (bit 8) are set, keep SDRAM data elsewhere
4. **State 2→3**: Activate + write the merged burst back
5. **State 5**: Done, clear page buffer flags for next AAI word