### PR TITLE
fix: harden SPI NOR emulation and host protocol handling

### DIFF
--- a/build.tcl
+++ b/build.tcl
@@ -19,6 +19,7 @@ add_file src/pll.v
 
 # Add constraints
 add_file tangprimer25k.cst
+add_file tangprimer25k.sdc
 
 # Set top module
 set_option -top_module top

--- a/src/glue.v
+++ b/src/glue.v
@@ -59,7 +59,7 @@ module glue(
     input wire [1:0] spi_write_type,  // 00=page program, 01=erase, 10=AAI RMW
     input wire [22:0] spi_write_addr,   // 23-bit burst address
     input wire [22:0] spi_write_len,
-    output reg spi_write_done,
+    output reg spi_write_done,   // Toggles once per completed write/erase
     
     input wire spi_write_buf_strobe,
     input wire [7:0] spi_write_buf_offset,
@@ -132,10 +132,12 @@ module glue(
         CMD_TOCTOU       = 8'h39,  // TOCTOU trap management
         CMD_LOGPOLL      = 8'h3A;  // Drain logger ring FIFO
 
-    // Terminator byte appended to every CMD_LOGPOLL response.  The
-    // logger never emits 0xA0 (all its packet type bytes are 0xA1-0xA4),
-    // so the host can unambiguously detect end-of-poll.
+    // Terminator byte appended to every CMD_LOGPOLL response.  Log data
+    // bytes equal to the terminator or escape byte are byte-stuffed as
+    // 0xA5 0x00 (for 0xA0) or 0xA5 0x05 (for 0xA5), so the terminator is
+    // unambiguous even when raw packet payloads contain 0xA0.
     localparam LOG_POLL_TERMINATOR = 8'hA0;
+    localparam LOG_POLL_ESCAPE     = 8'hA5;
 
     // Max log bytes sent per poll.  Bounds response length so the host
     // cannot be starved by a busy SPI master filling the FIFO faster
@@ -173,10 +175,12 @@ module glue(
 
     // CMD_LOGPOLL state machine.
     //   log_poll_state 0 = idle
-    //                  1 = drain FIFO (send log bytes while available)
+    //                  1 = drain FIFO (send/escape log bytes while available)
     //                  2 = terminator (send 0xA0 and return to idle)
+    //                  3 = escaped byte payload
     reg [1:0] log_poll_state;
-    reg [7:0] log_poll_remain;  // bytes still allowed before forced terminator
+    reg [7:0] log_poll_remain;       // raw log bytes still allowed before terminator
+    reg [7:0] log_poll_escape_code;  // second byte after LOG_POLL_ESCAPE
 
     reg txd_strobe_buf;
     reg [7:0] txd_data_buf;
@@ -270,7 +274,7 @@ module glue(
     
     // CHIPCONFIG state
     reg [6:0] sfdp_wr_pos;
-    reg [6:0] cfg_sfdp_remaining;
+    reg [7:0] cfg_sfdp_remaining;
     
     // TOCTOU trap table (4 entries)
     reg [23:0] trap_start [0:3];     // Byte address match value
@@ -316,6 +320,7 @@ module glue(
 
             log_poll_state <= 0;
             log_poll_remain <= 0;
+            log_poll_escape_code <= 0;
             log_fifo_read_strobe <= 0;
 
             sdram_access_cmd <= 0;
@@ -566,7 +571,7 @@ module glue(
                 
                 i_spi_write_type <= spi_write_type;
                 case (spi_write_type)
-                    2'd0: i_spi_write_state <= 0;  // Page program: prepare data
+                    2'd0: i_spi_write_state <= 6;  // Page program: read-modify-write bursts
                     2'd1: i_spi_write_state <= 2;  // Erase: activate for write
                     2'd2: i_spi_write_state <= 6;  // AAI: read-modify-write
                     default: i_spi_write_state <= 0;
@@ -574,7 +579,6 @@ module glue(
                 
                 addr <= spi_write_addr;
                 i_spi_len <= spi_write_len;
-                spi_write_done <= 0;
                 
                 if (spi_write_type == 2'd1)
                     write_buffer <= 64'hFFFFFFFFFFFFFFFF;
@@ -583,11 +587,10 @@ module glue(
             // SPI write state machine
             if (spi_writing && !sdram_busy) begin
                 if (i_spi_write_state == 0) begin
-                    // Page program: prepare data from page buffer
-                    for (i = 0; i < 8; i = i + 1) begin
-                        write_buffer[i*8 +: 8] <= i_spi_write_data[{addr[4:0], 3'b000} + i][7:0];
-                    end
-                    i_spi_write_state <= 1;
+                    // Legacy direct page-program state is no longer used.
+                    // Page program now uses the RMW path (states 6-8) so
+                    // partial programs preserve untouched bytes.
+                    i_spi_write_state <= 6;
                 end
                 else if (i_spi_write_state == 1) begin
                     i_spi_write_state <= 2;
@@ -610,7 +613,7 @@ module glue(
                 end
                 else if (i_spi_write_state == 4) begin
                     case (i_spi_write_type)
-                        2'd0: i_spi_write_state <= 0;  // Page program: next burst
+                        2'd0: i_spi_write_state <= 6;  // Page program: next RMW burst
                         2'd1: i_spi_write_state <= 2;  // Erase: next burst
                         default: i_spi_write_state <= 0;
                     endcase
@@ -619,22 +622,24 @@ module glue(
                 end
                 else if (i_spi_write_state == 5) begin
                     spi_writing <= 0;
-                    spi_write_done <= 1;
+                    spi_write_done <= !spi_write_done;
                     
-                    // Clear page buffer write flags after AAI so the next
-                    // AAI word starts with a clean flag state.
-                    if (i_spi_write_type == 2'd2) begin
+                    // Clear page buffer write flags after SPI-originated
+                    // programs so the next program starts with a clean flag
+                    // state and cannot reuse stale bytes.
+                    if (i_spi_write_type == 2'd0 || i_spi_write_type == 2'd2) begin
                         for (i = 0; i < 256; i = i + 1)
                             i_spi_write_data[i][8] <= 0;
                     end
                 end
                 // ---------------------------------------------------------
-                // AAI Read-Modify-Write (write_type == 2)
+                // SPI program Read-Modify-Write (page program or AAI).
                 //
-                // Writes exactly 2 bytes into a single 8-byte SDRAM burst
-                // without corrupting the other 6 bytes.  Uses the page
-                // buffer write flags (bit 8) to select which bytes come
-                // from the page buffer and which are preserved from SDRAM.
+                // Page program writes a full 256-byte page window but only
+                // updates bytes whose write flags were set by the SPI data
+                // phase. AAI writes exactly the flagged bytes in one burst.
+                // Programmed bytes are merged as old & new to preserve NOR
+                // flash semantics (program can clear bits, not set them).
                 //
                 // State 6: Activate row for read
                 // State 7: Issue SDRAM read command
@@ -656,7 +661,7 @@ module glue(
                     // data if its write flag is set, otherwise keep SDRAM data.
                     for (i = 0; i < 8; i = i + 1) begin
                         if (i_spi_write_data[{addr[4:0], 3'b000} + i][8])
-                            write_buffer[i*8 +: 8] <= i_spi_write_data[{addr[4:0], 3'b000} + i][7:0];
+                            write_buffer[i*8 +: 8] <= sdram_read_buffer[i*8 +: 8] & i_spi_write_data[{addr[4:0], 3'b000} + i][7:0];
                         else
                             write_buffer[i*8 +: 8] <= sdram_read_buffer[i*8 +: 8];
                     end
@@ -738,16 +743,31 @@ module glue(
             // actively hammering the bus.  Running ungated also means
             // monitor tools can poll while logging real-time traffic.
             //
-            //   State 1: pop one byte per TX slot while FIFO has data
-            //            and the per-poll cap has not been exhausted.
+            //   State 1: pop one raw byte per TX slot while FIFO has data
+            //            and the per-poll cap has not been exhausted.  If
+            //            the raw byte collides with framing, send ESCAPE
+            //            now and state 3 sends the escape code next.
             //   State 2: emit 0xA0 terminator and return to idle.
+            //   State 3: emit second byte of an escaped raw log byte.
             // -----------------------------------------------------------
             if (log_poll_state == 2'd1 && can_send) begin
                 if (log_fifo_data_available && log_poll_remain != 0) begin
                     txd_strobe_buf       <= 1;
-                    txd_data_buf         <= log_fifo_read_data;
                     log_fifo_read_strobe <= 1;
                     log_poll_remain      <= log_poll_remain - 1;
+                    if (log_fifo_read_data == LOG_POLL_TERMINATOR) begin
+                        txd_data_buf         <= LOG_POLL_ESCAPE;
+                        log_poll_escape_code <= 8'h00;
+                        log_poll_state       <= 2'd3;
+                    end
+                    else if (log_fifo_read_data == LOG_POLL_ESCAPE) begin
+                        txd_data_buf         <= LOG_POLL_ESCAPE;
+                        log_poll_escape_code <= 8'h05;
+                        log_poll_state       <= 2'd3;
+                    end
+                    else begin
+                        txd_data_buf <= log_fifo_read_data;
+                    end
                 end
                 else begin
                     log_poll_state <= 2'd2;
@@ -758,6 +778,11 @@ module glue(
                 txd_data_buf   <= LOG_POLL_TERMINATOR;
                 log_poll_state <= 2'd0;
                 cmd            <= CMD_NOP;
+            end
+            else if (log_poll_state == 2'd3 && can_send) begin
+                txd_strobe_buf <= 1;
+                txd_data_buf   <= log_poll_escape_code;
+                log_poll_state <= 2'd1;
             end
 
             // -----------------------------------------------------------
@@ -845,7 +870,7 @@ module glue(
                         else if (in_count == 8'd7)
                             cfg_chip_erase_bursts[7:0] <= rxd_data_buf;
                         else if (in_count == 8'd8) begin
-                            cfg_sfdp_remaining <= rxd_data_buf[6:0];
+                            cfg_sfdp_remaining <= rxd_data_buf;
                             sfdp_wr_pos <= 0;
                         end
                         // SFDP data bytes
@@ -856,14 +881,14 @@ module glue(
                         end
                         
                         // Advance or finish
-                        if (in_count == 8'd8 && rxd_data_buf[6:0] == 0) begin
+                        if (in_count == 8'd8 && rxd_data_buf == 0) begin
                             // No SFDP data, done immediately
                             txd_strobe_buf <= 1;
                             txd_data_buf <= 8'h01;
                             in_count <= 0;
                             cmd <= CMD_NOP;
                         end
-                        else if (in_count > 8'd8 && cfg_sfdp_remaining == 7'd1) begin
+                        else if (in_count > 8'd8 && cfg_sfdp_remaining == 8'd1) begin
                             // Last SFDP byte received, done
                             txd_strobe_buf <= 1;
                             txd_data_buf <= 8'h01;

--- a/src/sdram.v
+++ b/src/sdram.v
@@ -157,10 +157,16 @@ module sdram(
     //   [21:9]  = row (13 bits)
     //   [8:7]   = bank (2 bits)
     //   [6:0]   = column burst index (col[8:2])
-    wire spi_chip_sel  = spi_addr[22];
-    wire [12:0] spi_row  = spi_addr[21:9];
-    wire [1:0]  spi_bank = spi_addr[8:7];
-    wire [8:0]  spi_col  = {spi_addr[6:0], 2'b00};  // Burst-4 aligned
+    // Latch the multi-bit SPI address in the system clock domain when the
+    // synchronized activate request is accepted, then use only the latched
+    // value for ACTIVATE/READ.  spi_trx holds spi_addr stable across the
+    // request handshake; this avoids using a live cross-domain bus later in
+    // the SDRAM command sequence.
+    reg [22:0] spi_addr_latched;
+    wire spi_chip_sel  = spi_addr_latched[22];
+    wire [12:0] spi_row  = spi_addr_latched[21:9];
+    wire [1:0]  spi_bank = spi_addr_latched[8:7];
+    wire [8:0]  spi_col  = {spi_addr_latched[6:0], 2'b00};  // Burst-4 aligned
 
     // Serial/glue path: 25-bit address = {chip, row, bank, col}
     //   [24]     = chip select
@@ -222,6 +228,7 @@ module sdram(
             spi_cmd_activate_ack <= 0;
             spi_cmd_read_ack <= 0;
             spi_activate_done <= 0;
+            spi_addr_latched <= 0;
         end
         else begin
             refreshcount <= refreshcount + 1;
@@ -451,15 +458,16 @@ module sdram(
                     cmdtarget <= tRCD;
                     spi_cmd_activate_ack <= 1;
                     spi_activate_done <= 1;
+                    spi_addr_latched <= spi_addr;
 
                     // ACTIVATE command
-                    cs_o <= spi_chip_sel;
+                    cs_o <= spi_addr[22];
                     ras_o <= 0;
                     cas_o <= 1;
                     we_o <= 1;
                     dqm_o <= 2'b11;
-                    ba_o <= spi_bank;
-                    a_o <= spi_row;
+                    ba_o <= spi_addr[8:7];
+                    a_o <= spi_addr[21:9];
                 end
                 else if (spi_cmd_read_buf[1] && !spi_cmd_read_ack && spi_activate_done) begin
                     // SPI fast-path read

--- a/src/spi_trx.v
+++ b/src/spi_trx.v
@@ -43,7 +43,7 @@ module spi_trx(
     output reg [1:0] write_type,  // 00=page program, 01=erase, 10=AAI RMW
     output reg [22:0] write_addr,     // 23-bit burst address
     output reg [22:0] write_len,
-    input wire write_done,
+    input wire write_done,       // Toggles once per completed write/erase
     
     output reg write_buf_strobe,
     output reg [7:0] write_buf_offset,
@@ -125,24 +125,32 @@ module spi_trx(
         CMD_WRITEENABLE     = 8'h06,
         CMD_FASTREAD        = 8'h0B,
         CMD_FASTREAD_4B     = 8'h0C,
+        CMD_PAGEPROGRAM_4B  = 8'h12,
         CMD_READ_4B         = 8'h13,
+        CMD_DUALREAD_4B     = 8'h3C,  // Dual Output Read with 4-byte address
         CMD_SECTORERASE_4K  = 8'h20,
+        CMD_SECTORERASE_4K_4B = 8'h21,
         CMD_READSTATUS2     = 8'h35,  // Read Status Register 2
         CMD_DUALREAD        = 8'h3B,  // Dual Output Read (1-1-2)
         CMD_BLOCKERASE_32K  = 8'h52,
+        CMD_BLOCKERASE_32K_4B = 8'h5C,
         CMD_CHIPERASE1      = 8'h60,
         CMD_QUADREAD        = 8'h6B,  // Quad Output Read (1-1-4)
+        CMD_QUADREAD_4B     = 8'h6C,  // Quad Output Read with 4-byte address
         CMD_READID1         = 8'h9E,
         CMD_READSFDP        = 8'h5A,  // Read SFDP table
         CMD_READID2         = 8'h9F,
         CMD_4BYTEENABLE     = 8'hB7,
         CMD_DUALIOREAD      = 8'hBB,  // Dual I/O Read (1-2-2)
+        CMD_DUALIOREAD_4B   = 8'hBC,  // Dual I/O Read with 4-byte address
         CMD_CHIPERASE2      = 8'hC7,
         CMD_BLOCKERASE_64K  = 8'hD8,
+        CMD_BLOCKERASE_64K_4B = 8'hDC,
         CMD_EWSR            = 8'h50,  // Enable Write Status Register (SST)
         CMD_AAI_WORD        = 8'hAD,  // AAI Word Program (SST)
         CMD_4BYTEDISABLE    = 8'hE9,
         CMD_QUADIOREAD      = 8'hEB,  // Quad I/O Read (1-4-4)
+        CMD_QUADIOREAD_4B   = 8'hEC,  // Quad I/O Read with 4-byte address
         CMD_LOG             = 8'hF2;
     
     // State machine states
@@ -190,17 +198,18 @@ module spi_trx(
     reg [7:0] status_reg = 8'b00000000;
     reg [7:0] status_reg2 = 8'h02;     // QE bit (bit 1) default enabled
     
-    // Synchronize write_done from system clock domain
-    reg [2:0] write_done_sync;
-    
-    always @(posedge clk) begin
-        write_done_sync <= {write_done_sync[1:0], write_done};
-    end
-    
-    wire write_busy_clr = write_done_sync[2];
+    // Synchronize write_done from the system clock domain into spi_clk.
+    // glue.v toggles write_done once per completed program/erase, so the
+    // event is preserved even if spi_clk is stopped while the write runs.
+    reg [2:0] write_done_sync = 0;
+    wire write_busy_clr = write_done_sync[1] ^ write_done_sync[2];
+
+    reg status_read_sel2 = 0;
 
     // Main SPI state machine
     always @(posedge spi_clk) begin
+        write_done_sync <= {write_done_sync[1:0], write_done};
+
         if (is_selected) begin
             fresh_read <= 0;
             
@@ -229,6 +238,7 @@ module spi_trx(
                 is_quad_read <= 0;
                 is_sfdp_read <= 0;
                 is_aai <= 0;
+                status_read_sel2 <= 0;
                 mode_count <= 0;
                 
                 log_strobe <= 0;
@@ -271,12 +281,14 @@ module spi_trx(
                         
                     CMD_READSTATUS: begin
                         state <= STA_READSTATUS;
+                        status_read_sel2 <= 0;
                         spi_io1_oe_ff <= 1;
                         miso_byte <= status_reg;
                     end
                     
                     CMD_READSTATUS2: begin
                         state <= STA_READSTATUS;
+                        status_read_sel2 <= 1;
                         spi_io1_oe_ff <= 1;
                         miso_byte <= status_reg2;
                     end
@@ -307,11 +319,11 @@ module spi_trx(
                     end
                     
                     CMD_4BYTEENABLE: begin
-                        if (status_reg[1] && cfg_4byte) addr_4byte <= 1;
+                        if (cfg_4byte) addr_4byte <= 1;
                     end
                     
                     CMD_4BYTEDISABLE: begin
-                        if (status_reg[1] && cfg_4byte) addr_4byte <= 0;
+                        if (cfg_4byte) addr_4byte <= 0;
                     end
                         
                     CMD_READ: begin
@@ -341,59 +353,66 @@ module spi_trx(
                     end
                     
                     // Dual Output Read (1-1-2): cmd(1), addr(1), 8 dummy, data(2)
-                    CMD_DUALREAD: begin
+                    CMD_DUALREAD,
+                    CMD_DUALREAD_4B: begin
                         state <= STA_ADDR_READ;
-                        addr_count <= addr_4byte ? 31 : 23;
+                        addr_count <= ({mosi_byte[7:1], spi_io0_in} == CMD_DUALREAD_4B) ? 31 : (addr_4byte ? 31 : 23);
                         is_fast_read <= 1;   // Uses same dummy phase
                         is_dual_read <= 1;
                     end
                     
                     // Dual I/O Read (1-2-2): cmd(1), addr(2), mode+dummy(2), data(2)
-                    CMD_DUALIOREAD: begin
+                    CMD_DUALIOREAD,
+                    CMD_DUALIOREAD_4B: begin
                         state <= STA_ADDR_READ_DUAL;
-                        addr_count <= addr_4byte ? 31 : 23;
+                        addr_count <= ({mosi_byte[7:1], spi_io0_in} == CMD_DUALIOREAD_4B) ? 31 : (addr_4byte ? 31 : 23);
                         is_dual_read <= 1;
                     end
                     
                     // Quad Output Read (1-1-4): cmd(1), addr(1), 8 dummy, data(4)
-                    CMD_QUADREAD: begin
+                    CMD_QUADREAD,
+                    CMD_QUADREAD_4B: begin
                         if (status_reg2[1]) begin  // QE required
                             state <= STA_ADDR_READ;
-                            addr_count <= addr_4byte ? 31 : 23;
+                            addr_count <= ({mosi_byte[7:1], spi_io0_in} == CMD_QUADREAD_4B) ? 31 : (addr_4byte ? 31 : 23);
                             is_fast_read <= 1;   // Uses same dummy phase
                             is_quad_read <= 1;
                         end
                     end
                     
                     // Quad I/O Read (1-4-4): cmd(1), addr(4), mode+dummy(4), data(4)
-                    CMD_QUADIOREAD: begin
+                    CMD_QUADIOREAD,
+                    CMD_QUADIOREAD_4B: begin
                         if (status_reg2[1]) begin  // QE required
                             state <= STA_ADDR_READ_QUAD;
-                            addr_count <= addr_4byte ? 31 : 23;
+                            addr_count <= ({mosi_byte[7:1], spi_io0_in} == CMD_QUADIOREAD_4B) ? 31 : (addr_4byte ? 31 : 23);
                             is_quad_read <= 1;
                         end
                     end
 
-                    CMD_SECTORERASE_4K: begin
+                    CMD_SECTORERASE_4K,
+                    CMD_SECTORERASE_4K_4B: begin
                         if (status_reg[1]) begin
                             state <= STA_ADDR_ERASE;
-                            addr_count <= addr_4byte ? 31 : 23;
+                            addr_count <= ({mosi_byte[7:1], spi_io0_in} == CMD_SECTORERASE_4K_4B) ? 31 : (addr_4byte ? 31 : 23);
                             write_len <= 23'h001FF; // 4KB = 512 × 8-byte bursts - 1
                         end
                     end
                     
-                    CMD_BLOCKERASE_32K: begin
+                    CMD_BLOCKERASE_32K,
+                    CMD_BLOCKERASE_32K_4B: begin
                         if (status_reg[1]) begin
                             state <= STA_ADDR_ERASE;
-                            addr_count <= addr_4byte ? 31 : 23;
+                            addr_count <= ({mosi_byte[7:1], spi_io0_in} == CMD_BLOCKERASE_32K_4B) ? 31 : (addr_4byte ? 31 : 23);
                             write_len <= 23'h00FFF; // 32KB = 4096 × 8-byte bursts - 1
                         end
                     end
                     
-                    CMD_BLOCKERASE_64K: begin
+                    CMD_BLOCKERASE_64K,
+                    CMD_BLOCKERASE_64K_4B: begin
                         if (status_reg[1]) begin
                             state <= STA_ADDR_ERASE;
-                            addr_count <= addr_4byte ? 31 : 23;
+                            addr_count <= ({mosi_byte[7:1], spi_io0_in} == CMD_BLOCKERASE_64K_4B) ? 31 : (addr_4byte ? 31 : 23);
                             write_len <= 23'h01FFF; // 64KB = 8192 × 8-byte bursts - 1
                         end
                     end
@@ -411,10 +430,11 @@ module spi_trx(
                         end
                     end
                     
-                    CMD_PAGEPROGRAM: begin
+                    CMD_PAGEPROGRAM,
+                    CMD_PAGEPROGRAM_4B: begin
                         if (status_reg[1]) begin
                             state <= STA_ADDR_WRITE;
-                            addr_count <= addr_4byte ? 31 : 23;
+                            addr_count <= ({mosi_byte[7:1], spi_io0_in} == CMD_PAGEPROGRAM_4B) ? 31 : (addr_4byte ? 31 : 23);
                             write_len <= 23'h0001F; // 256 byte page = 32 × 8-byte bursts - 1
                         end
                     end
@@ -483,7 +503,7 @@ module spi_trx(
                     log_byte_count <= 0;
                 end
                 else if ((state == STA_READSTATUS) && (bit_count_in == 0)) begin
-                    miso_byte <= status_reg;
+                    miso_byte <= status_read_sel2 ? status_reg2 : status_reg;
                 end
                 else if (state == STA_ADDR_READ) begin
                     // Receiving address bytes for read (single-bit, 1 bit/clock)

--- a/src/top.v
+++ b/src/top.v
@@ -128,21 +128,16 @@ module top(
     
     // SPI input signals
     //
-    // spi_cs_pin is debounced in the system clock domain to reject short
-    // glitches caused by Simultaneous Switching Output (SSO) ground bounce.
-    // When all 4 quad IO pins (IO0-IO3) transition HIGH->LOW simultaneously
-    // during the quad address phase (e.g. address nibble 0000 following
-    // 1111), the shared PMOD ground bounces and briefly pulls spi_cs_pin
-    // above the FPGA's VIH threshold.  Without debouncing, the async
-    // reset_cs flip-flop in spi_trx interprets this as a CS deassertion
-    // and resets the SPI state machine mid-transaction.  The 4-cycle
-    // filter (~33ns at 120 MHz) rejects these nanosecond-scale bounces
-    // while preserving responsiveness to real CS edges.
+    // Keep the debounced CS path feeding spi_trx.  It rejects short CS
+    // glitches caused by SSO/ground-bounce during quad transfers; removing
+    // it can reset the SPI state machine mid-transaction.  Top-level output
+    // enables are additionally gated with the raw CS pin below so the FPGA
+    // still releases the bus immediately when the real CS deasserts.
     reg [3:0] spi_cs_filter = 4'hF;
     reg spi_cs_debounced = 1;
     always @(posedge clk) begin
         spi_cs_filter <= {spi_cs_filter[2:0], spi_cs_pin};
-        if (&spi_cs_filter)        spi_cs_debounced <= 1;  // all 1s: CS released
+        if (&spi_cs_filter)         spi_cs_debounced <= 1;  // all 1s: CS released
         else if (~(|spi_cs_filter)) spi_cs_debounced <= 0;  // all 0s: CS asserted
     end
     wire spi_cs_in = spi_cs_debounced;
@@ -161,7 +156,7 @@ module top(
     wire spi_debug_out;
     
     // IO0 (MOSI pin): input normally, output during dual/quad read data phase
-    wire spi_active_out = !spi_cs_in && spi_power_in;
+    wire spi_active_out = !spi_cs_pin && spi_power_in;
     assign spi_mosi_pin = (spi_io0_oe && spi_active_out) ? spi_io0_out : 1'bz;
     wire spi_io0_in = spi_mosi_pin;
     
@@ -322,17 +317,27 @@ module top(
     // them into the system clock domain with edge detection in glue.
     // -----------------------------------------------------------
     
-    reg [1:0] log_addr_valid_sys;
+    reg log_addr_toggle_spi = 0;
+    reg [31:0] log_addr_hold_spi = 0;
+    always @(posedge spi_clk_in) begin
+        if (log_addr_valid) begin
+            log_addr_hold_spi <= log_addr_out;
+            log_addr_toggle_spi <= !log_addr_toggle_spi;
+        end
+    end
+
+    reg [2:0] log_addr_toggle_sys;
     reg [1:0] spi_active_sys;
     reg [31:0] log_addr_latched;
     
     always @(posedge clk) begin
-        log_addr_valid_sys <= {log_addr_valid_sys[0], log_addr_valid};
-        spi_active_sys     <= {spi_active_sys[0], spi_active};
-        // Latch addr when valid fires (stable for multiple sys clocks)
-        if (log_addr_valid && !log_addr_valid_sys[0])
-            log_addr_latched <= log_addr_out;
+        log_addr_toggle_sys <= {log_addr_toggle_sys[1:0], log_addr_toggle_spi};
+        spi_active_sys      <= {spi_active_sys[0], spi_active};
+        if (log_addr_toggle_sys[2] != log_addr_toggle_sys[1])
+            log_addr_latched <= log_addr_hold_spi;
     end
+
+    wire log_addr_valid_pulse_sys = log_addr_toggle_sys[2] != log_addr_toggle_sys[1];
     
     // -----------------------------------------------------------
     // TOCTOU Address Redirect Mux
@@ -599,7 +604,7 @@ module top(
         .log_fifo_read_strobe(log_fifo_read_strobe),
 
 
-        .log_addr_valid_sync(log_addr_valid_sys[1]),
+        .log_addr_valid_sync(log_addr_valid_pulse_sys),
         .log_addr_sync(log_addr_latched[23:0]),
         .spi_active_sync(spi_active_sys[1]),
 

--- a/tangprimer25k.sdc
+++ b/tangprimer25k.sdc
@@ -1,0 +1,6 @@
+// Timing constraints for Tang Primer 25K SPI Flash Emulator
+//
+// spi_clk_pin is an external input clock from the SPI master (max 30 MHz).
+// Constraining it here enables the PnR tool to perform timing analysis on
+// all paths in the spi_clk domain and optimize routing accordingly.
+create_clock -name spi_clk -period 33.333 [get_ports {spi_clk_pin}]

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -27,6 +27,7 @@ const BLOCK_SIZE: usize = 16384; // 2048 bursts * 8 bytes
 // ~20ms, well within budget.  Writes are unaffected (data flows
 // host-to-FPGA, SDRAM writes complete in microseconds).
 const UART_READ_BLOCK_SIZE: usize = 4096; // 512 bursts * 8 bytes
+const SDRAM_SIZE_BYTES: u64 = 64 * 1024 * 1024;
 
 const PROTOCOL_VERSION: u8 = 5;
 
@@ -43,9 +44,11 @@ const CMD_LOGCTL: u8 = 0x38; // Enable/disable SPI bus logging capture (protocol
 const CMD_TOCTOU: u8 = 0x39; // TOCTOU trap management (protocol v5+)
 const CMD_LOGPOLL: u8 = 0x3A; // Drain logger ring FIFO (protocol v5+)
 
-// CMD_LOGPOLL response terminator.  Everything the logger emits starts
-// with 0xA1-0xA4, so 0xA0 unambiguously signals end-of-poll.
+// CMD_LOGPOLL framing. Raw log bytes equal to 0xA0 or 0xA5 are escaped
+// by the FPGA as 0xA5 0x00 or 0xA5 0x05 respectively, leaving 0xA0 as an
+// unambiguous end-of-poll marker.
 const LOG_POLL_TERMINATOR: u8 = 0xA0;
+const LOG_POLL_ESCAPE: u8 = 0xA5;
 
 // TOCTOU sub-commands
 const TOCTOU_SET: u8 = 0x01;
@@ -272,12 +275,12 @@ impl Transport for Ft245Transport {
 // FT245 transport -- rs-ftdi backend (pure Rust, nusb)
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "ftdi")]
+#[cfg(all(feature = "ftdi", not(feature = "d2xx")))]
 struct Ft245Transport {
     dev: ftdi::FtdiDevice,
 }
 
-#[cfg(feature = "ftdi")]
+#[cfg(all(feature = "ftdi", not(feature = "d2xx")))]
 impl Ft245Transport {
     fn open(serial: Option<&str>) -> Result<Self> {
         // Open the FT2232H Channel A.  The EEPROM must already be
@@ -337,7 +340,7 @@ impl Ft245Transport {
     }
 }
 
-#[cfg(feature = "ftdi")]
+#[cfg(all(feature = "ftdi", not(feature = "d2xx")))]
 impl Transport for Ft245Transport {
     fn write_all(&mut self, data: &[u8]) -> Result<()> {
         self.dev.write_all(data).map_err(|e| anyhow!(e))?;
@@ -373,6 +376,22 @@ struct FlashDevice {
     read_block_size: usize,
 }
 
+fn validate_sdram_range(address: u32, length: usize, what: &str) -> Result<()> {
+    let end = (address as u64)
+        .checked_add(length as u64)
+        .with_context(|| format!("{} range overflows address arithmetic", what))?;
+    if end > SDRAM_SIZE_BYTES {
+        bail!(
+            "{} range 0x{:08x}..0x{:08x} exceeds {} MiB SDRAM backing store",
+            what,
+            address,
+            end,
+            SDRAM_SIZE_BYTES / (1024 * 1024)
+        );
+    }
+    Ok(())
+}
+
 impl FlashDevice {
     fn open_serial(port_name: &str) -> Result<Self> {
         Ok(Self {
@@ -391,9 +410,7 @@ impl FlashDevice {
 
     fn get_version(&mut self) -> Result<u8> {
         self.transport.write_all(&[CMD_VERSION])?;
-        let mut buf = [0u8; 1];
-        self.transport.read_exact(&mut buf)?;
-        Ok(buf[0])
+        self.read_ack("version")
     }
 
     /// Read one response byte, transparently skipping stray 0x00 bytes
@@ -526,6 +543,8 @@ impl FlashDevice {
             bail!("Length must be a multiple of 8");
         }
 
+        validate_sdram_range(address, length, "read")?;
+
         let addr_units = address / 8;
         let len_units = length / 8;
 
@@ -556,6 +575,8 @@ impl FlashDevice {
         if data.len() % 8 != 0 {
             bail!("Data length must be a multiple of 8");
         }
+
+        validate_sdram_range(address, data.len(), "write")?;
 
         let addr_units = address / 8;
         let len_units = data.len() / 8;
@@ -643,6 +664,13 @@ impl FlashDevice {
         if sfdp_len > 128 {
             bail!("SFDP table too large: {} bytes (max 128)", sfdp_len);
         }
+        if chip.total_size as u64 > SDRAM_SIZE_BYTES {
+            bail!(
+                "chip size {} bytes exceeds {} MiB SDRAM backing store",
+                chip.total_size,
+                SDRAM_SIZE_BYTES / (1024 * 1024)
+            );
+        }
 
         // Build the full command in one buffer to avoid USB transfer gaps
         let mut buf = Vec::with_capacity(9 + sfdp_len);
@@ -671,8 +699,8 @@ impl FlashDevice {
     /// the target flash and silencing it so NORbert can respond instead.
     /// Mutually exclusive with quad I/O.
     ///
-    /// Protocol (CMD_HOLDCTL = 0x34):
-    ///   Byte 0: 0x34
+    /// Protocol (CMD_HOLDCTL = 0x37):
+    ///   Byte 0: 0x37
     ///   Byte 1: 0x01 = assert hold, 0x00 = release hold
     ///   Response: 0x01 on success.
     fn set_hold(&mut self, enable: bool) -> Result<()> {
@@ -720,23 +748,34 @@ impl FlashDevice {
     ///
     /// Protocol (CMD_LOGPOLL = 0x3A):
     ///   Host:  0x3A
-    ///   FPGA:  [log byte]* 0xA0
-    /// The response ends when 0xA0 is seen.  The FPGA caps each poll at
-    /// 255 data bytes; any remaining log data is picked up on the next
-    /// poll.
+    ///   FPGA:  [escaped log byte]* 0xA0
+    /// The response ends when an unescaped 0xA0 is seen.  Raw payload
+    /// 0xA0 is encoded as 0xA5 0x00; raw 0xA5 is encoded as 0xA5 0x05.
+    /// The FPGA caps each poll at 255 raw data bytes; any remaining log
+    /// data is picked up on the next poll.
     fn log_poll(&mut self) -> Result<Vec<u8>> {
         self.transport.write_all(&[CMD_LOGPOLL])?;
         let mut out = Vec::with_capacity(256);
         loop {
             let mut byte = [0u8; 1];
             self.transport.read_exact(&mut byte)?;
-            if byte[0] == LOG_POLL_TERMINATOR {
-                return Ok(out);
+            match byte[0] {
+                LOG_POLL_TERMINATOR => return Ok(out),
+                LOG_POLL_ESCAPE => {
+                    let mut code = [0u8; 1];
+                    self.transport.read_exact(&mut code)?;
+                    match code[0] {
+                        0x00 => out.push(LOG_POLL_TERMINATOR),
+                        0x05 => out.push(LOG_POLL_ESCAPE),
+                        other => bail!("LOGPOLL: invalid escape code 0x{:02x}", other),
+                    }
+                }
+                b => out.push(b),
             }
-            out.push(byte[0]);
             // Safety net: cap log poll responses so a misbehaving
             // device cannot lock the tool in this loop.  Should never
-            // trip given the FPGA's LOG_POLL_MAX = 255 + terminator.
+            // trip given the FPGA's LOG_POLL_MAX = 255 raw bytes plus
+            // escapes and terminator.
             if out.len() > 1024 {
                 bail!(
                     "log poll overran 1024 bytes without terminator; last byte 0x{:02x}",
@@ -762,10 +801,9 @@ impl FlashDevice {
             (replace & 0xFF) as u8,
         ];
         self.transport.write_all(&buf)?;
-        let mut resp = [0u8; 1];
-        self.transport.read_exact(&mut resp)?;
-        if resp[0] != 0x01 {
-            bail!("TOCTOU set failed: unexpected response 0x{:02x}", resp[0]);
+        let resp = self.read_ack("TOCTOU set")?;
+        if resp != 0x01 {
+            bail!("TOCTOU set failed: unexpected response 0x{:02x}", resp);
         }
         Ok(())
     }
@@ -773,10 +811,9 @@ impl FlashDevice {
     fn toctou_arm(&mut self, index: u8) -> Result<()> {
         self.transport
             .write_all(&[CMD_TOCTOU, TOCTOU_ARM, index & 0x03])?;
-        let mut resp = [0u8; 1];
-        self.transport.read_exact(&mut resp)?;
-        if resp[0] != 0x01 {
-            bail!("TOCTOU arm failed: unexpected response 0x{:02x}", resp[0]);
+        let resp = self.read_ack("TOCTOU arm")?;
+        if resp != 0x01 {
+            bail!("TOCTOU arm failed: unexpected response 0x{:02x}", resp);
         }
         Ok(())
     }
@@ -784,13 +821,9 @@ impl FlashDevice {
     fn toctou_disarm(&mut self, index: u8) -> Result<()> {
         self.transport
             .write_all(&[CMD_TOCTOU, TOCTOU_DISARM, index & 0x03])?;
-        let mut resp = [0u8; 1];
-        self.transport.read_exact(&mut resp)?;
-        if resp[0] != 0x01 {
-            bail!(
-                "TOCTOU disarm failed: unexpected response 0x{:02x}",
-                resp[0]
-            );
+        let resp = self.read_ack("TOCTOU disarm")?;
+        if resp != 0x01 {
+            bail!("TOCTOU disarm failed: unexpected response 0x{:02x}", resp);
         }
         Ok(())
     }
@@ -798,28 +831,25 @@ impl FlashDevice {
     fn toctou_reset(&mut self, index: u8) -> Result<()> {
         self.transport
             .write_all(&[CMD_TOCTOU, TOCTOU_RESET, index & 0x03])?;
-        let mut resp = [0u8; 1];
-        self.transport.read_exact(&mut resp)?;
-        if resp[0] != 0x01 {
-            bail!("TOCTOU reset failed: unexpected response 0x{:02x}", resp[0]);
+        let resp = self.read_ack("TOCTOU reset")?;
+        if resp != 0x01 {
+            bail!("TOCTOU reset failed: unexpected response 0x{:02x}", resp);
         }
         Ok(())
     }
 
     fn toctou_reset_all(&mut self) -> Result<()> {
         self.transport.write_all(&[CMD_TOCTOU, TOCTOU_RESET_ALL])?;
-        let mut resp = [0u8; 1];
-        self.transport.read_exact(&mut resp)?;
-        if resp[0] != 0x01 {
+        let resp = self.read_ack("TOCTOU reset-all")?;
+        if resp != 0x01 {
             bail!(
                 "TOCTOU reset-all failed: unexpected response 0x{:02x}",
-                resp[0]
+                resp
             );
         }
         Ok(())
     }
 
-    #[allow(dead_code)]
     fn write(&mut self, address: u32, data: &[u8]) -> Result<()> {
         if address % 8 != 0 {
             bail!("Address must be 8-byte aligned for writes");
@@ -1050,7 +1080,7 @@ fn open_device(cli: &Cli) -> Result<FlashDevice> {
             return FlashDevice::open_ft245(cli.ft_serial.as_deref());
         }
         #[cfg(not(any(feature = "d2xx", feature = "ftdi")))]
-        bail!("--ft245 requires the 'd2xx' or 'ftdi' feature (build with --features d2xx or --features ftdi)");
+        bail!("--ft245 requires the 'd2xx' or 'ftdi' feature (build with --features d2xx, --features ftdi, or --no-default-features --features d2xx)");
     }
     FlashDevice::open_serial(&cli.port)
 }
@@ -1161,7 +1191,7 @@ fn cmd_write(cli: &Cli, address: u32, data_hex: &str) -> Result<()> {
         padded.resize((padded.len() + 7) / 8 * 8, 0xFF);
     }
 
-    device.with_emulation_stopped(|device| device.write_block(address, &padded))?;
+    device.with_emulation_stopped(|device| device.write(address, &padded))?;
     println!("Wrote {} bytes to 0x{:08x}", data.len(), address);
     Ok(())
 }
@@ -1392,7 +1422,7 @@ fn cmd_probe(cli: &Cli) -> Result<()> {
 
     // Test bytes: mix of valid commands, diagnostics, and non-commands
     let probes: Vec<(u8, &str, Option<u8>)> = vec![
-        (0x30, "CMD_VERSION", Some(0x02)),
+        (0x30, "CMD_VERSION", Some(PROTOCOL_VERSION)),
         (0x00, "NOP / zero", None),
         (0x55, "non-command 0x55", None),
         (0xAA, "non-command 0xAA", None),
@@ -1545,7 +1575,7 @@ fn cmd_probe(cli: &Cli) -> Result<()> {
 
     // Test bytes
     let probes: Vec<(u8, &str, Option<u8>)> = vec![
-        (0x30, "CMD_VERSION", Some(0x02)),
+        (0x30, "CMD_VERSION", Some(PROTOCOL_VERSION)),
         (0x00, "NOP / zero", None),
         (0x55, "non-command 0x55", None),
         (0xAA, "non-command 0xAA", None),
@@ -1753,21 +1783,29 @@ fn spi_opcode_name(opcode: u8) -> &'static str {
         0x06 => "WRITE_ENABLE",
         0x0B => "FAST_READ",
         0x0C => "FAST_READ_4B",
+        0x12 => "PAGE_PROGRAM_4B",
         0x13 => "READ_4B",
         0x20 => "SECTOR_ERASE_4K",
+        0x21 => "SECTOR_ERASE_4K_4B",
         0x35 => "READ_STATUS2",
         0x3B => "DUAL_READ",
+        0x3C => "DUAL_READ_4B",
         0x52 => "BLOCK_ERASE_32K",
+        0x5C => "BLOCK_ERASE_32K_4B",
         0x5A => "READ_SFDP",
         0x60 => "CHIP_ERASE",
         0x6B => "QUAD_READ",
+        0x6C => "QUAD_READ_4B",
         0x9E | 0x9F => "READ_JEDEC_ID",
         0xB7 => "4BYTE_ENABLE",
         0xBB => "DUAL_IO_READ",
+        0xBC => "DUAL_IO_READ_4B",
         0xC7 => "CHIP_ERASE",
         0xD8 => "BLOCK_ERASE_64K",
+        0xDC => "BLOCK_ERASE_64K_4B",
         0xE9 => "4BYTE_DISABLE",
         0xEB => "QUAD_IO_READ",
+        0xEC => "QUAD_IO_READ_4B",
         _ => "UNKNOWN",
     }
 }
@@ -1775,7 +1813,7 @@ fn spi_opcode_name(opcode: u8) -> &'static str {
 fn is_read_opcode(opcode: u8) -> bool {
     matches!(
         opcode,
-        0x03 | 0x0B | 0x0C | 0x13 | 0x3B | 0x5A | 0x6B | 0xBB | 0xEB
+        0x03 | 0x0B | 0x0C | 0x13 | 0x3B | 0x3C | 0x5A | 0x6B | 0x6C | 0xBB | 0xBC | 0xEB | 0xEC
     )
 }
 

--- a/tool/src/sfdp.rs
+++ b/tool/src/sfdp.rs
@@ -58,9 +58,9 @@ fn write_sfdp_header(table: &mut [u8; SFDP_TABLE_SIZE]) {
 fn write_param_header(table: &mut [u8; SFDP_TABLE_SIZE]) {
     table[0x08] = 0x00; // Parameter ID LSB (BFPT = 0xFF00)
     table[0x09] = 0x06; // Parameter minor revision
-    table[0x0A] = BFPT_DWORDS; // Length in DWORDs
-    table[0x0B] = 0x01; // Parameter major revision
-                        // Table pointer (24-bit little-endian)
+    table[0x0A] = 0x01; // Parameter major revision
+    table[0x0B] = BFPT_DWORDS; // Length in DWORDs
+                               // Table pointer (24-bit little-endian)
     table[0x0C] = BFPT_OFFSET as u8;
     table[0x0D] = (BFPT_OFFSET >> 8) as u8;
     table[0x0E] = (BFPT_OFFSET >> 16) as u8;


### PR DESCRIPTION
fix: harden SPI NOR emulation and host protocol handling

Several flashprog flows exposed places where the emulator relied on
full-page writes, sticky cross-domain status levels, or a smaller set of
SPI opcodes than large NOR parts actually use.

Tighten the RTL behavior:

  * Page program now uses the same read-modify-write path as AAI, keyed
    by per-byte valid flags.  Short page programs preserve untouched
    bytes, and programmed bytes are merged as old & new to model NOR
    flash semantics.

  * write_done is a completion toggle synchronized into the SPI clock
    domain.  This avoids losing a completion while SCK is idle and avoids
    clearing BUSY from a stale high level on the next write.

  * Native four-byte read/program/erase opcodes are handled, including
    the 0xec quad-I/O read path that flashprog selects for W25Q512JV.
    EN4B/EX4B no longer require WEL, matching the flashprog model for
    FEATURE_4BA_ENTER parts.

  * The debounced CS path is kept for spi_trx so short SSO/ground-bounce
    glitches do not reset the SPI state machine mid-transaction.  The
    top-level output enables are gated with raw CS so the FPGA still
    releases the SPI bus immediately when the real CS pin deasserts.

  * TOCTOU address capture and the SDRAM fast-path address now latch
    cross-domain buses before use.

  * LOGPOLL byte-stuffs raw 0xa0/0xa5 payload bytes so the terminator
    cannot collide with address/opcode/count data.

Tighten the host tool in step with the RTL:

  * Decode escaped LOGPOLL data and name the native 4-byte opcodes in
    monitor output.

  * Make D2XX and rs-ftdi FT245 backends mutually exclusive when users
    build with `--features d2xx`.

  * Route version/TOCTOU one-byte replies through the ACK reader, reject
    accesses beyond the 64 MiB SDRAM backing store, fix generated SFDP
    BFPT header ordering, and make the debug write command use the
    chunking helper.

Also add the SDC file to the Gowin build so the checked-in SPI clock
constraint is actually used during place-and-route.

Verified with:

  * cargo check
  * cargo check --features d2xx
  * cargo check --no-default-features --features d2xx
  * cargo check --no-default-features
  * yosys read_verilog over all RTL sources
  * make build && make prog
  * flashprog partial-page layout write/readback on W25Q64FV emulation
  * W25Q64FV reads through FT4222 at 1, 10, and 30 MHz in single,
    dual, and quad modes; monitor confirmed 0x03, 0xbb, and 0xeb
    read paths respectively
  * temporary 64 MiB W25Q512JV and MX25L51245G flashprog probes,
    top-page writes, and full 64 MiB readback checks

Generated with AI assistance; hardware tests and final review were run
locally before committing.

Signed-off-by: Arthur Heymans <arthur@aheymans.xyz>
