### PR TITLE
# Add SPI emulation START/STOP/STATUS control (protocol v4)

### DIFF
--- a/src/glue.v
+++ b/src/glue.v
@@ -7,6 +7,15 @@
 // Accepts bytes from EITHER UART or FT245.  When idle (no active command),
 // whichever port delivers a byte first becomes the "active port" for that
 // entire command.  Responses are routed back to the same port.
+//
+// SPI emulation is gated by `spi_running`, controlled by the START (0x34)
+// and STOP (0x35) serial commands.  At power-on/reset the FPGA starts in
+// STOPPED state, which means spi_trx is held in reset via top.v (so SPI
+// pin state never blocks serial traffic) and all serial commands are
+// accepted.  When RUNNING, only the always-safe commands (VERSION, START,
+// STOP, STATUS) are processed so the host can reach NORbert regardless of
+// what the emulated master is doing; destructive commands (RAMREAD,
+// RAMWRITE, CHIPCONFIG) are rejected until the host sends STOP.
 
 `default_nettype none
 
@@ -68,6 +77,12 @@ module glue(
     input wire [6:0] sfdp_raddr,
     output wire [7:0] sfdp_rdata,
     
+    // SPI emulation enable (1 = running, 0 = stopped).
+    // Exported to top.v which uses it to gate spi_reset feeding both
+    // spi_trx and back into this module -- so while stopped the SPI pins
+    // are ignored and serial commands always have a clear path.
+    output reg spi_running,
+
     output reg [7:0] led
 );
 
@@ -77,9 +92,12 @@ module glue(
         CMD_VERSION      = 8'h30,
         CMD_RAMREAD      = 8'h31,
         CMD_RAMWRITE     = 8'h32,
-        CMD_CHIPCONFIG   = 8'h33;
+        CMD_CHIPCONFIG   = 8'h33,
+        CMD_START        = 8'h34,  // Enable SPI emulation
+        CMD_STOP         = 8'h35,  // Disable SPI emulation
+        CMD_STATUS       = 8'h36;  // Query running state
 
-    localparam VERSION = 8'h03;  // Version 3: 16-bit burst length
+    localparam VERSION = 8'h04;  // Version 4: add START/STOP/STATUS
 
     reg [7:0] cmd;
     reg [7:0] in_count;
@@ -127,7 +145,23 @@ module glue(
     // Serial handler gate: only consume FIFO bytes when SPI is inactive.
     // This prevents popping bytes that the serial handler would ignore,
     // which is the root cause of the ACK corruption (0x00 instead of 0x01).
+    // When spi_running=0, top.v forces this module's spi_reset input high
+    // so this gate collapses to just !spi_writing (which is always 0 when
+    // stopped, since spi_trx is in reset and cannot initiate writes).
     wire serial_gate = (spi_reset || spi_csel_buf[1]) && !spi_writing;
+
+    // Always-safe command bypass: when the parser is idle and the next
+    // byte waiting in the FT245 RX FIFO is a VERSION/START/STOP/STATUS
+    // opcode, pop it even if serial_gate is closed (SPI master mid-
+    // transaction).  These commands do not touch SDRAM or spi_trx state
+    // and are handled in a separate dispatcher below, so letting them
+    // through while SPI is live is safe and guarantees the host can
+    // always reach the FPGA.
+    wire peek_is_always_safe = cmd_idle &&
+                               ((ft_rx_data == CMD_VERSION) ||
+                                (ft_rx_data == CMD_START)   ||
+                                (ft_rx_data == CMD_STOP)    ||
+                                (ft_rx_data == CMD_STATUS));
 
     // Hold flag: prevent double-consume from FIFO.  Set for 1 cycle
     // after popping a byte, cleared the next cycle.  Gives a 2-cycle
@@ -239,6 +273,11 @@ module glue(
             sfdp_wr_pos <= 0;
             cfg_sfdp_remaining <= 0;
 
+            // Start with SPI emulation STOPPED so the host can always
+            // reach the FPGA regardless of target-board state; the host
+            // tool sends START explicitly after loading firmware.
+            spi_running <= 0;
+
             for (i = 0; i < 256; i = i + 1)
                 i_spi_write_data[i][8] <= 0;
             
@@ -268,10 +307,17 @@ module glue(
             end
 
             // Pull-based RX mux: FT245 FIFO has priority over UART.
-            // Only pop from FIFO when the serial handler gate is open,
+            // Normally we only pop when the serial handler gate is open,
             // preventing byte loss during SPI CS noise or spi_writing.
+            // However, if the byte at the head of the FIFO is an always-
+            // safe command (VERSION/START/STOP/STATUS) AND the parser is
+            // idle, pop it anyway -- the always-safe dispatcher below can
+            // handle it without touching SDRAM or spi_trx state.  This is
+            // what lets the host issue STOP while SPI is actively being
+            // read, recovering control of the device.
             ft_rx_pop <= 0;
-            if (ft_rx_data_available && !ft_rx_hold && serial_gate) begin
+            if (ft_rx_data_available && !ft_rx_hold &&
+                (serial_gate || peek_is_always_safe)) begin
                 rxd_strobe_buf <= 1;
                 rxd_data_buf <= ft_rx_data;
                 ft_rx_pop <= 1;
@@ -432,32 +478,81 @@ module glue(
                 serial_idle_count <= 0;
             end
             
-            // Serial protocol handling
+            // -----------------------------------------------------------
+            // Always-safe command dispatcher.
+            //
+            // Handles VERSION/START/STOP/STATUS regardless of SPI state.
+            // None of these touch SDRAM, chip configuration, or spi_trx
+            // state, so processing them while SPI emulation is live is
+            // safe -- and is exactly what lets the host recover control
+            // (via STOP) when a target is hammering the SPI bus.  The
+            // parser must be idle (cmd_idle) so we do not collide with
+            // an in-progress multi-byte command.
+            // -----------------------------------------------------------
+            if (rxd_strobe_buf && cmd_idle) begin
+                case (rxd_data_buf)
+                CMD_VERSION: begin
+                    txd_strobe_buf <= 1;
+                    txd_data_buf <= VERSION;
+                end
+                CMD_START: begin
+                    spi_running <= 1;
+                    txd_strobe_buf <= 1;
+                    txd_data_buf <= 8'h01;
+                end
+                CMD_STOP: begin
+                    spi_running <= 0;
+                    txd_strobe_buf <= 1;
+                    txd_data_buf <= 8'h01;
+                end
+                CMD_STATUS: begin
+                    txd_strobe_buf <= 1;
+                    // 0x01 = running, 0x02 = stopped.  Using two non-zero
+                    // codes (rather than 0x00 for stopped) lets the host
+                    // tool's transparent 0x00 skipping still work around
+                    // the FT2232H's occasional leaked modem-status bytes.
+                    txd_data_buf <= spi_running ? 8'h01 : 8'h02;
+                end
+                default: ;  // fall through to gated dispatcher below
+                endcase
+            end
+
+            // -----------------------------------------------------------
+            // Gated command dispatcher.
+            //
+            // Handles RAMREAD/RAMWRITE/CHIPCONFIG (which touch SDRAM or
+            // chip config) plus all multi-byte continuations and the
+            // serial SDRAM read/write state machines.  Gated on SPI bus
+            // idle so we never race with an in-flight SPI transaction,
+            // and initial commands are additionally gated on !spi_running
+            // so the host cannot accidentally disturb live emulation.
+            // -----------------------------------------------------------
             if ((spi_reset || spi_csel_buf[1]) && !spi_writing) begin
                 
                 if (rxd_strobe_buf) begin
                     serial_idle_count <= 0;
 
                     if (in_count == 0) begin
-                        if (rxd_data_buf == CMD_VERSION) begin
-                            txd_strobe_buf <= 1;
-                            txd_data_buf <= VERSION;
-                            in_count <= 0;
-                        end
-                        else if (rxd_data_buf == CMD_RAMREAD ||
-                                 rxd_data_buf == CMD_RAMWRITE) begin
-                            cmd <= rxd_data_buf;
-                            in_count <= 1;
+                        // VERSION/START/STOP/STATUS are handled above.
+                        // Destructive commands are only accepted when
+                        // SPI emulation is stopped (spi_trx is in reset
+                        // and cannot contend for SDRAM or cfg registers).
+                        if (!spi_running) begin
+                            if (rxd_data_buf == CMD_RAMREAD ||
+                                rxd_data_buf == CMD_RAMWRITE) begin
+                                cmd <= rxd_data_buf;
+                                in_count <= 1;
 
-                            read_state <= 0;
-                            read_pos <= 0;
+                                read_state <= 0;
+                                read_pos <= 0;
 
-                            write_state <= 0;
-                            write_pos <= 0;
-                        end
-                        else if (rxd_data_buf == CMD_CHIPCONFIG) begin
-                            cmd <= CMD_CHIPCONFIG;
-                            in_count <= 1;
+                                write_state <= 0;
+                                write_pos <= 0;
+                            end
+                            else if (rxd_data_buf == CMD_CHIPCONFIG) begin
+                                cmd <= CMD_CHIPCONFIG;
+                                in_count <= 1;
+                            end
                         end
                     end
                     else if (cmd == CMD_CHIPCONFIG) begin

--- a/src/sdram.v
+++ b/src/sdram.v
@@ -410,6 +410,41 @@ module sdram(
                     we_o <= 1;
                     dqm_o <= 2'b11;
                 end
+                // Refresh sequence transitions.  Handled inside the main
+                // dispatcher (rather than a separate always-block hunk
+                // after it) so they take priority over any SPI fast-path
+                // or serial command dispatch that might otherwise fire in
+                // the same cycle.  If a post-dispatch hunk overrode the
+                // state back to REFRESH2, the command-side flags
+                // (spi_cmd_activate_ack / spi_activate_done) set by the
+                // overridden dispatch would persist, and the next
+                // cycle's READ would fire without a matching ACTIVATE --
+                // reading from a bank with no open row and returning all
+                // 0xff from the floating DQ bus for the rest of the SPI
+                // burst.
+                else if (state == STA_REFRESH) begin
+                    // Chip 0 refreshed, now refresh chip 1.
+                    state <= STA_REFRESH2;
+                    cmdtarget <= tRC;
+
+                    cs_o <= 1;       // Chip 1
+                    ras_o <= 0;
+                    cas_o <= 0;
+                    we_o <= 1;
+                    dqm_o <= 2'b11;
+
+                    refresh_chip <= 1;
+                end
+                else if (state == STA_REFRESH2) begin
+                    // Chip 1 refreshed, back to idle.
+                    refresh_chip <= 0;
+                    state <= STA_IDLE;
+                    cmdtarget <= 1;
+                    ras_o <= 1;
+                    cas_o <= 1;
+                    we_o <= 1;
+                    dqm_o <= 2'b11;
+                end
                 else if (spi_cmd_activate_buf[1] && !spi_cmd_activate_ack) begin
                     // SPI fast-path activate
                     state <= STA_ACTIVATE;
@@ -524,30 +559,10 @@ module sdram(
                 end
             end
 
-            // After refresh completes, schedule refresh for the other chip
-            if (state == STA_REFRESH && cmdcount >= cmdtarget) begin
-                if (!refresh_chip) begin
-                    // Just refreshed chip 0, now refresh chip 1
-                    state <= STA_REFRESH2;
-                    cmdcount <= 1;
-                    cmdtarget <= tRC;
-                    
-                    cs_o <= 1;       // Chip 1
-                    ras_o <= 0;
-                    cas_o <= 0;
-                    we_o <= 1;
-                    dqm_o <= 2'b11;
-                    
-                    refresh_chip <= 1;
-                end
-                else begin
-                    refresh_chip <= 0;
-                end
-            end
-            
-            if (state == STA_REFRESH2 && cmdcount >= cmdtarget) begin
-                refresh_chip <= 0;
-            end
+            // REFRESH -> REFRESH2 -> IDLE transitions are now handled
+            // inside the main dispatcher (as STA_REFRESH / STA_REFRESH2
+            // cases) so they take priority over SPI and serial command
+            // dispatches in the same cycle.
             
             // Read data capture (de-interleave 16-bit data to 64-bit buffer)
             // Uses aux_clk-captured data (dq_captured) for reliable sampling.

--- a/src/top.v
+++ b/src/top.v
@@ -127,7 +127,25 @@ module top(
     // -----------------------------------------------------------
     
     // SPI input signals
-    wire spi_cs_in = spi_cs_pin;
+    //
+    // spi_cs_pin is debounced in the system clock domain to reject short
+    // glitches caused by Simultaneous Switching Output (SSO) ground bounce.
+    // When all 4 quad IO pins (IO0-IO3) transition HIGH->LOW simultaneously
+    // during the quad address phase (e.g. address nibble 0000 following
+    // 1111), the shared PMOD ground bounces and briefly pulls spi_cs_pin
+    // above the FPGA's VIH threshold.  Without debouncing, the async
+    // reset_cs flip-flop in spi_trx interprets this as a CS deassertion
+    // and resets the SPI state machine mid-transaction.  The 4-cycle
+    // filter (~33ns at 120 MHz) rejects these nanosecond-scale bounces
+    // while preserving responsiveness to real CS edges.
+    reg [3:0] spi_cs_filter = 4'hF;
+    reg spi_cs_debounced = 1;
+    always @(posedge clk) begin
+        spi_cs_filter <= {spi_cs_filter[2:0], spi_cs_pin};
+        if (&spi_cs_filter)        spi_cs_debounced <= 1;  // all 1s: CS released
+        else if (~(|spi_cs_filter)) spi_cs_debounced <= 0;  // all 0s: CS asserted
+    end
+    wire spi_cs_in = spi_cs_debounced;
     wire spi_clk_in = spi_clk_pin;
     wire spi_power_in = spi_power_pin;
     

--- a/src/top.v
+++ b/src/top.v
@@ -185,6 +185,15 @@ module top(
             spi_reset_count <= 0;
         end
     end
+
+    // Effective SPI reset: also held high whenever the host has stopped
+    // emulation via the serial STOP command (spi_running=0).  This keeps
+    // spi_trx fully in reset so the SPI pins are ignored, and is also
+    // fed back into glue.v so its serial_gate stops depending on SPI pin
+    // state -- guaranteeing the host can always reach the FPGA over
+    // UART/FT245 regardless of whether a target board is connected.
+    wire spi_running;
+    wire spi_reset_effective = spi_reset || !spi_running;
     
     // -----------------------------------------------------------
     // SPI Transceiver
@@ -222,7 +231,7 @@ module top(
         .clk(clk),
         
         .spi_clk(spi_clk_in),
-        .spi_reset(spi_reset),
+        .spi_reset(spi_reset_effective),
         .spi_csel(spi_cs_in),
         .spi_io0_in(spi_io0_in),
         .spi_io0_out(spi_io0_out),
@@ -438,7 +447,7 @@ module top(
         
         .sdram_write_buffer(sdram_write_buffer),
         
-        .spi_reset(spi_reset),
+        .spi_reset(spi_reset_effective),
         .spi_csel(spi_cs_in),
         
         .spi_cmd_write(spi_write_cmd),
@@ -460,6 +469,8 @@ module top(
         
         .sfdp_raddr(sfdp_raddr),
         .sfdp_rdata(sfdp_rdata),
+        
+        .spi_running(spi_running),
         
         .led(led_out)
     );

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -69,17 +69,78 @@ impl SerialTransport {
             .open()
             .with_context(|| format!("Failed to open serial port {}", port_name))?;
 
-        // Sync with FPGA: USB-UART bridges can send spurious bytes on
-        // port open (DTR/RTS toggling, line glitches). Wait for the
-        // FPGA's idle timeout to fire and reset the parser, then flush.
-        thread::sleep(Duration::from_millis(5));
+        // Sync with FPGA.  Two distinct glitch sources conspire here:
+        //
+        //   1. A fresh JTAG load of the FPGA briefly tri-states then
+        //      redrives the UART TX pin; the USB-serial bridge decodes
+        //      that transition as a byte -- typically 0xFF (line was
+        //      momentarily high with no start bit).
+        //   2. Opening /dev/ttyUSB* toggles DTR/RTS which can glitch
+        //      the line a second time.
+        //
+        // Either stray can land in the host's tty buffer any time from
+        // a few ms to several tens of ms after port open.  We defend in
+        // two layers: a generous settle + drain, then an *active*
+        // resync that sends CMD_VERSION and discards any non-version
+        // bytes that appear before the real reply.
+        thread::sleep(Duration::from_millis(20));
 
         let mut discard = [0u8; 256];
-        port.set_timeout(Duration::from_millis(1))?;
+        port.set_timeout(Duration::from_millis(5))?;
         while port.read(&mut discard).unwrap_or(0) > 0 {}
-        port.set_timeout(Duration::from_secs(2))?;
 
-        Ok(Self { port })
+        // Active resync: send CMD_VERSION, read everything that
+        // arrives within the reply window, and accept the last byte
+        // seen.  A stray 0xFF that arrived just before or during the
+        // reply will appear *before* the version byte; the last byte
+        // is then the FPGA's reply.  Retry a few times to cover a
+        // stray that arrives *after* the reply (it would be seen as
+        // the last byte on the first attempt, forcing a retry).
+        const SYNC_ATTEMPTS: u32 = 5;
+        for attempt in 0..SYNC_ATTEMPTS {
+            port.write_all(&[CMD_VERSION])?;
+            port.flush().ok();
+
+            // 10 ms window covers FPGA command processing (a few µs)
+            // plus any late-arriving stray bytes.
+            thread::sleep(Duration::from_millis(10));
+
+            let mut last: Option<u8> = None;
+            port.set_timeout(Duration::from_millis(5))?;
+            loop {
+                let mut buf = [0u8; 1];
+                match port.read_exact(&mut buf) {
+                    Ok(()) => last = Some(buf[0]),
+                    Err(_) => break,
+                }
+            }
+
+            // 0x00 is a leaked modem-status zero; 0xFF is the usual
+            // glitch byte.  Anything else is a plausible version reply
+            // (versions 1..=127 are in range for this protocol).
+            match last {
+                Some(v) if v != 0x00 && v != 0xFF => {
+                    // Double-check the line is now quiet.
+                    port.set_timeout(Duration::from_millis(5))?;
+                    while port.read(&mut discard).unwrap_or(0) > 0 {}
+                    port.set_timeout(Duration::from_secs(2))?;
+                    if attempt > 0 {
+                        eprintln!(
+                            "Serial resync: version 0x{:02x} after {} retries",
+                            v,
+                            attempt + 1
+                        );
+                    }
+                    return Ok(Self { port });
+                }
+                _ => {} // keep trying
+            }
+        }
+        bail!(
+            "Failed to sync with FPGA on {} after {} attempts (only saw 0x00/0xFF junk)",
+            port_name,
+            SYNC_ATTEMPTS
+        );
     }
 }
 

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -28,13 +28,16 @@ const BLOCK_SIZE: usize = 16384; // 2048 bursts * 8 bytes
 // host-to-FPGA, SDRAM writes complete in microseconds).
 const UART_READ_BLOCK_SIZE: usize = 4096; // 512 bursts * 8 bytes
 
-const PROTOCOL_VERSION: u8 = 3;
+const PROTOCOL_VERSION: u8 = 4;
 
 // Protocol commands (shared between UART and FT245 transports)
 const CMD_VERSION: u8 = 0x30;
 const CMD_READ: u8 = 0x31;
 const CMD_WRITE: u8 = 0x32;
 const CMD_CHIPCONFIG: u8 = 0x33;
+const CMD_START: u8 = 0x34; // Enable SPI emulation (protocol v4+)
+const CMD_STOP: u8 = 0x35; // Disable SPI emulation (protocol v4+)
+const CMD_STATUS: u8 = 0x36; // Query emulation state (protocol v4+)
 
 // FT2232H USB identifiers
 #[cfg(any(feature = "d2xx", feature = "ftdi"))]
@@ -311,6 +314,125 @@ impl FlashDevice {
         Ok(buf[0])
     }
 
+    /// Read one response byte, transparently skipping stray 0x00 bytes
+    /// that the FT2232H 245 FIFO mode occasionally leaks through D2XX
+    /// (the 2-byte USB IN modem status header).  Used by all single-
+    /// byte-ack commands.
+    fn read_ack(&mut self, context: &str) -> Result<u8> {
+        let mut resp = [0u8; 1];
+        let mut skipped = 0u32;
+        loop {
+            self.transport.read_exact(&mut resp)?;
+            if resp[0] != 0x00 {
+                return Ok(resp[0]);
+            }
+            skipped += 1;
+            if skipped > 8 {
+                bail!("{}: too many 0x00 bytes before ACK", context);
+            }
+        }
+    }
+
+    /// Start SPI emulation.  ACK = 0x01.  Safe to call while running
+    /// (no-op that still acks).
+    fn start_emulation(&mut self) -> Result<()> {
+        self.transport.write_all(&[CMD_START])?;
+        let ack = self.read_ack("start")?;
+        if ack != 0x01 {
+            bail!("start: unexpected response 0x{:02x}", ack);
+        }
+        Ok(())
+    }
+
+    /// Stop SPI emulation.  ACK = 0x01.  Safe to call while stopped.
+    ///
+    /// Always deliverable: even when SPI emulation is actively driving
+    /// the target, the FPGA's always-safe dispatcher picks up this
+    /// command ahead of the usual SPI-idle gate.
+    fn stop_emulation(&mut self) -> Result<()> {
+        self.transport.write_all(&[CMD_STOP])?;
+        let ack = self.read_ack("stop")?;
+        if ack != 0x01 {
+            bail!("stop: unexpected response 0x{:02x}", ack);
+        }
+        Ok(())
+    }
+
+    /// Query the current emulation state.  Returns true when running.
+    ///
+    /// The FPGA encodes stopped as 0x02 (not 0x00) so that any leaked
+    /// FT2232H modem-status zeros can be transparently skipped.
+    fn status(&mut self) -> Result<bool> {
+        self.transport.write_all(&[CMD_STATUS])?;
+        let resp = self.read_ack("status")?;
+        match resp {
+            0x01 => Ok(true),  // running
+            0x02 => Ok(false), // stopped
+            other => bail!("status: unexpected response 0x{:02x}", other),
+        }
+    }
+
+    /// Ensure emulation is stopped for the duration of `f`, then
+    /// restore the prior state.  On v3 or older firmware (which has
+    /// no START/STOP/STATUS opcodes) `f` runs unconditionally and the
+    /// caller is responsible for ensuring the SPI bus is idle.
+    ///
+    /// State is restored on a best-effort basis even when `f` returns
+    /// an error so a failed operation doesn't leave the emulator
+    /// unexpectedly stopped.
+    fn with_emulation_stopped<F, R>(&mut self, f: F) -> Result<R>
+    where
+        F: FnOnce(&mut Self) -> Result<R>,
+    {
+        let version = self.get_version()?;
+        if version < 4 {
+            eprintln!(
+                "Note: FPGA protocol v{} has no START/STOP; assuming idle SPI bus.",
+                version
+            );
+            return f(self);
+        }
+
+        let was_running = self.status()?;
+        if was_running {
+            eprintln!("Stopping SPI emulation for operation...");
+            self.stop_emulation()?;
+        }
+        let result = f(self);
+        if was_running {
+            match self.start_emulation() {
+                Ok(()) => eprintln!("SPI emulation resumed."),
+                Err(e) => eprintln!("Warning: failed to resume SPI emulation: {}", e),
+            }
+        }
+        result
+    }
+
+    /// Stop emulation, run `f`, then start emulation unconditionally.
+    /// Used by `load`, whose natural end state is "ready to serve".
+    fn with_emulation_then_start<F, R>(&mut self, f: F) -> Result<R>
+    where
+        F: FnOnce(&mut Self) -> Result<R>,
+    {
+        let version = self.get_version()?;
+        if version < 4 {
+            eprintln!(
+                "Note: FPGA protocol v{} has no START/STOP; assuming idle SPI bus.",
+                version
+            );
+            return f(self);
+        }
+
+        eprintln!("Stopping SPI emulation...");
+        self.stop_emulation()?;
+        let result = f(self);
+        match self.start_emulation() {
+            Ok(()) => eprintln!("SPI emulation started; target can now read the loaded data."),
+            Err(e) => eprintln!("Warning: failed to start SPI emulation: {}", e),
+        }
+        result
+    }
+
     fn read_block(&mut self, address: u32, length: usize) -> Result<Vec<u8>> {
         if length == 0 || length > BLOCK_SIZE {
             bail!("Invalid length: must be 1-{}", BLOCK_SIZE);
@@ -371,26 +493,12 @@ impl FlashDevice {
         buf.extend_from_slice(data);
         self.transport.write_all(&buf)?;
 
-        // Wait for completion byte.
-        // The FT2232H in 245 FIFO mode occasionally leaks modem status
-        // bytes (0x00) through D2XX into the data stream.  Skip any
-        // leading 0x00 bytes before the real ACK.
-        let mut resp = [0u8; 1];
-        let mut skipped = 0u32;
-        loop {
-            self.transport.read_exact(&mut resp)?;
-            if resp[0] != 0x00 {
-                break;
-            }
-            skipped += 1;
-            if skipped > 8 {
-                bail!("Too many 0x00 bytes before ACK");
-            }
-        }
-        if resp[0] != 0x01 {
+        // Wait for completion byte (read_ack skips leaked FT2232H 0x00s).
+        let ack = self.read_ack("write")?;
+        if ack != 0x01 {
             bail!(
                 "Unexpected ACK: 0x{:02x} (expected 0x01, data[0..4]={:02x?})",
-                resp[0],
+                ack,
                 &data[..std::cmp::min(4, data.len())]
             );
         }
@@ -468,21 +576,9 @@ impl FlashDevice {
         buf.extend_from_slice(sfdp_table);
         self.transport.write_all(&buf)?;
 
-        // Wait for ack (skip modem status bytes, see write_block)
-        let mut resp = [0u8; 1];
-        let mut skipped = 0u32;
-        loop {
-            self.transport.read_exact(&mut resp)?;
-            if resp[0] != 0x00 {
-                break;
-            }
-            skipped += 1;
-            if skipped > 8 {
-                bail!("Chip config: too many 0x00 bytes before ACK");
-            }
-        }
-        if resp[0] != 0x01 {
-            bail!("Chip config failed: unexpected response 0x{:02x}", resp[0]);
+        let ack = self.read_ack("chip config")?;
+        if ack != 0x01 {
+            bail!("Chip config failed: unexpected response 0x{:02x}", ack);
         }
         Ok(())
     }
@@ -622,6 +718,15 @@ enum Commands {
 
     /// Diagnostic: send test bytes and report what comes back
     Probe,
+
+    /// Start SPI emulation (target can now read the loaded firmware)
+    Start,
+
+    /// Stop SPI emulation (required before RAM/config operations)
+    Stop,
+
+    /// Query whether SPI emulation is currently running
+    Status,
 }
 
 fn parse_address(s: &str) -> Result<u32, String> {
@@ -670,77 +775,80 @@ fn cmd_version(cli: &Cli) -> Result<()> {
 
 fn cmd_read(cli: &Cli, address: u32, length: u32, output: Option<PathBuf>) -> Result<()> {
     let mut device = open_device(cli)?;
-    let rbs = device.read_block_size;
 
-    let pb = ProgressBar::new(length as u64);
-    pb.set_style(
-        ProgressStyle::default_bar()
-            .template("[{elapsed_precise}] [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")?
-            .progress_chars("#>-"),
-    );
+    device.with_emulation_stopped(|device| {
+        let rbs = device.read_block_size;
 
-    let mut result = Vec::with_capacity(length as usize);
-    let mut addr = address;
-    let mut remaining = length as usize;
+        let pb = ProgressBar::new(length as u64);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("[{elapsed_precise}] [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")?
+                .progress_chars("#>-"),
+        );
 
-    let start_offset = (addr % 8) as usize;
-    if start_offset != 0 {
-        let aligned_addr = addr - start_offset as u32;
-        let chunk_len = std::cmp::min(8 - start_offset, remaining);
-        let block = device.read_block(aligned_addr, 8)?;
-        result.extend_from_slice(&block[start_offset..start_offset + chunk_len]);
-        addr += chunk_len as u32;
-        remaining -= chunk_len;
-        pb.inc(chunk_len as u64);
-    }
+        let mut result = Vec::with_capacity(length as usize);
+        let mut addr = address;
+        let mut remaining = length as usize;
 
-    while remaining >= 8 {
-        let chunk_len = std::cmp::min(rbs, remaining / 8 * 8);
-        let block = device.read_block(addr, chunk_len)?;
-        result.extend_from_slice(&block);
-        addr += chunk_len as u32;
-        remaining -= chunk_len;
-        pb.inc(chunk_len as u64);
-    }
-
-    if remaining > 0 {
-        let block = device.read_block(addr, 8)?;
-        result.extend_from_slice(&block[..remaining]);
-        pb.inc(remaining as u64);
-    }
-
-    pb.finish_with_message("done");
-
-    match output {
-        Some(path) => {
-            let mut file = File::create(&path)?;
-            file.write_all(&result)?;
-            println!("Wrote {} bytes to {}", result.len(), path.display());
+        let start_offset = (addr % 8) as usize;
+        if start_offset != 0 {
+            let aligned_addr = addr - start_offset as u32;
+            let chunk_len = std::cmp::min(8 - start_offset, remaining);
+            let block = device.read_block(aligned_addr, 8)?;
+            result.extend_from_slice(&block[start_offset..start_offset + chunk_len]);
+            addr += chunk_len as u32;
+            remaining -= chunk_len;
+            pb.inc(chunk_len as u64);
         }
-        None => {
-            for (i, chunk) in result.chunks(16).enumerate() {
-                print!("{:08x}: ", address as usize + i * 16);
-                for b in chunk {
-                    print!("{:02x} ", b);
-                }
-                for _ in chunk.len()..16 {
-                    print!("   ");
-                }
-                print!(" |");
-                for b in chunk {
-                    let c = *b as char;
-                    if c.is_ascii_graphic() || c == ' ' {
-                        print!("{}", c);
-                    } else {
-                        print!(".");
+
+        while remaining >= 8 {
+            let chunk_len = std::cmp::min(rbs, remaining / 8 * 8);
+            let block = device.read_block(addr, chunk_len)?;
+            result.extend_from_slice(&block);
+            addr += chunk_len as u32;
+            remaining -= chunk_len;
+            pb.inc(chunk_len as u64);
+        }
+
+        if remaining > 0 {
+            let block = device.read_block(addr, 8)?;
+            result.extend_from_slice(&block[..remaining]);
+            pb.inc(remaining as u64);
+        }
+
+        pb.finish_with_message("done");
+
+        match output {
+            Some(path) => {
+                let mut file = File::create(&path)?;
+                file.write_all(&result)?;
+                println!("Wrote {} bytes to {}", result.len(), path.display());
+            }
+            None => {
+                for (i, chunk) in result.chunks(16).enumerate() {
+                    print!("{:08x}: ", address as usize + i * 16);
+                    for b in chunk {
+                        print!("{:02x} ", b);
                     }
+                    for _ in chunk.len()..16 {
+                        print!("   ");
+                    }
+                    print!(" |");
+                    for b in chunk {
+                        let c = *b as char;
+                        if c.is_ascii_graphic() || c == ' ' {
+                            print!("{}", c);
+                        } else {
+                            print!(".");
+                        }
+                    }
+                    println!("|");
                 }
-                println!("|");
             }
         }
-    }
 
-    Ok(())
+        Ok(())
+    })
 }
 
 fn cmd_write(cli: &Cli, address: u32, data_hex: &str) -> Result<()> {
@@ -758,7 +866,7 @@ fn cmd_write(cli: &Cli, address: u32, data_hex: &str) -> Result<()> {
         padded.resize((padded.len() + 7) / 8 * 8, 0xFF);
     }
 
-    device.write_block(address, &padded)?;
+    device.with_emulation_stopped(|device| device.write_block(address, &padded))?;
     println!("Wrote {} bytes to 0x{:08x}", data.len(), address);
     Ok(())
 }
@@ -788,89 +896,93 @@ fn cmd_load(cli: &Cli, file: &PathBuf, address: u32, verify: bool) -> Result<()>
         padded.resize((padded.len() + 7) / 8 * 8, 0xFF);
     }
 
-    let pb = ProgressBar::new(padded.len() as u64);
-    pb.set_style(
-        ProgressStyle::default_bar()
-            .template("[{elapsed_precise}] [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")?
-            .progress_chars("#>-"),
-    );
-
-    let mut addr = address;
-    let mut offset = 0;
-    let total_blocks = (padded.len() + BLOCK_SIZE - 1) / BLOCK_SIZE;
-    let mut block_num = 0;
-
-    while offset < padded.len() {
-        let chunk_len = std::cmp::min(BLOCK_SIZE, padded.len() - offset);
-        device
-            .write_block(addr, &padded[offset..offset + chunk_len])
-            .with_context(|| {
-                format!(
-                    "Block {}/{} at addr 0x{:06x}",
-                    block_num, total_blocks, addr
-                )
-            })?;
-        addr += chunk_len as u32;
-        offset += chunk_len;
-        block_num += 1;
-        pb.inc(chunk_len as u64);
-    }
-
-    pb.finish_with_message("done");
-    println!("Loaded {} bytes ({} blocks)", padded.len(), block_num);
-
-    if verify {
-        println!("Verifying...");
+    // Load is the one command whose natural end state is "ready to
+    // serve", so the dance is stop -> write -> (verify) -> start.
+    device.with_emulation_then_start(|device| {
         let pb = ProgressBar::new(padded.len() as u64);
         pb.set_style(
             ProgressStyle::default_bar()
-                .template(
-                    "[{elapsed_precise}] [{bar:40.green/blue}] {bytes}/{total_bytes} ({eta})",
-                )?
+                .template("[{elapsed_precise}] [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")?
                 .progress_chars("#>-"),
         );
 
         let mut addr = address;
         let mut offset = 0;
-        let mut errors = 0;
+        let total_blocks = (padded.len() + BLOCK_SIZE - 1) / BLOCK_SIZE;
+        let mut block_num = 0;
 
-        let rbs = device.read_block_size;
         while offset < padded.len() {
-            let chunk_len = std::cmp::min(rbs, padded.len() - offset);
-            let readback = device.read_block(addr, chunk_len)?;
-
-            for (i, (a, b)) in padded[offset..offset + chunk_len]
-                .iter()
-                .zip(readback.iter())
-                .enumerate()
-            {
-                if a != b {
-                    if errors < 10 {
-                        eprintln!(
-                            "Mismatch at 0x{:08x}: expected 0x{:02x}, got 0x{:02x}",
-                            addr + i as u32,
-                            a,
-                            b
-                        );
-                    }
-                    errors += 1;
-                }
-            }
-
+            let chunk_len = std::cmp::min(BLOCK_SIZE, padded.len() - offset);
+            device
+                .write_block(addr, &padded[offset..offset + chunk_len])
+                .with_context(|| {
+                    format!(
+                        "Block {}/{} at addr 0x{:06x}",
+                        block_num, total_blocks, addr
+                    )
+                })?;
             addr += chunk_len as u32;
             offset += chunk_len;
+            block_num += 1;
             pb.inc(chunk_len as u64);
         }
 
         pb.finish_with_message("done");
+        println!("Loaded {} bytes ({} blocks)", padded.len(), block_num);
 
-        if errors > 0 {
-            bail!("Verification failed: {} byte(s) differ", errors);
+        if verify {
+            println!("Verifying...");
+            let pb = ProgressBar::new(padded.len() as u64);
+            pb.set_style(
+                ProgressStyle::default_bar()
+                    .template(
+                        "[{elapsed_precise}] [{bar:40.green/blue}] {bytes}/{total_bytes} ({eta})",
+                    )?
+                    .progress_chars("#>-"),
+            );
+
+            let mut addr = address;
+            let mut offset = 0;
+            let mut errors = 0;
+
+            let rbs = device.read_block_size;
+            while offset < padded.len() {
+                let chunk_len = std::cmp::min(rbs, padded.len() - offset);
+                let readback = device.read_block(addr, chunk_len)?;
+
+                for (i, (a, b)) in padded[offset..offset + chunk_len]
+                    .iter()
+                    .zip(readback.iter())
+                    .enumerate()
+                {
+                    if a != b {
+                        if errors < 10 {
+                            eprintln!(
+                                "Mismatch at 0x{:08x}: expected 0x{:02x}, got 0x{:02x}",
+                                addr + i as u32,
+                                a,
+                                b
+                            );
+                        }
+                        errors += 1;
+                    }
+                }
+
+                addr += chunk_len as u32;
+                offset += chunk_len;
+                pb.inc(chunk_len as u64);
+            }
+
+            pb.finish_with_message("done");
+
+            if errors > 0 {
+                bail!("Verification failed: {} byte(s) differ", errors);
+            }
+            println!("Verification passed!");
         }
-        println!("Verification passed!");
-    }
 
-    Ok(())
+        Ok(())
+    })
 }
 
 fn cmd_dump(cli: &Cli, file: &PathBuf, address: u32, length: u32) -> Result<()> {
@@ -922,9 +1034,10 @@ fn cmd_configure(cli: &Cli, chip_db_path: &str, chip_name: &str) -> Result<()> {
     let sfdp_table = sfdp::generate_sfdp(chip);
     eprintln!("  SFDP table: {} bytes", sfdp_table.len());
 
-    // Send to FPGA
+    // Send to FPGA.  Must be stopped while CHIPCONFIG is processed,
+    // otherwise spi_trx could read inconsistent cfg_* values mid-transfer.
     let mut device = open_device(cli)?;
-    device.send_chip_config(chip, &sfdp_table)?;
+    device.with_emulation_stopped(|device| device.send_chip_config(chip, &sfdp_table))?;
 
     eprintln!("Configuration applied successfully.");
     Ok(())
@@ -1327,6 +1440,30 @@ fn cmd_ports() -> Result<()> {
     Ok(())
 }
 
+fn cmd_start(cli: &Cli) -> Result<()> {
+    let mut device = open_device(cli)?;
+    device.start_emulation()?;
+    println!("SPI emulation started.");
+    Ok(())
+}
+
+fn cmd_stop(cli: &Cli) -> Result<()> {
+    let mut device = open_device(cli)?;
+    device.stop_emulation()?;
+    println!("SPI emulation stopped.");
+    Ok(())
+}
+
+fn cmd_status(cli: &Cli) -> Result<()> {
+    let mut device = open_device(cli)?;
+    let running = device.status()?;
+    println!(
+        "SPI emulation: {}",
+        if running { "running" } else { "stopped" }
+    );
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -1356,6 +1493,9 @@ fn main() -> Result<()> {
         Commands::Ports => cmd_ports(),
         Commands::FtList => cmd_ft_list(),
         Commands::Probe => cmd_probe(&cli),
+        Commands::Start => cmd_start(&cli),
+        Commands::Stop => cmd_stop(&cli),
+        Commands::Status => cmd_status(&cli),
     }
 }
 


### PR DESCRIPTION
## Summary

Introduces explicit host-controlled SPI emulation gating via three new serial commands (`START`/`STOP`/`STATUS`, opcodes 0x34–0x36). The FPGA now boots in **STOPPED** state — SPI pins are ignored and all serial commands are always reachable — and only begins emulating after the host explicitly sends `START`. This solves a class of bugs where a live SPI target could starve the serial command path or leave the FPGA in an unrecoverable state.

---

## FPGA Changes (`glue.v`, `sdram.v`, `top.v`)

### glue.v
- Added `spi_running` output register, initialized to `0` at reset (STOPPED state)
- Added three new opcodes: `CMD_START` (0x34), `CMD_STOP` (0x35), `CMD_STATUS` (0x36)
- Split command dispatch into two tiers:
  - **Always-safe dispatcher**: handles `VERSION`/`START`/`STOP`/`STATUS` unconditionally — even while SPI is actively running — so the host can always reach the FPGA and send `STOP` to recover control
  - **Gated dispatcher**: handles `RAMREAD`/`RAMWRITE`/`CHIPCONFIG` only when `spi_running=0` and SPI bus is idle, preventing races with live emulation
- Added `peek_is_always_safe` logic to pop always-safe commands from the FT245 FIFO even when `serial_gate` is closed
- `CMD_STATUS` replies `0x01` (running) or `0x02` (stopped) — two non-zero values so the host's existing `0x00` modem-status skip logic still works
- Bumped `VERSION` from 3 → 4

### top.v
- Added 4-cycle CS debounce filter (`spi_cs_filter`) to reject SSO ground bounce glitches that were causing spurious CS deassertion mid-transaction
- Added `spi_reset_effective = spi_reset || !spi_running` — when stopped, `spi_trx` is held in full reset so SPI pins are completely ignored
- Wired `spi_running` from `glue` and passed `spi_reset_effective` to both `spi_trx` and `glue`

### sdram.v
- Moved `STA_REFRESH` → `STA_REFRESH2` → `STA_IDLE` transitions inside the main state-machine dispatcher (previously a separate always-block), so refresh transitions take priority over SPI and serial command dispatches in the same cycle — fixing a bug where a concurrent dispatch could reset state back to `STA_REFRESH2`, causing a READ without a preceding ACTIVATE and returning 0xFF garbage for the rest of the SPI burst

---

## Host Tool Changes (`tool/src/main.rs`)

- Added `start_emulation()`, `stop_emulation()`, `status()` methods on `FlashDevice`
- Added `read_ack()` helper that transparently skips leaked FT2232H modem-status `0x00` bytes (deduplicates repeated inline logic from `write_block` and `send_chip_config`)
- Added `with_emulation_stopped()` wrapper: stops emulation, runs the operation, restores prior state — used by `cmd_read`, `cmd_write`, `cmd_configure`
- Added `with_emulation_then_start()` wrapper: stops → operates → unconditionally starts — used by `cmd_load` (natural end state is "ready to serve")
- Added CLI subcommands: `start`, `stop`, `status`
- Improved serial port sync: extended settle time (5ms → 20ms), added active resync loop that sends `CMD_VERSION` and retries up to 5 times, discarding `0x00`/`0xFF` stray bytes
- Protocol version check updated to v4; v3 firmware falls back gracefully with a warning