### PR TITLE
Add a browser interface for NORbert

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg=web_sys_unstable_apis"]

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,55 @@
+name: Deploy web to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+        with:
+          workspaces: tool -> target
+          key: wasm32-unknown-unknown
+
+      - uses: taiki-e/install-action@fcf5432d9f50d67e37ee6e29bdb7a224ff67b4a7 # v2
+        with:
+          tool: trunk
+
+      - name: Build Web UI
+        run: trunk build --release --public-url /NORbert/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -32,6 +32,18 @@ jobs:
         with:
           tool: trunk
 
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install --yes libudev-dev pkg-config
+
+      - name: Test native tool
+        run: cargo test --manifest-path tool/Cargo.toml
+
+      - name: Lint native tool
+        run: cargo clippy --manifest-path tool/Cargo.toml --all-targets -- --deny warnings
+
+      - name: Lint WebAssembly tool
+        run: cargo clippy --manifest-path tool/Cargo.toml --target wasm32-unknown-unknown --no-default-features --features wasm -- --deny warnings
+
       - name: Build Web UI
         run: trunk build --release --public-url /NORbert/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 impl/
 tool/target/
+dist/

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CST_FILE = tangprimer25k.cst
 # Gowin IDE output
 BITSTREAM = impl/pnr/spi_flash.fs
 
-.PHONY: all build lint prog flash clean tool ftdi-setup help
+.PHONY: all build lint prog flash clean tool webui webui-serve ftdi-setup help
 
 all: build
 
@@ -61,6 +61,13 @@ tool:
 	cargo build --release --manifest-path tool/Cargo.toml
 	@echo "Tool built: tool/target/release/spi-flash-tool"
 
+# Build and serve the browser UI with Trunk.
+webui:
+	trunk build --release
+
+webui-serve:
+	trunk serve
+
 help:
 	@echo "Tang Primer 25K SPI Flash Emulator"
 	@echo ""
@@ -68,7 +75,8 @@ help:
 	@echo "  make prog    - Program FPGA (volatile)"
 	@echo "  make flash   - Program to flash (persistent)"
 	@echo "  make lint    - Lint Verilog with yosys"
-	@echo "  make tool    - Build spi-flash-tool (rs-ftdi backend, default)"
-
+	@echo "  make tool    - Build spi-flash-tool (ftdi-nusb backend, default)"
+	@echo "  make webui  - Build the WebUSB/Web Serial browser UI"
+	@echo "  make webui-serve - Build and serve the UI at http://localhost:8081"
 	@echo "  make ftdi-setup - Program FT2232H EEPROM for 245 FIFO"
 	@echo "  make clean   - Clean build artifacts"

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ ftdi-setup:
 	@echo ""
 	@echo "EEPROM programmed. Unplug and replug the FT2232H now."
 
-# Build the spi-flash-tool (default: rs-ftdi backend, pure Rust)
+# Build the spi-flash-tool (default: ftdi-nusb backend, pure Rust)
 tool:
 	cargo build --release --manifest-path tool/Cargo.toml
 	@echo "Tool built: tool/target/release/spi-flash-tool"

--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ If you have [Nix](https://nixos.org/) with flakes enabled, just enter the dev sh
 nix develop    # or let direnv handle it
 ```
 
-This provides the Gowin IDE (Education Edition), yosys, openFPGALoader, verilator, and the Rust toolchain.
+This provides the Gowin IDE (Education Edition), yosys, openFPGALoader, verilator, the Rust toolchain with the WebAssembly target, `wasm-bindgen-cli`, and Trunk for building and serving the Web UI.
 
 Without Nix, you'll need:
+
 - [Gowin IDE Education Edition](https://www.gowinsemi.com/en/support/home/) v1.9.11.03 (`gw_sh` on PATH)
 - [openFPGALoader](https://github.com/trabucayre/openFPGALoader)
 - [yosys](https://github.com/YosysHQ/yosys) (optional, for linting)
@@ -75,6 +76,50 @@ make tool
 ```
 
 This builds `spi-flash-tool` at `tool/target/release/spi-flash-tool`.
+
+The tool also exposes a WebAssembly library for browser frontends.
+`WebFlashDevice.requestUsb()` opens the FT2232H FT245 interface through WebUSB,
+while `WebFlashDevice.requestSerial()` opens the dock's 2 Mbaud UART through Web
+Serial. The returned device provides the same protocol operations for either
+transport, automatically stops and restores SPI emulation around RAM and
+configuration changes, and applies I/O timeouts. Browser
+frontends should prefer `read_chunks` and `write_file` for bounded-memory
+transfers with progress and cancellation callbacks. Check the WASM build with:
+
+```
+rustup target add wasm32-unknown-unknown
+cargo check --manifest-path tool/Cargo.toml \
+  --target wasm32-unknown-unknown --no-default-features --features wasm --lib
+```
+
+`WebFlashDevice.requestUsb()` and `WebFlashDevice.requestSerial()` must be called
+from a browser user gesture so the browser can display its device
+permission picker. Web Serial currently requires a Chromium-based browser and,
+like WebUSB, a secure context (HTTPS or localhost).
+
+A ready-to-use frontend is in `web/`. From the Nix development shell, build and
+serve it with Trunk:
+
+```sh
+make webui-serve
+```
+
+Without Nix, first install the WebAssembly target, Trunk, and the
+`wasm-bindgen-cli` version recorded in `tool/Cargo.lock`:
+
+```sh
+rustup target add wasm32-unknown-unknown
+cargo install trunk
+cargo install wasm-bindgen-cli --version 0.2.127
+make webui-serve
+```
+
+Open <http://localhost:8081> and choose either **Connect FT245 (WebUSB)** or
+**Connect UART (Web Serial)**. The UI uses the compiled-in rflasher database to
+search for and configure the emulated chip, and provides emulation control,
+verified SDRAM uploads and downloads, target-flash `#HOLD`, decoded live SPI
+activity monitoring, and full TOCTOU trap configuration. Browser device APIs
+are unavailable when opening `web/index.html` directly as a `file://` URL.
 
 ## Usage
 
@@ -264,7 +309,7 @@ while the parser is idle, and routes the response back to the same port.
 
 | Opcode | Name       | Args                                                | Reply                            |
 |--------|------------|-----------------------------------------------------|----------------------------------|
-| `0x30` | VERSION    | none                                                | 1 byte (current: `0x04`)         |
+| `0x30` | VERSION    | none                                                | 1 byte (current: `0x05`)         |
 | `0x31` | RAMREAD    | 3-byte burst addr + 2-byte burst count              | `count*8` data bytes             |
 | `0x32` | RAMWRITE   | 3-byte burst addr + 2-byte burst count + data       | `0x01`                           |
 | `0x33` | CHIPCONFIG | JEDEC(3) + flags + erase_bursts(3) + sfdp_len + sfdp| `0x01`                           |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ NORbert exposes the SPI flash interface on the **PMOD J5** connector of the Tang
 | `GND`      | —        | 10          | Ground                             |
 | `VCC`      | —        | 9           | 3.3V Power                         |
 
-*Note: D3 and `#HOLD#` share the physical IO3 pin. Asserting `#HOLD` drives it low to silence a real flash on a shared bus. Consult the `.lpf` constraint file for exact pin assignments.*
+*Note: D3 and `#HOLD#` share the physical IO3 pin. Asserting `#HOLD` drives it low to silence a real flash on a shared bus. Consult `tangprimer25k.cst` for exact pin assignments.*
 
 ## Building
 
@@ -47,7 +47,7 @@ NORbert exposes the SPI flash interface on the **PMOD J5** connector of the Tang
 
 If you have [Nix](https://nixos.org/) with flakes enabled, just enter the dev shell:
 
-```
+```sh
 nix develop    # or let direnv handle it
 ```
 
@@ -63,7 +63,7 @@ Without Nix, you'll need:
 
 ### FPGA bitstream
 
-```
+```sh
 make build                  # synthesize + place & route
 make prog                   # program FPGA (volatile, lost on power cycle)
 make flash                  # program to flash (persistent)
@@ -71,7 +71,7 @@ make flash                  # program to flash (persistent)
 
 ### Host tool
 
-```
+```sh
 make tool
 ```
 
@@ -86,7 +86,7 @@ configuration changes, and applies I/O timeouts. Browser
 frontends should prefer `read_chunks` and `write_file` for bounded-memory
 transfers with progress and cancellation callbacks. Check the WASM build with:
 
-```
+```sh
 rustup target add wasm32-unknown-unknown
 cargo check --manifest-path tool/Cargo.toml \
   --target wasm32-unknown-unknown --no-default-features --features wasm --lib
@@ -125,7 +125,7 @@ are unavailable when opening `web/index.html` directly as a `file://` URL.
 
 Load a firmware image into NORbert's SDRAM, then let your target SPI master read it back as if it were a real flash chip.
 
-```
+```sh
 # Check connection
 spi-flash-tool version
 spi-flash-tool status       # running | stopped
@@ -163,13 +163,13 @@ Use `-p /dev/ttyUSBx` if your device isn't on the default `/dev/ttyUSB0`.
 
 `monitor` streams decoded SPI activity from NORbert in real time. It works over either UART or FT245 and is safe to run while the target is actively reading:
 
-```
+```sh
 spi-flash-tool monitor
 ```
 
 Example output while flashprog reads a 4 KB region:
 
-```
+```text
 TXN#   COMMAND            ADDRESS    INFO
 ------------------------------------------------------------
 1      0x9F READ_JEDEC_ID
@@ -185,7 +185,7 @@ The monitor also tracks double-reads of the same (opcode, address) pair and flag
 
 Four independent trap entries redirect matching reads to a different SDRAM location on the second (and subsequent) access. The first matching read is let through unchanged -- it arms the trap. The first 8 bytes of the redirected read come from the original address because the SDRAM prefetch pipeline fires before the trap check completes; bytes 8+ come from the replacement.
 
-```
+```sh
 # Configure: any read in 0x001000-0x001FFF gets redirected to 0x101000-0x101FFF
 spi-flash-tool toctou set 1 0x001000 0xFFF000 0x101000
 spi-flash-tool toctou arm 1
@@ -210,7 +210,7 @@ When NORbert shares a SPI bus with a real flash chip, `hold on` drives IO3 low c
 
 For much faster bulk transfers (~5 MB/s vs ~200 KB/s over UART), connect an FT2232H module and use `--ft245`:
 
-```
+```sh
 # List connected FT2232H devices
 spi-flash-tool ft-list
 
@@ -283,7 +283,7 @@ commands (0xBB, 0xEB) use fewer SPI clocks for the address, leaving less headroo
 
 ## Project structure
 
-```
+```text
 src/
   top.v        Top-level module, clock/reset, bus wiring, TOCTOU address mux
   spi_trx.v    SPI flash transceiver (command decoder + data path)

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,0 +1,12 @@
+[build]
+target = "web/index.html"
+dist = "dist"
+
+[watch]
+watch = ["tool/src", "tool/Cargo.toml", "tool/Cargo.lock", "web"]
+ignore = ["tool/target", "dist"]
+
+[serve]
+addresses = ["127.0.0.1"]
+port = 8081
+open = false

--- a/flake.lock
+++ b/flake.lock
@@ -77,7 +77,28 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "gowin-eda": "gowin-eda",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787713867,
+        "narHash": "sha256-ZRYTEvDb8QZLCHRoMyIZle9V3Bvw905m0teeo1RvI7M=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "494680f9ffa2b4bf9f2df0f442c7096e44adfa00",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,10 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     gowin-eda = {
       url = "github:Blue-Berry/gowin-eda.nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -15,6 +19,7 @@
       self,
       nixpkgs,
       flake-utils,
+      rust-overlay,
       gowin-eda,
     }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ] (
@@ -22,11 +27,34 @@
       let
         pkgs = import nixpkgs {
           inherit system;
+          overlays = [ (import rust-overlay) ];
           config.allowUnfree = true;
+        };
+
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [
+            "rust-src"
+            "rust-analyzer"
+            "rustfmt"
+            "clippy"
+          ];
+          targets = [ "wasm32-unknown-unknown" ];
         };
 
         # Gowin EDA Education edition from gowin-eda.nix
         gowinEda = gowin-eda.packages.${system}.default;
+
+        # Keep the CLI exactly in sync with the wasm-bindgen crate in
+        # tool/Cargo.lock. Mismatched versions cannot process its Wasm output.
+        wasmBindgenCli = pkgs.runCommand "wasm-bindgen-cli-0.2.127" { } ''
+          mkdir -p $out/bin
+          install -m755 ${
+            pkgs.fetchzip {
+              url = "https://github.com/wasm-bindgen/wasm-bindgen/releases/download/0.2.127/wasm-bindgen-0.2.127-x86_64-unknown-linux-musl.tar.gz";
+              hash = "sha256-X6rT4cwbJaCX/oyWX8NDN4u6uUS/Io5axRy8nvUQi7I=";
+            }
+          }/{wasm-bindgen,wasm-bindgen-test-runner,wasm2es6js} $out/bin/
+        '';
 
         # Create a gw_sh wrapper using the same FHS approach
         gowinSrc = pkgs.stdenv.mkDerivation {
@@ -146,11 +174,10 @@
             # FTDI EEPROM programming (FT2232H async 245 setup)
             libftdi1
 
-            # Rust toolchain for spi-flash-tool
-            cargo
-            rustc
-            rustfmt
-            clippy
+            # Rust and WebAssembly toolchain for spi-flash-tool and the Web UI
+            rustToolchain
+            trunk
+            wasmBindgenCli
             pkg-config
             udev
           ];
@@ -166,7 +193,9 @@
             echo "  verilator        - Verilog simulation"
             echo "  gtkwave          - Waveform viewer"
             echo "  ftdi_eeprom      - FT2232H EEPROM programmer"
-            echo "  cargo            - Rust build tool"
+            echo "  cargo            - Rust build tool (including wasm32 target support)"
+            echo "  wasm-bindgen      - Generate browser bindings for the Web UI"
+            echo "  trunk             - Build and serve the Web UI"
             echo ""
             echo "Build commands:"
             echo "  make build       - Synthesize with gw_sh (CLI)"
@@ -174,6 +203,7 @@
             echo "  make flash       - Program to flash (persistent)"
             echo "  make lint        - Lint with yosys"
             echo "  make tool        - Build spi-flash-tool"
+            echo "  make webui-serve - Build and serve the browser UI"
             echo ""
           '';
         };

--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -59,6 +59,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,10 +242,23 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76e3391b248c458fce989a635a3afdd2297764e17645172c1d5fabc1779231de"
 dependencies = [
+ "js-sys",
  "log",
  "maybe-async",
  "nusb",
  "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -242,6 +266,17 @@ name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
 
 [[package]]
 name = "futures-task"
@@ -256,9 +291,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -653,14 +701,21 @@ name = "spi-flash-tool"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "ctrlc",
  "ftdi-nusb",
+ "futures-util",
+ "gloo-timers",
  "indicatif",
+ "js-sys",
  "maybe-async",
  "nusb",
  "rflasher-chips",
  "serialport",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
  "zerocopy",
 ]
 

--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -114,9 +114,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -143,7 +143,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -239,21 +239,21 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -327,9 +327,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -370,9 +370,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "mach2"
@@ -483,15 +483,15 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "prettyplease"
@@ -620,14 +620,14 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "serialport"
-version = "4.9.0"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d91116f97173694f1642263b2ff837f80d933aa837e2314969f6728f661df3"
+checksum = "6a2f4ac56b5d3af3c40fbbee17be96d532cba02fa5853926aacdb77d926272ab"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
@@ -657,6 +657,8 @@ dependencies = [
  "ctrlc",
  "ftdi-nusb",
  "indicatif",
+ "maybe-async",
+ "nusb",
  "rflasher-chips",
  "serialport",
  "zerocopy",
@@ -687,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -698,22 +700,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -751,9 +753,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -764,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -774,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -784,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -797,18 +799,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -3,6 +3,77 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
+name = "accesskit"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b76d84ee70e30a4a7e39ab9018e2b17a6a09e31084176cc7c0b2dec036ba45"
+dependencies = [
+ "enumn",
+ "serde",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "android-activity"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
+dependencies = [
+ "android-properties",
+ "bitflags 2.13.1",
+ "cc",
+ "jni",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +130,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
 name = "async-trait"
 version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +162,18 @@ dependencies = [
  "quote",
  "syn 3.0.4",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -92,11 +198,20 @@ dependencies = [
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -106,10 +221,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.13.1",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
+dependencies = [
+ "bitflags 2.13.1",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "tracing",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop 0.13.0",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
+dependencies = [
+ "calloop 0.14.4",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -122,6 +332,15 @@ name = "cfg_aliases"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "cgl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "clap"
@@ -164,10 +383,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "console"
@@ -179,6 +426,26 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -198,6 +465,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,15 +515,176 @@ dependencies = [
 ]
 
 [[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.1",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dpi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "ecolor"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775cfde491852059e386c4e1deb4aef381c617dc364184c6f6afee99b87c402b"
+dependencies = [
+ "bytemuck",
+ "emath",
+ "serde",
+]
+
+[[package]]
+name = "eframe"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ac2645a9bf4826eb4e91488b1f17b8eaddeef09396706b2f14066461338e24f"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "egui-winit",
+ "egui_glow",
+ "glow",
+ "glutin",
+ "glutin-winit",
+ "home",
+ "image",
+ "js-sys",
+ "log",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "parking_lot",
+ "percent-encoding",
+ "raw-window-handle",
+ "ron",
+ "serde",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "web-time",
+ "winapi",
+ "windows-sys 0.52.0",
+ "winit",
+]
+
+[[package]]
+name = "egui"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53eafabcce0cb2325a59a98736efe0bf060585b437763f8c476957fb274bb974"
+dependencies = [
+ "accesskit",
+ "ahash",
+ "emath",
+ "epaint",
+ "log",
+ "nohash-hasher",
+ "ron",
+ "serde",
+]
+
+[[package]]
+name = "egui-winit"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9c430f4f816340e8e8c1b20eec274186b1be6bc4c7dfc467ed50d57abc36c6"
+dependencies = [
+ "ahash",
+ "arboard",
+ "egui",
+ "log",
+ "raw-window-handle",
+ "serde",
+ "smithay-clipboard",
+ "web-time",
+ "webbrowser",
+ "winit",
+]
+
+[[package]]
+name = "egui_glow"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e39bccc683cd43adab530d8f21a13eb91e80de10bcc38c3f1c16601b6f62b26"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "egui",
+ "glow",
+ "log",
+ "memoffset",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "emath"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1fe0049ce51d0fb414d029e668dd72eb30bc2b739bf34296ed97bd33df544f3"
+dependencies = [
+ "bytemuck",
+ "serde",
 ]
 
 [[package]]
@@ -225,6 +692,47 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "epaint"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a32af8da821bd4f43f2c137e295459ee2e1661d87ca8779dfa0eaf45d870e20f"
+dependencies = [
+ "ab_glyph",
+ "ahash",
+ "bytemuck",
+ "ecolor",
+ "emath",
+ "epaint_default_fonts",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "serde",
+]
+
+[[package]]
+name = "epaint_default_fonts"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "483440db0b7993cf77a20314f08311dbe95675092405518c0677aa08c151a3ea"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -237,6 +745,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "ftdi-nusb"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,7 +821,7 @@ dependencies = [
  "log",
  "maybe-async",
  "nusb",
- "thiserror",
+ "thiserror 2.0.20",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -298,6 +873,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +929,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "glow"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51fa363f025f5c111e03f13eda21162faeacb6911fe8caa0c0349f9cf0c4483"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg_aliases",
+ "cgl",
+ "dispatch2",
+ "glutin_egl_sys",
+ "glutin_glx_sys",
+ "glutin_wgl_sys",
+ "libloading",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "once_cell",
+ "raw-window-handle",
+ "wayland-sys",
+ "windows-sys 0.52.0",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin-winit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
+dependencies = [
+ "cfg_aliases",
+ "glutin",
+ "raw-window-handle",
+ "winit",
+]
+
+[[package]]
+name = "glutin_egl_sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4680ba6195f424febdc3ba46e7a42a0e58743f2edb115297b86d7f8ecc02d2"
+dependencies = [
+ "gl_generator",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "glutin_glx_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7bb2938045a88b612499fbcba375a77198e01306f52272e692f8c1f3751185"
+dependencies = [
+ "gl_generator",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +1014,12 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -333,6 +1036,148 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "indicatif"
@@ -374,6 +1219,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.20",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,10 +1298,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "plain",
+ "redox_syscall 0.9.3",
+]
 
 [[package]]
 name = "libudev"
@@ -412,9 +1359,36 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -452,6 +1426,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.13.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,25 +1523,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "nusb"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18ef13beb3b3a8fc16fd7aea912ebd3d45dde00a9a5b968d0742297468065845"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "futures-core",
  "io-kit-sys 0.5.0",
  "js-sys",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "log",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
 ]
 
 [[package]]
@@ -506,10 +1607,250 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.1",
+ "dispatch2",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.13.1",
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-contacts",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "dispatch",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+ "objc2-link-presentation",
+ "objc2-quartz-core",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+]
 
 [[package]]
 name = "once_cell"
@@ -524,6 +1865,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "orbclient"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
+dependencies = [
+ "libc",
+ "libredox",
+]
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,10 +1945,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "prettyplease"
@@ -552,6 +2003,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,12 +2021,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d678d17679829e73d371e96880897e98fee2ded7acc0a50bdf8af2affa4b2fe5"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -588,7 +2108,7 @@ dependencies = [
  "rflasher-chips-codegen",
  "ron",
  "serde",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -617,6 +2137,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,7 +2167,7 @@ dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -636,10 +2178,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -679,7 +2242,7 @@ checksum = "6a2f4ac56b5d3af3c40fbbee17be96d532cba02fa5853926aacdb77d926272ab"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "io-kit-sys 0.4.1",
  "libudev",
@@ -691,10 +2254,134 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.13.1",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
+dependencies = [
+ "bitflags 2.13.1",
+ "calloop 0.14.4",
+ "calloop-wayland-source 0.4.1",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 1.1.4",
+ "thiserror 2.0.20",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226"
+dependencies = [
+ "libc",
+ "smithay-client-toolkit 0.20.0",
+ "wayland-backend",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "spi-flash-tool"
@@ -703,7 +2390,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "console_error_panic_hook",
  "ctrlc",
+ "eframe",
+ "egui",
  "ftdi-nusb",
  "futures-util",
  "gloo-timers",
@@ -713,6 +2403,7 @@ dependencies = [
  "nusb",
  "rflasher-chips",
  "serialport",
+ "tracing-wasm",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -724,6 +2415,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -754,12 +2451,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.20",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -774,12 +2502,121 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "unescaper"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7285e83a80ce76f5e7bce79fa41f68d78ba62d1003cf27bf748ab24413808cf4"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -787,6 +2624,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -801,10 +2644,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -862,6 +2748,141 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.13.1",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.13.1",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix 1.1.4",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,6 +2903,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
+dependencies = [
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "url",
+ "web-sys",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,7 +2961,25 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -911,14 +2997,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -928,10 +3031,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -940,10 +3055,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -952,10 +3079,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -964,10 +3103,180 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winit"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
+dependencies = [
+ "ahash",
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "bytemuck",
+ "calloop 0.13.0",
+ "cfg_aliases",
+ "concurrent-queue",
+ "core-foundation 0.9.4",
+ "core-graphics",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "libc",
+ "memmap2",
+ "ndk",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit",
+ "orbclient",
+ "percent-encoding",
+ "pin-project",
+ "raw-window-handle",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.44",
+ "smithay-client-toolkit 0.19.2",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "as-raw-xcb-connection",
+ "gethostname",
+ "libc",
+ "libloading",
+ "once_cell",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xcursor"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "163b33ed8786455e2fa5d72f554057ce3f3182425434f756cd39c99839d88e23"
+
+[[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.13.1",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -987,4 +3296,58 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -54,6 +54,8 @@ web-sys = { version = "0.3.104", optional = true, features = [
     "Blob",
     "BlobPropertyBag",
     "Document",
+    "DomTokenList",
+    "Element",
     "File",
     "FileList",
     "HtmlAnchorElement",

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -15,15 +15,67 @@ cli = [
     "dep:ctrlc",
 ]
 ftdi = ["cli", "dep:ftdi-nusb", "ftdi-nusb/std", "dep:nusb"]
-# Reserved for the browser bindings added in the next change.
-wasm = []
+wasm = [
+    "dep:async-trait",
+    "dep:ftdi-nusb",
+    "ftdi-nusb/wasm",
+    "dep:nusb",
+    "dep:wasm-bindgen",
+    "dep:wasm-bindgen-futures",
+    "dep:web-sys",
+    "dep:js-sys",
+    "dep:gloo-timers",
+    "dep:futures-util",
+]
 
 [dependencies]
 anyhow = "1.0"
+async-trait = { version = "0.1.92", optional = true }
 ftdi-nusb = { version = "0.2", default-features = false, optional = true }
 nusb = { version = "0.2.7", optional = true }
 zerocopy = { version = "=0.8.55", features = ["derive"] }
+wasm-bindgen = { version = "0.2.127", optional = true }
+wasm-bindgen-futures = { version = "0.4.77", optional = true }
+js-sys = { version = "0.3.104", optional = true }
+gloo-timers = { version = "0.3", features = ["futures"], optional = true }
+futures-util = { version = "0.3.34", optional = true }
 maybe-async = "0.2"
+web-sys = { version = "0.3.104", optional = true, features = [
+    "Blob",
+    "File",
+    "Navigator",
+    "Window",
+    "WorkerNavigator",
+    "Serial",
+    "SerialOptions",
+    "SerialPort",
+    "ReadableStream",
+    "ReadableStreamDefaultReader",
+    "WritableStream",
+    "WritableStreamDefaultWriter",
+    "Usb",
+    "UsbDevice",
+    "UsbConfiguration",
+    "UsbInterface",
+    "UsbAlternateInterface",
+    "UsbEndpoint",
+    "UsbDirection",
+    "UsbEndpointType",
+    "UsbControlTransferParameters",
+    "UsbDeviceFilter",
+    "UsbDeviceRequestOptions",
+    "UsbInTransferResult",
+    "UsbOutTransferResult",
+    "UsbIsochronousInTransferResult",
+    "UsbIsochronousOutTransferResult",
+    "UsbIsochronousInTransferPacket",
+    "UsbIsochronousOutTransferPacket",
+    "UsbTransferStatus",
+    "UsbRecipient",
+    "UsbRequestType",
+    "UsbConnectionEvent",
+    "UsbConnectionEventInit",
+] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 serialport = { version = "4.9", optional = true }
@@ -31,6 +83,9 @@ clap = { version = "4.6", features = ["derive"], optional = true }
 indicatif = { version = "0.18", optional = true }
 rflasher-chips = { git = "https://github.com/ArthurHeymans/rflasher.git", rev = "1879f3819cb4f3d9fde76447198346cae3e2b40d", features = ["static-chips"], optional = true }
 ctrlc = { version = "3.5", optional = true }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
 
 [[bin]]
 name = "spi-flash-tool"

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -17,6 +17,11 @@ cli = [
 ftdi = ["cli", "dep:ftdi-nusb", "ftdi-nusb/std", "dep:nusb"]
 wasm = [
     "dep:async-trait",
+    "dep:eframe",
+    "dep:egui",
+    "dep:console_error_panic_hook",
+    "dep:tracing-wasm",
+    "dep:rflasher-chips",
     "dep:ftdi-nusb",
     "ftdi-nusb/wasm",
     "dep:nusb",
@@ -39,11 +44,24 @@ wasm-bindgen-futures = { version = "0.4.77", optional = true }
 js-sys = { version = "0.3.104", optional = true }
 gloo-timers = { version = "0.3", features = ["futures"], optional = true }
 futures-util = { version = "0.3.34", optional = true }
+eframe = { version = "0.29", optional = true, default-features = false, features = ["default_fonts", "glow", "persistence"] }
+egui = { version = "0.29", optional = true }
+console_error_panic_hook = { version = "0.1", optional = true }
+tracing-wasm = { version = "0.2", optional = true }
+rflasher-chips = { git = "https://github.com/ArthurHeymans/rflasher.git", rev = "1879f3819cb4f3d9fde76447198346cae3e2b40d", features = ["static-chips"], optional = true }
 maybe-async = "0.2"
 web-sys = { version = "0.3.104", optional = true, features = [
     "Blob",
+    "BlobPropertyBag",
+    "Document",
     "File",
+    "FileList",
+    "HtmlAnchorElement",
+    "HtmlCanvasElement",
+    "HtmlElement",
+    "HtmlInputElement",
     "Navigator",
+    "Url",
     "Window",
     "WorkerNavigator",
     "Serial",
@@ -81,7 +99,6 @@ web-sys = { version = "0.3.104", optional = true, features = [
 serialport = { version = "4.9", optional = true }
 clap = { version = "4.6", features = ["derive"], optional = true }
 indicatif = { version = "0.18", optional = true }
-rflasher-chips = { git = "https://github.com/ArthurHeymans/rflasher.git", rev = "1879f3819cb4f3d9fde76447198346cae3e2b40d", features = ["static-chips"], optional = true }
 ctrlc = { version = "3.5", optional = true }
 
 [lib]
@@ -91,3 +108,8 @@ crate-type = ["cdylib", "rlib"]
 name = "spi-flash-tool"
 path = "src/main.rs"
 required-features = ["cli"]
+
+[[bin]]
+name = "norbert-web"
+path = "src/web_main.rs"
+required-features = ["wasm"]

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -4,12 +4,35 @@ version = "0.2.0"
 edition = "2024"
 description = "Tool for loading data into the Tang Primer 25K SPI Flash Emulator (UART + FT245)"
 
+[features]
+default = ["cli", "ftdi"]
+cli = [
+    "maybe-async/is_sync",
+    "dep:serialport",
+    "dep:clap",
+    "dep:indicatif",
+    "dep:rflasher-chips",
+    "dep:ctrlc",
+]
+ftdi = ["cli", "dep:ftdi-nusb", "ftdi-nusb/std", "dep:nusb"]
+# Reserved for the browser bindings added in the next change.
+wasm = []
+
 [dependencies]
-serialport = "4.9"
-ftdi = { package = "ftdi-nusb", version = "0.2.0" }
-clap = { version = "4.6", features = ["derive"] }
 anyhow = "1.0"
-indicatif = "0.18"
-rflasher-chips = { git = "https://github.com/ArthurHeymans/rflasher.git", rev = "1879f3819cb4f3d9fde76447198346cae3e2b40d", features = ["static-chips"] }
-ctrlc = "3.5"
+ftdi-nusb = { version = "0.2", default-features = false, optional = true }
+nusb = { version = "0.2.7", optional = true }
 zerocopy = { version = "=0.8.55", features = ["derive"] }
+maybe-async = "0.2"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+serialport = { version = "4.9", optional = true }
+clap = { version = "4.6", features = ["derive"], optional = true }
+indicatif = { version = "0.18", optional = true }
+rflasher-chips = { git = "https://github.com/ArthurHeymans/rflasher.git", rev = "1879f3819cb4f3d9fde76447198346cae3e2b40d", features = ["static-chips"], optional = true }
+ctrlc = { version = "3.5", optional = true }
+
+[[bin]]
+name = "spi-flash-tool"
+path = "src/main.rs"
+required-features = ["cli"]

--- a/tool/src/chip.rs
+++ b/tool/src/chip.rs
@@ -8,9 +8,6 @@ pub trait FlashChipExt {
     /// Full 3-byte JEDEC ID: [manufacturer, device_hi, device_lo].
     fn jedec_id_bytes(&self) -> [u8; 3];
 
-    /// Number of 8-byte SDRAM bursts needed to erase the whole chip, minus 1.
-    fn chip_erase_bursts(&self) -> u32;
-
     /// Whether the chip supports 4-byte addressing as advertised by rflasher.
     fn supports_4byte(&self) -> bool;
 
@@ -31,10 +28,6 @@ impl FlashChipExt for FlashChip {
             (self.jedec_device >> 8) as u8,
             self.jedec_device as u8,
         ]
-    }
-
-    fn chip_erase_bursts(&self) -> u32 {
-        (self.total_size / 8).saturating_sub(1)
     }
 
     fn supports_4byte(&self) -> bool {

--- a/tool/src/commands.rs
+++ b/tool/src/commands.rs
@@ -7,9 +7,10 @@ use monitor::cmd_monitor;
 use crate::chip::{self, FlashChipExt};
 use crate::cli::{Cli, HoldState, ToctouAction};
 use crate::device::FlashDevice;
+#[cfg(feature = "ftdi")]
+use crate::device::{FT2232H_PID, FTDI_VID};
 use crate::protocol::*;
 use crate::sfdp;
-use crate::transport::{FT2232H_PID, FTDI_VID};
 use anyhow::{Context, Result, anyhow, bail};
 use indicatif::{ProgressBar, ProgressStyle};
 use std::fs::File;
@@ -20,6 +21,38 @@ use std::time::Duration;
 // ---------------------------------------------------------------------------
 // Command implementations
 // ---------------------------------------------------------------------------
+
+#[derive(Debug, Eq, PartialEq)]
+struct MismatchSample {
+    offset: usize,
+    expected: u8,
+    actual: u8,
+}
+
+fn summarize_mismatches(
+    expected: &[u8],
+    actual: &[u8],
+    sample_limit: usize,
+) -> (u64, Vec<MismatchSample>) {
+    expected
+        .iter()
+        .zip(actual)
+        .enumerate()
+        .filter(|(_, (expected, actual))| expected != actual)
+        .fold(
+            (0u64, Vec::with_capacity(sample_limit)),
+            |(count, mut samples), (offset, (&expected, &actual))| {
+                if samples.len() < sample_limit {
+                    samples.push(MismatchSample {
+                        offset,
+                        expected,
+                        actual,
+                    });
+                }
+                (count.saturating_add(1), samples)
+            },
+        )
+}
 
 fn decode_hex(s: &str) -> Result<Vec<u8>, String> {
     let mut decoded = Vec::with_capacity(s.len() / 2);
@@ -49,8 +82,13 @@ fn decode_hex(s: &str) -> Result<Vec<u8>, String> {
 
 fn open_device(cli: &Cli) -> Result<FlashDevice> {
     if cli.ft245 {
-        eprintln!("Opening FT2232H in async FIFO mode (ftdi-nusb)...");
-        return FlashDevice::open_ft245(cli.ft_serial.as_deref());
+        #[cfg(feature = "ftdi")]
+        {
+            eprintln!("Opening FT2232H in async FIFO mode (ftdi-nusb)...");
+            return FlashDevice::open_ft245(cli.ft_serial.as_deref());
+        }
+        #[cfg(not(feature = "ftdi"))]
+        bail!("--ft245 requires the 'ftdi' feature (build with --features ftdi)");
     }
     FlashDevice::open_serial(&cli.port)
 }
@@ -58,12 +96,9 @@ fn open_device(cli: &Cli) -> Result<FlashDevice> {
 fn cmd_version(cli: &Cli) -> Result<()> {
     let mut device = open_device(cli)?;
     let version = device.get_version()?;
-    println!("Protocol version: {}", version);
+    println!("Protocol version: {version}");
     if version != PROTOCOL_VERSION {
-        eprintln!(
-            "Warning: Expected version {}, got {}",
-            PROTOCOL_VERSION, version
-        );
+        eprintln!("Note: connected to compatible protocol version {version}");
     }
     Ok(())
 }
@@ -71,52 +106,51 @@ fn cmd_version(cli: &Cli) -> Result<()> {
 fn cmd_read(cli: &Cli, address: u32, length: u32, output: Option<PathBuf>) -> Result<()> {
     let mut device = open_device(cli)?;
 
-    device.with_emulation_stopped(|device| {
-        let pb = ProgressBar::new(length as u64);
-        pb.set_style(
-            ProgressStyle::default_bar()
-                .template(
-                    "[{elapsed_precise}] [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})",
-                )?
-                .progress_chars("#>-"),
-        );
+    let pb = ProgressBar::new(length as u64);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template(
+                "[{elapsed_precise}] [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})",
+            )?
+            .progress_chars("#>-"),
+    );
 
-        let result = device.read_with_progress(address, length, |completed| {
-            pb.inc(completed as u64);
-        })?;
-        pb.finish_with_message("done");
+    let result = device.read_with_progress(address, length, |completed| {
+        pb.inc(completed as u64);
+        Ok(())
+    })?;
+    pb.finish_with_message("done");
 
-        match output {
-            Some(path) => {
-                let mut file = File::create(&path)?;
-                file.write_all(&result)?;
-                println!("Wrote {} bytes to {}", result.len(), path.display());
-            }
-            None => {
-                for (i, chunk) in result.chunks(16).enumerate() {
-                    print!("{:08x}: ", address as usize + i * 16);
-                    for b in chunk {
-                        print!("{:02x} ", b);
-                    }
-                    for _ in chunk.len()..16 {
-                        print!("   ");
-                    }
-                    print!(" |");
-                    for b in chunk {
-                        let c = *b as char;
-                        if c.is_ascii_graphic() || c == ' ' {
-                            print!("{}", c);
-                        } else {
-                            print!(".");
-                        }
-                    }
-                    println!("|");
+    match output {
+        Some(path) => {
+            let mut file = File::create(&path)?;
+            file.write_all(&result)?;
+            println!("Wrote {} bytes to {}", result.len(), path.display());
+        }
+        None => {
+            for (i, chunk) in result.chunks(16).enumerate() {
+                print!("{:08x}: ", address as usize + i * 16);
+                for b in chunk {
+                    print!("{:02x} ", b);
                 }
+                for _ in chunk.len()..16 {
+                    print!("   ");
+                }
+                print!(" |");
+                for b in chunk {
+                    let c = *b as char;
+                    if c.is_ascii_graphic() || c == ' ' {
+                        print!("{}", c);
+                    } else {
+                        print!(".");
+                    }
+                }
+                println!("|");
             }
         }
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 fn cmd_write(cli: &Cli, address: u32, data_hex: &str) -> Result<()> {
@@ -128,7 +162,7 @@ fn cmd_write(cli: &Cli, address: u32, data_hex: &str) -> Result<()> {
 
     let mut device = open_device(cli)?;
 
-    device.with_emulation_stopped(|device| device.write(address, &data))?;
+    device.write(address, &data)?;
     println!("Wrote {} bytes to 0x{:08x}", data.len(), address);
     Ok(())
 }
@@ -164,8 +198,9 @@ fn cmd_load(cli: &Cli, file: &PathBuf, address: u32, verify: bool) -> Result<()>
                 )?
                 .progress_chars("#>-"),
         );
-        device.write_with_progress(address, &data, |completed| {
+        device.write_raw_with_progress(address, &data, |completed| {
             progress.inc(completed as u64);
+            Ok(())
         })?;
         progress.finish_with_message("loaded");
         println!("Loaded {} bytes", data.len());
@@ -180,27 +215,29 @@ fn cmd_load(cli: &Cli, file: &PathBuf, address: u32, verify: bool) -> Result<()>
                     )?
                     .progress_chars("#>-"),
             );
-            let readback = device.read_with_progress(address, data.len() as u32, |completed| {
+            let readback = device.read_raw_with_progress(address, data.len() as u32, |completed| {
                 progress.inc(completed as u64);
+                Ok(())
             })?;
             progress.finish_with_message("verified");
-            let mismatches: Vec<_> = data
-                .iter()
-                .zip(&readback)
-                .enumerate()
-                .filter(|(_, (expected, actual))| expected != actual)
-                .collect();
+            let (mismatch_count, mismatch_samples) =
+                summarize_mismatches(&data, &readback, 10);
 
-            for (offset, (expected, actual)) in mismatches.iter().take(10) {
+            for MismatchSample {
+                offset,
+                expected,
+                actual,
+            } in mismatch_samples
+            {
                 eprintln!(
                     "Mismatch at 0x{:08x}: expected 0x{:02x}, got 0x{:02x}",
-                    address + *offset as u32,
+                    address + offset as u32,
                     expected,
                     actual
                 );
             }
-            if !mismatches.is_empty() {
-                bail!("Verification failed: {} byte(s) differ", mismatches.len());
+            if mismatch_count != 0 {
+                bail!("Verification failed: {mismatch_count} byte(s) differ");
             }
             println!("Verification passed!");
         }
@@ -282,7 +319,12 @@ fn cmd_configure(cli: &Cli, chip_db_path: Option<&Path>, chip_name: &str) -> Res
     // Send to FPGA.  Must be stopped while CHIPCONFIG is processed,
     // otherwise spi_trx could read inconsistent cfg_* values mid-transfer.
     let mut device = open_device(cli)?;
-    device.with_emulation_stopped(|device| device.send_chip_config(chip, &sfdp_table))?;
+    device.configure(
+        chip.jedec_id_bytes(),
+        chip.total_size,
+        chip.supports_4byte(),
+        &sfdp_table,
+    )?;
 
     eprintln!("Configuration applied successfully.");
     Ok(())
@@ -428,7 +470,7 @@ pub(crate) fn run(cli: &Cli) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::decode_hex;
+    use super::{MismatchSample, decode_hex, summarize_mismatches};
 
     #[test]
     fn hex_decoder_accepts_ascii_whitespace() {
@@ -442,5 +484,24 @@ mod tests {
     fn hex_decoder_rejects_invalid_and_incomplete_input() {
         assert!(decode_hex("0g").is_err());
         assert!(decode_hex("abc").is_err());
+    }
+
+    #[test]
+    fn verification_counts_all_mismatches_but_bounds_samples() {
+        let expected = vec![0u8; 100];
+        let actual = vec![1u8; 100];
+        let (count, samples) = summarize_mismatches(&expected, &actual, 10);
+
+        assert_eq!(count, 100);
+        assert_eq!(samples.len(), 10);
+        assert_eq!(
+            samples[0],
+            MismatchSample {
+                offset: 0,
+                expected: 0,
+                actual: 1,
+            }
+        );
+        assert_eq!(samples[9].offset, 9);
     }
 }

--- a/tool/src/commands/diagnostics.rs
+++ b/tool/src/commands/diagnostics.rs
@@ -4,27 +4,10 @@ use super::*;
 // Probe command -- ftdi-nusb backend
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "ftdi")]
 pub(super) fn cmd_probe(cli: &Cli) -> Result<()> {
-    // Open FT2232H via rs-ftdi
     eprintln!("Opening FT2232H for probe (ftdi-nusb)...");
-    let serial = cli.ft_serial.as_deref();
-    let mut dev = if let Some(sn) = serial {
-        let filter = ftdi_nusb::DeviceFilter::new(FTDI_VID, FT2232H_PID).serial(sn);
-        ftdi_nusb::FtdiDevice::open_with_filter(&filter, ftdi_nusb::Interface::A)
-            .with_context(|| format!("No FT2232H with serial '{}'", sn))?
-    } else {
-        let filter =
-            ftdi_nusb::DeviceFilter::new(FTDI_VID, FT2232H_PID).description("NORbert FT245");
-        ftdi_nusb::FtdiDevice::open_with_filter(&filter, ftdi_nusb::Interface::A)
-            .or_else(|_| {
-                ftdi_nusb::FtdiDevice::open_with_interface(
-                    FTDI_VID,
-                    FT2232H_PID,
-                    ftdi_nusb::Interface::A,
-                )
-            })
-            .context("No FT2232H found")?
-    };
+    let mut dev = crate::transport::open_ft2232h(cli.ft_serial.as_deref())?;
 
     dev.usb_reset().context("FT2232H reset failed")?;
     dev.flush_all().context("FT2232H flush failed")?;
@@ -51,7 +34,7 @@ pub(super) fn cmd_probe(cli: &Cli) -> Result<()> {
         (0xFF, "non-command 0xFF", None),
     ];
 
-    println!("FT245 probe (rs-ftdi): send 1 byte, wait 200ms, read back\n");
+    println!("FT245 probe (ftdi-nusb): send 1 byte, wait 200ms, read back\n");
     println!("{:<30} {:>4}   {:>8}  Response", "Test", "Sent", "Expected");
     println!("{}", "-".repeat(70));
 
@@ -150,6 +133,7 @@ pub(super) fn cmd_probe(cli: &Cli) -> Result<()> {
 // FT-list command
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "ftdi")]
 pub(super) fn cmd_ft_list() -> Result<()> {
     let devices = ftdi_nusb::find_devices(FTDI_VID, FT2232H_PID)
         .map_err(|e| anyhow!(e))
@@ -167,16 +151,27 @@ pub(super) fn cmd_ft_list() -> Result<()> {
     println!("FT2232H devices ({} found):", devices.len());
     for (i, dev) in devices.iter().enumerate() {
         println!(
-            "  [{}] bus={} addr={} vid={:04x} pid={:04x}",
+            "  [{}] bus={} addr={} vid={:04x} pid={:04x} serial={}",
             i,
             dev.busnum(),
             dev.device_address(),
             dev.vendor_id(),
             dev.product_id(),
+            dev.serial_number().unwrap_or("<unavailable>"),
         );
     }
     println!();
     println!("Use --ft-serial <SERIAL> to select a specific device.");
     println!("Channel A is used by default for async FIFO.");
     Ok(())
+}
+
+#[cfg(not(feature = "ftdi"))]
+pub(super) fn cmd_probe(_cli: &Cli) -> Result<()> {
+    bail!("probe requires the 'ftdi' feature (build with --features ftdi)")
+}
+
+#[cfg(not(feature = "ftdi"))]
+pub(super) fn cmd_ft_list() -> Result<()> {
+    bail!("ft-list requires the 'ftdi' feature (build with --features ftdi)")
 }

--- a/tool/src/commands/diagnostics.rs
+++ b/tool/src/commands/diagnostics.rs
@@ -9,14 +9,19 @@ pub(super) fn cmd_probe(cli: &Cli) -> Result<()> {
     eprintln!("Opening FT2232H for probe (ftdi-nusb)...");
     let serial = cli.ft_serial.as_deref();
     let mut dev = if let Some(sn) = serial {
-        let filter = ftdi::DeviceFilter::new(FTDI_VID, FT2232H_PID).serial(sn);
-        ftdi::FtdiDevice::open_with_filter(&filter, ftdi::Interface::A)
+        let filter = ftdi_nusb::DeviceFilter::new(FTDI_VID, FT2232H_PID).serial(sn);
+        ftdi_nusb::FtdiDevice::open_with_filter(&filter, ftdi_nusb::Interface::A)
             .with_context(|| format!("No FT2232H with serial '{}'", sn))?
     } else {
-        let filter = ftdi::DeviceFilter::new(FTDI_VID, FT2232H_PID).description("NORbert FT245");
-        ftdi::FtdiDevice::open_with_filter(&filter, ftdi::Interface::A)
+        let filter =
+            ftdi_nusb::DeviceFilter::new(FTDI_VID, FT2232H_PID).description("NORbert FT245");
+        ftdi_nusb::FtdiDevice::open_with_filter(&filter, ftdi_nusb::Interface::A)
             .or_else(|_| {
-                ftdi::FtdiDevice::open_with_interface(FTDI_VID, FT2232H_PID, ftdi::Interface::A)
+                ftdi_nusb::FtdiDevice::open_with_interface(
+                    FTDI_VID,
+                    FT2232H_PID,
+                    ftdi_nusb::Interface::A,
+                )
             })
             .context("No FT2232H found")?
     };
@@ -146,7 +151,7 @@ pub(super) fn cmd_probe(cli: &Cli) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 pub(super) fn cmd_ft_list() -> Result<()> {
-    let devices = ftdi::find_devices(FTDI_VID, FT2232H_PID)
+    let devices = ftdi_nusb::find_devices(FTDI_VID, FT2232H_PID)
         .map_err(|e| anyhow!(e))
         .context("Failed to enumerate FTDI devices")?;
 

--- a/tool/src/commands/monitor.rs
+++ b/tool/src/commands/monitor.rs
@@ -42,11 +42,10 @@ fn spi_opcode_name(opcode: u8) -> &'static str {
 }
 
 fn is_read_opcode(opcode: u8) -> bool {
-    match opcode {
-        0x03 | 0x0B | 0x0C | 0x13 | 0x3B | 0x3C | 0x5A | 0x6B | 0x6C | 0xBB | 0xBC | 0xEB
-        | 0xEC => true,
-        _ => false,
-    }
+    const READ_OPCODES: [u8; 13] = [
+        0x03, 0x0B, 0x0C, 0x13, 0x3B, 0x3C, 0x5A, 0x6B, 0x6C, 0xBB, 0xBC, 0xEB, 0xEC,
+    ];
+    READ_OPCODES.contains(&opcode)
 }
 
 // ---------------------------------------------------------------------------

--- a/tool/src/device.rs
+++ b/tool/src/device.rs
@@ -276,7 +276,11 @@ impl FlashDevice {
         length: u32,
         mut progress: impl FnMut(usize) -> Result<()>,
     ) -> Result<Vec<u8>> {
-        let mut result = Vec::with_capacity(length as usize);
+        validate_sdram_range(address, length as usize, "read")?;
+        let mut result = Vec::new();
+        result
+            .try_reserve_exact(length as usize)
+            .context("failed to reserve read result buffer")?;
         self.read_chunks(address, length, |_, chunk| {
             result.extend_from_slice(chunk);
             progress(chunk.len())
@@ -756,6 +760,21 @@ mod tests {
         fn is_connected(&self) -> bool {
             self.connected
         }
+    }
+
+    #[test]
+    fn out_of_range_read_is_rejected_before_transport_io() {
+        let (transport, writes) = MockTransport::new([]);
+        let mut device =
+            FlashDevice::new(transport, ConnectionKind::Ft245, Some(PROTOCOL_VERSION)).unwrap();
+
+        let error = device
+            .read(SDRAM_SIZE_BYTES as u32, 1)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("exceeds 64 MiB SDRAM"));
+        assert!(writes.borrow().is_empty());
     }
 
     #[test]

--- a/tool/src/device.rs
+++ b/tool/src/device.rs
@@ -1,513 +1,811 @@
-use crate::chip::{self, FlashChipExt};
 use crate::protocol::*;
-use crate::transport::Ft245Transport;
-use crate::transport::{
-    BLOCK_SIZE, SDRAM_SIZE_BYTES, SerialTransport, Transport, UART_READ_BLOCK_SIZE,
-};
 use anyhow::{Context, Result, bail};
 use std::mem::size_of;
 use zerocopy::IntoBytes;
 
-// ---------------------------------------------------------------------------
-// FlashDevice -- protocol implementation over any transport
-// ---------------------------------------------------------------------------
+#[cfg(any(feature = "ftdi", feature = "wasm"))]
+pub(crate) const FTDI_VID: u16 = 0x0403;
+#[cfg(any(feature = "ftdi", feature = "wasm"))]
+pub(crate) const FT2232H_PID: u16 = 0x6010;
+pub(crate) const UART_BAUD_RATE: u32 = 2_000_000;
+
+// 64 KiB transfers are unreliable in the FPGA glue/SDRAM path. Keep FT245
+// protocol requests at or below the largest size that passes stress tests.
+#[cfg(any(feature = "ftdi", feature = "wasm", test))]
+const FT245_READ_BLOCK_SIZE: usize = 16_384;
+
+// UART reads must complete inside the SDRAM refresh window. At 2 Mbaud a
+// 4 KiB read takes about 20 ms, leaving adequate margin.
+const UART_READ_BLOCK_SIZE: usize = 4_096;
+const MAX_WRITE_BLOCK_SIZE: usize = 16_384;
+pub(crate) const SDRAM_SIZE_BYTES: u64 = 64 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ConnectionKind {
+    #[cfg(any(feature = "ftdi", feature = "wasm", test))]
+    Ft245,
+    Uart,
+}
+
+impl ConnectionKind {
+    fn read_block_size(self) -> usize {
+        match self {
+            #[cfg(any(feature = "ftdi", feature = "wasm", test))]
+            Self::Ft245 => FT245_READ_BLOCK_SIZE,
+            Self::Uart => UART_READ_BLOCK_SIZE,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ProtocolCapabilities {
+    pub(crate) version: u8,
+    pub(crate) emulation_control: bool,
+    pub(crate) hold_control: bool,
+    pub(crate) activity_log: bool,
+    pub(crate) toctou: bool,
+}
+
+impl ProtocolCapabilities {
+    fn from_version(version: u8) -> Result<Self> {
+        if !is_supported_protocol_version(version) {
+            bail!(
+                "unsupported protocol version {version}; supported versions are {MIN_SUPPORTED_PROTOCOL_VERSION} through {PROTOCOL_VERSION}"
+            );
+        }
+        Ok(Self {
+            version,
+            emulation_control: supports_emulation_control(version),
+            hold_control: supports_hold_control(version),
+            activity_log: supports_activity_log(version),
+            toctou: supports_toctou(version),
+        })
+    }
+}
+
+#[cfg_attr(feature = "cli", allow(dead_code))]
+#[maybe_async::maybe_async(?Send)]
+pub(crate) trait Transport {
+    async fn write_all(&mut self, data: &[u8]) -> Result<()>;
+    async fn read(&mut self, buffer: &mut [u8]) -> Result<usize>;
+    async fn disconnect(&mut self) -> Result<()>;
+    fn is_connected(&self) -> bool;
+}
 
 pub(crate) struct FlashDevice {
     transport: Box<dyn Transport>,
     read_block_size: usize,
+    capabilities: Option<ProtocolCapabilities>,
 }
 
-fn validate_sdram_range(address: u32, length: usize, what: &str) -> Result<()> {
+pub(crate) struct WriteSession<'a> {
+    device: &'a mut FlashDevice,
+    next_address: u32,
+    remaining: usize,
+    was_running: bool,
+}
+
+pub(crate) fn validate_sdram_range(address: u32, length: usize, what: &str) -> Result<()> {
     let end = (address as u64)
         .checked_add(length as u64)
-        .with_context(|| format!("{} range overflows address arithmetic", what))?;
+        .with_context(|| format!("{what} range overflows address arithmetic"))?;
     if end > SDRAM_SIZE_BYTES {
         bail!(
-            "{} range 0x{:08x}..0x{:08x} exceeds {} MiB SDRAM backing store",
-            what,
-            address,
-            end,
+            "{what} range 0x{address:08x}..0x{end:08x} exceeds {} MiB SDRAM backing store",
             SDRAM_SIZE_BYTES / (1024 * 1024)
         );
     }
     Ok(())
 }
 
+#[cfg_attr(feature = "cli", allow(dead_code))]
+#[maybe_async::maybe_async(?Send)]
 impl FlashDevice {
-    pub(crate) fn open_serial(port_name: &str) -> Result<Self> {
+    pub(crate) fn new<T>(
+        transport: T,
+        connection: ConnectionKind,
+        known_version: Option<u8>,
+    ) -> Result<Self>
+    where
+        T: Transport + 'static,
+    {
+        let capabilities = known_version
+            .map(ProtocolCapabilities::from_version)
+            .transpose()?;
         Ok(Self {
-            transport: Box::new(SerialTransport::open(port_name)?),
-            read_block_size: UART_READ_BLOCK_SIZE,
+            transport: Box::new(transport),
+            read_block_size: connection.read_block_size(),
+            capabilities,
         })
     }
 
-    pub(crate) fn open_ft245(serial: Option<&str>) -> Result<Self> {
-        Ok(Self {
-            transport: Box::new(Ft245Transport::open(serial)?),
-            read_block_size: BLOCK_SIZE,
-        })
+    pub(crate) fn is_connected(&self) -> bool {
+        self.transport.is_connected()
     }
 
-    pub(crate) fn get_version(&mut self) -> Result<u8> {
-        self.transport.write_all(&[CMD_VERSION])?;
-        self.read_ack("version")
+    pub(crate) async fn disconnect(&mut self) -> Result<()> {
+        self.transport.disconnect().await
     }
 
-    /// Read one response byte, transparently skipping stray 0x00 bytes
-    /// that the FT2232H 245 FIFO mode can occasionally leak from USB
-    /// (the 2-byte USB IN modem status header).  Used by all single-
-    /// byte-ack commands.
-    pub(crate) fn read_ack(&mut self, context: &str) -> Result<u8> {
-        let mut resp = [0u8; 1];
-        let mut skipped = 0u32;
-        loop {
-            self.transport.read_exact(&mut resp)?;
-            if resp[0] != 0x00 {
-                return Ok(resp[0]);
-            }
-            skipped += 1;
-            if skipped > 8 {
-                bail!("{}: too many 0x00 bytes before ACK", context);
-            }
+    pub(crate) async fn capabilities(&mut self) -> Result<ProtocolCapabilities> {
+        if let Some(capabilities) = self.capabilities {
+            return Ok(capabilities);
+        }
+
+        self.transport.write_all(&[CMD_VERSION]).await?;
+        let version = self.read_ack("version").await?;
+        let capabilities = ProtocolCapabilities::from_version(version)?;
+        self.capabilities = Some(capabilities);
+        Ok(capabilities)
+    }
+
+    pub(crate) async fn get_version(&mut self) -> Result<u8> {
+        Ok(self.capabilities().await?.version)
+    }
+
+    async fn require_capability(
+        &mut self,
+        name: &str,
+        supported: impl FnOnce(ProtocolCapabilities) -> bool,
+    ) -> Result<()> {
+        let capabilities = self.capabilities().await?;
+        if supported(capabilities) {
+            Ok(())
+        } else {
+            bail!(
+                "{name} is unavailable with protocol version {}",
+                capabilities.version
+            )
         }
     }
 
-    fn expect_ack(&mut self, context: &str) -> Result<()> {
-        let ack = self.read_ack(context)?;
-        if ack != 0x01 {
-            bail!("{}: unexpected response 0x{:02x}", context, ack);
+    async fn read_exact(&mut self, buffer: &mut [u8]) -> Result<()> {
+        let mut offset = 0;
+        while offset < buffer.len() {
+            let count = self.transport.read(&mut buffer[offset..]).await?;
+            if count == 0 {
+                continue;
+            }
+            if count > buffer.len() - offset {
+                bail!("transport returned more bytes than requested");
+            }
+            offset += count;
         }
         Ok(())
     }
 
-    /// Start SPI emulation.  ACK = 0x01.  Safe to call while running
-    /// (no-op that still acks).
-    pub(crate) fn start_emulation(&mut self) -> Result<()> {
-        self.transport.write_all(&[CMD_START])?;
-        self.expect_ack("start")
+    /// Read one response byte while tolerating the known startup/status noise
+    /// bytes emitted by the UART and FT2232H paths.
+    pub(crate) async fn read_ack(&mut self, context: &str) -> Result<u8> {
+        let mut response = [0u8; 1];
+        for _ in 0..=8 {
+            self.read_exact(&mut response).await?;
+            if response[0] != 0x00 && response[0] != 0xff {
+                return Ok(response[0]);
+            }
+        }
+        bail!("{context}: too many synchronization bytes before ACK")
     }
 
-    /// Stop SPI emulation.  ACK = 0x01.  Safe to call while stopped.
-    ///
-    /// Always deliverable: even when SPI emulation is actively driving
-    /// the target, the FPGA's always-safe dispatcher picks up this
-    /// command ahead of the usual SPI-idle gate.
-    pub(crate) fn stop_emulation(&mut self) -> Result<()> {
-        self.transport.write_all(&[CMD_STOP])?;
-        self.expect_ack("stop")
-    }
-
-    /// Query the current emulation state.  Returns true when running.
-    ///
-    /// The FPGA encodes stopped as 0x02 (not 0x00) so that any leaked
-    /// FT2232H modem-status zeros can be transparently skipped.
-    pub(crate) fn status(&mut self) -> Result<bool> {
-        self.transport.write_all(&[CMD_STATUS])?;
-        let resp = self.read_ack("status")?;
-        match resp {
-            0x01 => Ok(true),  // running
-            0x02 => Ok(false), // stopped
-            other => bail!("status: unexpected response 0x{:02x}", other),
+    async fn expect_ack(&mut self, context: &str) -> Result<()> {
+        let response = self.read_ack(context).await?;
+        if response == 0x01 {
+            Ok(())
+        } else {
+            bail!("{context}: unexpected response 0x{response:02x}")
         }
     }
 
-    /// Ensure emulation is stopped for the duration of `f`, then
-    /// restore the prior state.  On v3 or older firmware (which has
-    /// no START/STOP/STATUS opcodes) `f` runs unconditionally and the
-    /// caller is responsible for ensuring the SPI bus is idle.
-    ///
-    /// State is restored on a best-effort basis even when `f` returns
-    /// an error so a failed operation doesn't leave the emulator
-    /// unexpectedly stopped.
-    pub(crate) fn with_emulation_stopped<F, R>(&mut self, f: F) -> Result<R>
-    where
-        F: FnOnce(&mut Self) -> Result<R>,
-    {
-        let version = self.get_version()?;
-        if version < 4 {
-            eprintln!(
-                "Note: FPGA protocol v{} has no START/STOP; assuming idle SPI bus.",
-                version
-            );
-            return f(self);
-        }
+    pub(crate) async fn start_emulation(&mut self) -> Result<()> {
+        self.require_capability("emulation control", |c| c.emulation_control)
+            .await?;
+        self.command_with_ack(CMD_START, "start").await
+    }
 
-        let was_running = self.status()?;
+    pub(crate) async fn stop_emulation(&mut self) -> Result<()> {
+        self.require_capability("emulation control", |c| c.emulation_control)
+            .await?;
+        self.command_with_ack(CMD_STOP, "stop").await
+    }
+
+    pub(crate) async fn status(&mut self) -> Result<bool> {
+        self.require_capability("emulation status", |c| c.emulation_control)
+            .await?;
+        self.transport.write_all(&[CMD_STATUS]).await?;
+        match self.read_ack("status").await? {
+            0x01 => Ok(true),
+            0x02 => Ok(false),
+            response => bail!("status: unexpected response 0x{response:02x}"),
+        }
+    }
+
+    pub(crate) async fn prepare_stopped(&mut self) -> Result<bool> {
+        let capabilities = self.capabilities().await?;
+        if !capabilities.emulation_control {
+            return Ok(false);
+        }
+        let was_running = self.status().await?;
         if was_running {
-            eprintln!("Stopping SPI emulation for operation...");
-            self.stop_emulation()?;
+            self.stop_emulation().await?;
         }
-        let operation = f(self);
+        Ok(was_running)
+    }
+
+    pub(crate) async fn finish_stopped<T>(
+        &mut self,
+        was_running: bool,
+        operation: Result<T>,
+    ) -> Result<T> {
         let restoration = if was_running {
-            self.start_emulation()
+            self.start_emulation().await
         } else {
             Ok(())
         };
-
         match (operation, restoration) {
-            (Ok(value), Ok(())) => {
-                if was_running {
-                    eprintln!("SPI emulation resumed.");
-                }
-                Ok(value)
+            (Ok(value), Ok(())) => Ok(value),
+            (Ok(_), Err(error)) => {
+                Err(error.context("operation completed, but emulation could not be resumed"))
             }
-            (Ok(_), Err(resume_error)) => {
-                Err(resume_error
-                    .context("operation completed, but SPI emulation could not be resumed"))
-            }
-            (Err(operation_error), Ok(())) => Err(operation_error),
-            (Err(operation_error), Err(resume_error)) => Err(operation_error.context(format!(
-                "SPI emulation also could not be resumed: {resume_error:#}"
+            (Err(error), Ok(())) => Err(error),
+            (Err(error), Err(resume_error)) => Err(error.context(format!(
+                "emulation also could not be resumed: {resume_error:#}"
             ))),
         }
     }
 
-    /// Stop emulation, run `f`, then start emulation unconditionally.
-    /// Used by `load`, whose natural end state is "ready to serve".
-    pub(crate) fn with_emulation_then_start<F, R>(&mut self, f: F) -> Result<R>
-    where
-        F: FnOnce(&mut Self) -> Result<R>,
-    {
-        let version = self.get_version()?;
-        if version < 4 {
-            eprintln!(
-                "Note: FPGA protocol v{} has no START/STOP; assuming idle SPI bus.",
-                version
-            );
-            return f(self);
-        }
-
-        eprintln!("Stopping SPI emulation...");
-        self.stop_emulation()?;
-        let operation = f(self);
-        let restoration = self.start_emulation();
-
-        match (operation, restoration) {
-            (Ok(value), Ok(())) => {
-                eprintln!("SPI emulation started; target can now read the loaded data.");
-                Ok(value)
-            }
-            (Ok(_), Err(start_error)) => {
-                Err(start_error.context("load completed, but SPI emulation could not be started"))
-            }
-            (Err(operation_error), Ok(())) => Err(operation_error),
-            (Err(operation_error), Err(start_error)) => Err(operation_error.context(format!(
-                "SPI emulation also could not be started: {start_error:#}"
-            ))),
-        }
+    pub(crate) async fn read(&mut self, address: u32, length: u32) -> Result<Vec<u8>> {
+        self.read_with_progress(address, length, |_| Ok(())).await
     }
 
-    pub(crate) fn read_block(&mut self, address: u32, length: usize) -> Result<Vec<u8>> {
-        if length == 0 || length > BLOCK_SIZE {
-            bail!("Invalid length: must be 1-{}", BLOCK_SIZE);
-        }
-        if !address.is_multiple_of(8) {
-            bail!("Address must be 8-byte aligned");
-        }
-        if !length.is_multiple_of(8) {
-            bail!("Length must be a multiple of 8");
-        }
-
-        validate_sdram_range(address, length, "read")?;
-
-        let addr_units = address / 8;
-        let len_units = length / 8;
-
-        // v3 header: cmd + 3 addr bytes + 2 len bytes (big-endian)
-        let len_units = u16::try_from(len_units).context("read burst count exceeds 16 bits")?;
-        let header =
-            RamHeader::read(addr_units, len_units).context("read burst address exceeds 24 bits")?;
-
-        self.transport.write_all(header.as_bytes())?;
-
-        let mut buf = vec![0u8; length];
-        self.transport.read_exact(&mut buf)?;
-        Ok(buf)
-    }
-
-    pub(crate) fn write_block(&mut self, address: u32, data: &[u8]) -> Result<()> {
-        if data.is_empty() || data.len() > BLOCK_SIZE {
-            bail!("Invalid data length: must be 1-{}", BLOCK_SIZE);
-        }
-        if !address.is_multiple_of(8) {
-            bail!("Address must be 8-byte aligned");
-        }
-        if !data.len().is_multiple_of(8) {
-            bail!("Data length must be a multiple of 8");
-        }
-
-        validate_sdram_range(address, data.len(), "write")?;
-
-        let addr_units = address / 8;
-        let len_units = data.len() / 8;
-
-        // Combine header and data into a single write to avoid
-        // transfer gaps that could trigger the FPGA's idle timeout.
-        // v3 header: cmd + 3 addr bytes + 2 len bytes (big-endian)
-        let len_units = u16::try_from(len_units).context("write burst count exceeds 16 bits")?;
-        let header = RamHeader::write(addr_units, len_units)
-            .context("write burst address exceeds 24 bits")?;
-        let mut buf = Vec::with_capacity(size_of::<RamHeader>() + data.len());
-        buf.extend_from_slice(header.as_bytes());
-        buf.extend_from_slice(data);
-        self.transport.write_all(&buf)?;
-
-        // Wait for completion byte (read_ack skips leaked FT2232H 0x00s).
-        self.expect_ack("write")
-    }
-
-    pub(crate) fn read_with_progress(
+    pub(crate) async fn read_with_progress(
         &mut self,
         address: u32,
         length: u32,
-        mut progress: impl FnMut(usize),
+        mut progress: impl FnMut(usize) -> Result<()>,
     ) -> Result<Vec<u8>> {
-        validate_sdram_range(address, length as usize, "read")?;
-        let rbs = self.read_block_size;
         let mut result = Vec::with_capacity(length as usize);
-        let mut addr = address;
-        let mut remaining = length as usize;
-
-        let start_offset = (addr % 8) as usize;
-        if start_offset != 0 {
-            let aligned_addr = addr - start_offset as u32;
-            let chunk_len = std::cmp::min(8 - start_offset, remaining);
-            let block = self.read_block(aligned_addr, 8)?;
-            result.extend_from_slice(&block[start_offset..start_offset + chunk_len]);
-            addr += chunk_len as u32;
-            remaining -= chunk_len;
-            progress(chunk_len);
-        }
-
-        while remaining >= 8 {
-            let chunk_len = std::cmp::min(rbs, remaining / 8 * 8);
-            let block = self.read_block(addr, chunk_len)?;
-            result.extend_from_slice(&block);
-            addr += chunk_len as u32;
-            remaining -= chunk_len;
-            progress(chunk_len);
-        }
-
-        if remaining > 0 {
-            let block = self.read_block(addr, 8)?;
-            result.extend_from_slice(&block[..remaining]);
-            progress(remaining);
-        }
-
+        self.read_chunks(address, length, |_, chunk| {
+            result.extend_from_slice(chunk);
+            progress(chunk.len())
+        })
+        .await?;
         Ok(result)
     }
 
-    /// Send chip configuration to the FPGA.
-    ///
-    /// Protocol (CMD_CHIPCONFIG = 0x33):
-    ///   Byte 0:    0x33
-    ///   Byte 1:    JEDEC manufacturer ID
-    ///   Byte 2:    JEDEC device ID high byte
-    ///   Byte 3:    JEDEC device ID low byte
-    ///   Byte 4:    Flags (bit 0 = supports 4-byte addressing)
-    ///   Byte 5-7:  Chip erase burst count (23-bit, MSB first)
-    ///              = (total_size / 8) - 1
-    ///   Byte 8:    SFDP table length (0-128)
-    ///   Byte 9+:   SFDP table data
-    ///
-    /// Response: 0x01 on success.
-    pub(crate) fn send_chip_config(
+    pub(crate) async fn read_chunks(
         &mut self,
-        chip: &chip::FlashChip,
+        address: u32,
+        length: u32,
+        mut on_chunk: impl FnMut(u32, &[u8]) -> Result<()>,
+    ) -> Result<()> {
+        validate_sdram_range(address, length as usize, "read")?;
+        let was_running = self.prepare_stopped().await?;
+        let operation = self.read_raw_chunks(address, length, &mut on_chunk).await;
+        self.finish_stopped(was_running, operation).await
+    }
+
+    #[cfg(feature = "cli")]
+    pub(crate) async fn read_raw_with_progress(
+        &mut self,
+        address: u32,
+        length: u32,
+        mut progress: impl FnMut(usize) -> Result<()>,
+    ) -> Result<Vec<u8>> {
+        let mut result = Vec::with_capacity(length as usize);
+        self.read_raw_chunks(address, length, |_, chunk| {
+            result.extend_from_slice(chunk);
+            progress(chunk.len())
+        })
+        .await?;
+        Ok(result)
+    }
+
+    async fn read_raw_chunks(
+        &mut self,
+        address: u32,
+        length: u32,
+        mut on_chunk: impl FnMut(u32, &[u8]) -> Result<()>,
+    ) -> Result<()> {
+        validate_sdram_range(address, length as usize, "read")?;
+        let mut current = address;
+        let mut remaining = length as usize;
+
+        let start_offset = (current % 8) as usize;
+        if start_offset != 0 {
+            let block = self.read_block(current - start_offset as u32, 8).await?;
+            let count = (8 - start_offset).min(remaining);
+            on_chunk(current, &block[start_offset..start_offset + count])?;
+            current += count as u32;
+            remaining -= count;
+        }
+
+        while remaining >= 8 {
+            let count = self.read_block_size.min(remaining / 8 * 8);
+            let block = self.read_block(current, count).await?;
+            on_chunk(current, &block)?;
+            current += count as u32;
+            remaining -= count;
+        }
+
+        if remaining != 0 {
+            let block = self.read_block(current, 8).await?;
+            on_chunk(current, &block[..remaining])?;
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn write(&mut self, address: u32, data: &[u8]) -> Result<()> {
+        self.write_with_progress(address, data, |_| Ok(())).await
+    }
+
+    pub(crate) async fn begin_write(
+        &mut self,
+        address: u32,
+        length: usize,
+    ) -> Result<WriteSession<'_>> {
+        if length == 0 {
+            bail!("no data to write");
+        }
+        validate_sdram_range(address, length, "write")?;
+        let was_running = self.prepare_stopped().await?;
+        Ok(WriteSession {
+            device: self,
+            next_address: address,
+            remaining: length,
+            was_running,
+        })
+    }
+
+    pub(crate) async fn write_with_progress(
+        &mut self,
+        address: u32,
+        data: &[u8],
+        mut progress: impl FnMut(usize) -> Result<()>,
+    ) -> Result<()> {
+        let mut session = self.begin_write(address, data.len()).await?;
+        let operation = session.write_chunk(data, &mut progress).await;
+        session.finish(operation).await
+    }
+
+    pub(crate) async fn write_raw_with_progress(
+        &mut self,
+        address: u32,
+        data: &[u8],
+        mut progress: impl FnMut(usize) -> Result<()>,
+    ) -> Result<()> {
+        if data.is_empty() {
+            bail!("no data to write");
+        }
+        validate_sdram_range(address, data.len(), "write")?;
+
+        let mut current_address = address;
+        let mut remaining = data;
+        let mut operation_number = 0usize;
+        let start_offset = (address % 8) as usize;
+        let initial_bytes = if start_offset == 0 {
+            0
+        } else {
+            (8 - start_offset).min(data.len())
+        };
+        let bytes_after_initial = data.len() - initial_bytes;
+        let aligned_bytes = bytes_after_initial / 8 * 8;
+        let total_operations = usize::from(initial_bytes != 0)
+            + aligned_bytes.div_ceil(MAX_WRITE_BLOCK_SIZE)
+            + usize::from(bytes_after_initial != aligned_bytes);
+
+        if start_offset != 0 {
+            let aligned_address = current_address - start_offset as u32;
+            let count = (8 - start_offset).min(remaining.len());
+            let mut burst = self.read_block(aligned_address, 8).await?;
+            burst[start_offset..start_offset + count].copy_from_slice(&remaining[..count]);
+            self.write_block(aligned_address, &burst).await?;
+            current_address += count as u32;
+            remaining = &remaining[count..];
+            progress(count)?;
+            operation_number += 1;
+        }
+
+        while remaining.len() >= 8 {
+            let count = MAX_WRITE_BLOCK_SIZE.min(remaining.len() / 8 * 8);
+            self.write_block(current_address, &remaining[..count])
+                .await
+                .with_context(|| {
+                    format!(
+                        "operation {}/{} at address 0x{:06x}",
+                        operation_number + 1,
+                        total_operations.max(operation_number + 1),
+                        current_address
+                    )
+                })?;
+            current_address += count as u32;
+            remaining = &remaining[count..];
+            progress(count)?;
+            operation_number += 1;
+        }
+
+        if !remaining.is_empty() {
+            let mut burst = self.read_block(current_address, 8).await?;
+            burst[..remaining.len()].copy_from_slice(remaining);
+            self.write_block(current_address, &burst).await?;
+            progress(remaining.len())?;
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn configure(
+        &mut self,
+        jedec_id: [u8; 3],
+        total_size: u32,
+        supports_4byte: bool,
         sfdp_table: &[u8],
     ) -> Result<()> {
-        let jedec = chip.jedec_id_bytes();
-        let erase_bursts = chip.chip_erase_bursts();
-        let flags: u8 = if chip.supports_4byte() { 0x01 } else { 0x00 };
+        let was_running = self.prepare_stopped().await?;
+        let operation = self
+            .configure_raw(jedec_id, total_size, supports_4byte, sfdp_table)
+            .await;
+        self.finish_stopped(was_running, operation).await
+    }
 
-        let sfdp_len = sfdp_table.len();
-        if sfdp_len > 128 {
-            bail!("SFDP table too large: {} bytes (max 128)", sfdp_len);
+    async fn configure_raw(
+        &mut self,
+        jedec_id: [u8; 3],
+        total_size: u32,
+        supports_4byte: bool,
+        sfdp_table: &[u8],
+    ) -> Result<()> {
+        let erase_bursts = capacity_erase_bursts(total_size)
+            .context("chip size must be a power of two between 8 bytes and 64 MiB")?;
+        if sfdp_table.len() > 128 {
+            bail!("SFDP table exceeds 128 bytes");
         }
-        if chip.total_size as u64 > SDRAM_SIZE_BYTES {
-            bail!(
-                "chip size {} bytes exceeds {} MiB SDRAM backing store",
-                chip.total_size,
-                SDRAM_SIZE_BYTES / (1024 * 1024)
-            );
-        }
 
-        let sfdp_len = u8::try_from(sfdp_len).context("SFDP table length exceeds 8 bits")?;
-        let header = ChipConfigHeader::new(jedec, flags, erase_bursts, sfdp_len)
-            .context("chip erase burst count exceeds the protocol's 23-bit field")?;
-
-        // Build the full command in one buffer to avoid USB transfer gaps.
-        let mut buf = Vec::with_capacity(size_of::<ChipConfigHeader>() + sfdp_table.len());
-        buf.extend_from_slice(header.as_bytes());
-        buf.extend_from_slice(sfdp_table);
-        self.transport.write_all(&buf)?;
-
-        self.expect_ack("chip config")
+        let flags = u8::from(supports_4byte);
+        let header = ChipConfigHeader::new(jedec_id, flags, erase_bursts, sfdp_table.len() as u8)
+            .context("chip erase burst count exceeds the protocol field")?;
+        let mut request = Vec::with_capacity(size_of::<ChipConfigHeader>() + sfdp_table.len());
+        request.extend_from_slice(header.as_bytes());
+        request.extend_from_slice(sfdp_table);
+        self.transport.write_all(&request).await?;
+        self.expect_ack("chip config").await
     }
 
-    /// Control the target flash #HOLD pin.
-    ///
-    /// When enabled, IO3 is driven LOW continuously, asserting #HOLD on
-    /// the target flash and silencing it so NORbert can respond instead.
-    /// Mutually exclusive with quad I/O.
-    ///
-    /// Protocol (CMD_HOLDCTL = 0x37):
-    ///   Byte 0: 0x37
-    ///   Byte 1: 0x01 = assert hold, 0x00 = release hold
-    ///   Response: 0x01 on success.
-    pub(crate) fn set_hold(&mut self, enable: bool) -> Result<()> {
+    pub(crate) async fn set_hold(&mut self, enabled: bool) -> Result<()> {
+        self.require_capability("target flash HOLD control", |c| c.hold_control)
+            .await?;
         self.transport
-            .write_all(ControlRequest::hold(enable).as_bytes())?;
-
-        self.expect_ack("hold control")
+            .write_all(ControlRequest::hold(enabled).as_bytes())
+            .await?;
+        self.expect_ack("hold control").await
     }
 
-    pub(crate) fn log_start(&mut self) -> Result<()> {
+    pub(crate) async fn log_start(&mut self) -> Result<()> {
+        self.require_capability("activity logging", |c| c.activity_log)
+            .await?;
         self.transport
-            .write_all(ControlRequest::log(true).as_bytes())?;
-        self.expect_ack("log start")
+            .write_all(ControlRequest::log(true).as_bytes())
+            .await?;
+        self.expect_ack("log start").await
     }
 
-    pub(crate) fn log_stop(&mut self) -> Result<()> {
+    pub(crate) async fn log_stop(&mut self) -> Result<()> {
+        self.require_capability("activity logging", |c| c.activity_log)
+            .await?;
         self.transport
-            .write_all(ControlRequest::log(false).as_bytes())?;
-        self.expect_ack("log stop")
+            .write_all(ControlRequest::log(false).as_bytes())
+            .await?;
+        self.expect_ack("log stop").await
     }
 
-    /// Drain the logger ring FIFO in a single poll.
-    ///
-    /// Protocol (CMD_LOGPOLL = 0x3A):
-    ///   Host:  0x3A
-    ///   FPGA:  [escaped log byte]* 0xA0
-    /// The response ends when an unescaped 0xA0 is seen.  Raw payload
-    /// 0xA0 is encoded as 0xA5 0x00; raw 0xA5 is encoded as 0xA5 0x05.
-    /// The FPGA caps each poll at 255 raw data bytes; any remaining log
-    /// data is picked up on the next poll.
-    pub(crate) fn log_poll(&mut self) -> Result<Vec<u8>> {
-        self.transport.write_all(&[CMD_LOGPOLL])?;
-        let mut out = Vec::with_capacity(256);
+    pub(crate) async fn log_poll(&mut self) -> Result<Vec<u8>> {
+        self.require_capability("activity logging", |c| c.activity_log)
+            .await?;
+        self.transport.write_all(&[CMD_LOGPOLL]).await?;
+        let mut output = Vec::with_capacity(256);
         loop {
-            let mut byte = [0u8; 1];
-            self.transport.read_exact(&mut byte)?;
-            match byte[0] {
-                LOG_POLL_TERMINATOR => return Ok(out),
-                LOG_POLL_ESCAPE => {
-                    let mut code = [0u8; 1];
-                    self.transport.read_exact(&mut code)?;
-                    match code[0] {
-                        0x00 => out.push(LOG_POLL_TERMINATOR),
-                        0x05 => out.push(LOG_POLL_ESCAPE),
-                        other => bail!("LOGPOLL: invalid escape code 0x{:02x}", other),
-                    }
-                }
-                b => out.push(b),
+            let byte = self.read_byte().await?;
+            match byte {
+                LOG_POLL_TERMINATOR => return Ok(output),
+                LOG_POLL_ESCAPE => match self.read_byte().await? {
+                    0x00 => output.push(LOG_POLL_TERMINATOR),
+                    0x05 => output.push(LOG_POLL_ESCAPE),
+                    code => bail!("invalid log escape 0x{code:02x}"),
+                },
+                value => output.push(value),
             }
-            // Safety net: cap log poll responses so a misbehaving
-            // device cannot lock the tool in this loop.  Should never
-            // trip given the FPGA's LOG_POLL_MAX = 255 raw bytes plus
-            // escapes and terminator.
-            if out.len() > 1024 {
-                bail!(
-                    "log poll overran 1024 bytes without terminator; last byte 0x{:02x}",
-                    byte[0]
-                );
+            if output.len() > 1024 {
+                bail!("log poll exceeded 1024 bytes without terminator");
             }
         }
     }
 
-    pub(crate) fn toctou_set(
+    pub(crate) async fn toctou_set(
         &mut self,
         index: u8,
         start: u32,
         mask: u32,
         replace: u32,
     ) -> Result<()> {
+        self.require_capability("TOCTOU traps", |c| c.toctou)
+            .await?;
         let request = ToctouSetRequest::new(index, start, mask, replace)
-            .context("TOCTOU addresses and masks must fit in 24 bits")?;
-        self.transport.write_all(request.as_bytes())?;
-        self.expect_ack("TOCTOU set")
+            .context("TOCTOU index must be 0-3 and addresses must fit in 24 bits")?;
+        self.transport.write_all(request.as_bytes()).await?;
+        self.expect_ack("TOCTOU set").await
     }
 
-    pub(crate) fn toctou_arm(&mut self, index: u8) -> Result<()> {
-        let request = ToctouIndexRequest::arm(index).context("trap index must be 0-3")?;
-        self.transport.write_all(request.as_bytes())?;
-        self.expect_ack("TOCTOU arm")
-    }
-
-    pub(crate) fn toctou_disarm(&mut self, index: u8) -> Result<()> {
-        let request = ToctouIndexRequest::disarm(index).context("trap index must be 0-3")?;
-        self.transport.write_all(request.as_bytes())?;
-        self.expect_ack("TOCTOU disarm")
-    }
-
-    pub(crate) fn toctou_reset(&mut self, index: u8) -> Result<()> {
-        let request = ToctouIndexRequest::reset(index).context("trap index must be 0-3")?;
-        self.transport.write_all(request.as_bytes())?;
-        self.expect_ack("TOCTOU reset")
-    }
-
-    pub(crate) fn toctou_reset_all(&mut self) -> Result<()> {
-        self.transport
-            .write_all(ControlRequest::toctou_reset_all().as_bytes())?;
-        self.expect_ack("TOCTOU reset-all")
-    }
-
-    pub(crate) fn write(&mut self, address: u32, data: &[u8]) -> Result<()> {
-        self.write_with_progress(address, data, |_| {})
-    }
-
-    pub(crate) fn write_with_progress(
+    async fn toctou_index(
         &mut self,
-        address: u32,
-        data: &[u8],
-        mut progress: impl FnMut(usize),
+        request: Option<ToctouIndexRequest>,
+        context: &str,
     ) -> Result<()> {
-        if data.is_empty() {
-            bail!("No data to write");
+        self.require_capability("TOCTOU traps", |c| c.toctou)
+            .await?;
+        let request = request.context("TOCTOU index must be 0-3")?;
+        self.transport.write_all(request.as_bytes()).await?;
+        self.expect_ack(context).await
+    }
+
+    pub(crate) async fn toctou_arm(&mut self, index: u8) -> Result<()> {
+        self.toctou_index(ToctouIndexRequest::arm(index), "TOCTOU arm")
+            .await
+    }
+
+    pub(crate) async fn toctou_disarm(&mut self, index: u8) -> Result<()> {
+        self.toctou_index(ToctouIndexRequest::disarm(index), "TOCTOU disarm")
+            .await
+    }
+
+    pub(crate) async fn toctou_reset(&mut self, index: u8) -> Result<()> {
+        self.toctou_index(ToctouIndexRequest::reset(index), "TOCTOU reset")
+            .await
+    }
+
+    pub(crate) async fn toctou_reset_all(&mut self) -> Result<()> {
+        self.require_capability("TOCTOU traps", |c| c.toctou)
+            .await?;
+        self.transport
+            .write_all(ControlRequest::toctou_reset_all().as_bytes())
+            .await?;
+        self.expect_ack("TOCTOU reset-all").await
+    }
+
+    async fn read_byte(&mut self) -> Result<u8> {
+        let mut byte = [0u8; 1];
+        self.read_exact(&mut byte).await?;
+        Ok(byte[0])
+    }
+
+    async fn command_with_ack(&mut self, command: u8, context: &str) -> Result<()> {
+        self.transport.write_all(&[command]).await?;
+        self.expect_ack(context).await
+    }
+
+    async fn read_block(&mut self, address: u32, length: usize) -> Result<Vec<u8>> {
+        if length == 0
+            || length > MAX_WRITE_BLOCK_SIZE
+            || !address.is_multiple_of(8)
+            || !length.is_multiple_of(8)
+        {
+            bail!("read block must be 8-byte aligned and at most {MAX_WRITE_BLOCK_SIZE} bytes");
+        }
+        validate_sdram_range(address, length, "read")?;
+        let header = RamHeader::read(address / 8, (length / 8) as u16)
+            .context("read address exceeds the protocol field")?;
+        self.transport.write_all(header.as_bytes()).await?;
+        let mut data = vec![0u8; length];
+        self.read_exact(&mut data).await?;
+        Ok(data)
+    }
+
+    async fn write_block(&mut self, address: u32, data: &[u8]) -> Result<()> {
+        if data.is_empty()
+            || data.len() > MAX_WRITE_BLOCK_SIZE
+            || !address.is_multiple_of(8)
+            || !data.len().is_multiple_of(8)
+        {
+            bail!("write block must be 8-byte aligned and at most {MAX_WRITE_BLOCK_SIZE} bytes");
         }
         validate_sdram_range(address, data.len(), "write")?;
+        let header = RamHeader::write(address / 8, (data.len() / 8) as u16)
+            .context("write address exceeds the protocol field")?;
+        let mut request = Vec::with_capacity(size_of::<RamHeader>() + data.len());
+        request.extend_from_slice(header.as_bytes());
+        request.extend_from_slice(data);
+        self.transport.write_all(&request).await?;
+        self.expect_ack("write").await
+    }
+}
 
-        let start_offset = (address % 8) as usize;
-        let aligned_address = address - start_offset as u32;
-        let aligned_len = (start_offset + data.len()).div_ceil(8) * 8;
-        let mut aligned = vec![0u8; aligned_len];
-
-        // Preserve bytes outside the requested range in the first and last
-        // bursts instead of silently overwriting them with padding.
-        if start_offset != 0 {
-            aligned[..8].copy_from_slice(&self.read_block(aligned_address, 8)?);
+#[maybe_async::maybe_async(?Send)]
+impl WriteSession<'_> {
+    pub(crate) async fn write_chunk(
+        &mut self,
+        data: &[u8],
+        mut progress: impl FnMut(usize) -> Result<()>,
+    ) -> Result<()> {
+        if data.is_empty() {
+            bail!("write chunk is empty");
         }
-        let end_offset = start_offset + data.len();
-        if !end_offset.is_multiple_of(8) {
-            let last_offset = aligned_len - 8;
-            if last_offset != 0 || start_offset == 0 {
-                let last_address = aligned_address + last_offset as u32;
-                aligned[last_offset..].copy_from_slice(&self.read_block(last_address, 8)?);
-            }
-        }
-        aligned[start_offset..end_offset].copy_from_slice(data);
-
-        let total_blocks = aligned.len().div_ceil(BLOCK_SIZE);
-        for (block_num, chunk) in aligned.chunks(BLOCK_SIZE).enumerate() {
-            let block_address = aligned_address + (block_num * BLOCK_SIZE) as u32;
-            self.write_block(block_address, chunk).with_context(|| {
-                format!(
-                    "Block {}/{} at addr 0x{:06x}",
-                    block_num + 1,
-                    total_blocks,
-                    block_address
-                )
-            })?;
-
-            let chunk_start = block_num * BLOCK_SIZE;
-            let chunk_end = chunk_start + chunk.len();
-            let written_start = chunk_start.max(start_offset);
-            let written_end = chunk_end.min(end_offset);
-            if written_end > written_start {
-                progress(written_end - written_start);
-            }
+        if data.len() > self.remaining {
+            bail!(
+                "write chunk contains {} bytes, but only {} remain",
+                data.len(),
+                self.remaining
+            );
         }
 
+        self.device
+            .write_raw_with_progress(self.next_address, data, &mut progress)
+            .await?;
+        self.next_address += data.len() as u32;
+        self.remaining -= data.len();
         Ok(())
+    }
+
+    pub(crate) async fn finish(self, operation: Result<()>) -> Result<()> {
+        let operation = operation.and_then(|()| {
+            if self.remaining == 0 {
+                Ok(())
+            } else {
+                bail!("write ended with {} bytes remaining", self.remaining)
+            }
+        });
+        self.device
+            .finish_stopped(self.was_running, operation)
+            .await
+    }
+}
+
+#[cfg(feature = "cli")]
+impl FlashDevice {
+    /// Load is the one operation whose natural end state is running, even if
+    /// the emulator was stopped before the operation.
+    pub(crate) fn with_emulation_then_start<F, R>(&mut self, operation: F) -> Result<R>
+    where
+        F: FnOnce(&mut Self) -> Result<R>,
+    {
+        let capabilities = self.capabilities()?;
+        if !capabilities.emulation_control {
+            eprintln!(
+                "Note: FPGA protocol v{} has no START/STOP; assuming idle SPI bus.",
+                capabilities.version
+            );
+            return operation(self);
+        }
+
+        eprintln!("Stopping SPI emulation...");
+        self.stop_emulation()?;
+        let result = operation(self);
+        let restoration = self.start_emulation();
+        match (result, restoration) {
+            (Ok(value), Ok(())) => {
+                eprintln!("SPI emulation started; target can now read the loaded data.");
+                Ok(value)
+            }
+            (Ok(_), Err(error)) => {
+                Err(error.context("load completed, but SPI emulation could not be started"))
+            }
+            (Err(error), Ok(())) => Err(error),
+            (Err(error), Err(start_error)) => Err(error.context(format!(
+                "SPI emulation also could not be started: {start_error:#}"
+            ))),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "cli"))]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
+    use std::rc::Rc;
+
+    struct MockTransport {
+        reads: VecDeque<u8>,
+        writes: Rc<RefCell<Vec<Vec<u8>>>>,
+        connected: bool,
+    }
+
+    impl MockTransport {
+        fn new(reads: impl IntoIterator<Item = u8>) -> (Self, Rc<RefCell<Vec<Vec<u8>>>>) {
+            let writes = Rc::new(RefCell::new(Vec::new()));
+            (
+                Self {
+                    reads: reads.into_iter().collect(),
+                    writes: writes.clone(),
+                    connected: true,
+                },
+                writes,
+            )
+        }
+    }
+
+    #[maybe_async::maybe_async(?Send)]
+    impl Transport for MockTransport {
+        async fn write_all(&mut self, data: &[u8]) -> Result<()> {
+            self.writes.borrow_mut().push(data.to_vec());
+            Ok(())
+        }
+
+        async fn read(&mut self, buffer: &mut [u8]) -> Result<usize> {
+            let count = buffer.len().min(self.reads.len());
+            for slot in &mut buffer[..count] {
+                *slot = self.reads.pop_front().unwrap();
+            }
+            Ok(count)
+        }
+
+        async fn disconnect(&mut self) -> Result<()> {
+            self.connected = false;
+            Ok(())
+        }
+
+        fn is_connected(&self) -> bool {
+            self.connected
+        }
+    }
+
+    #[test]
+    fn unsupported_protocol_is_rejected_before_commands_continue() {
+        let (transport, writes) = MockTransport::new([PROTOCOL_VERSION + 1]);
+        let mut device = FlashDevice::new(transport, ConnectionKind::Ft245, None).unwrap();
+
+        let error = device.get_version().unwrap_err().to_string();
+
+        assert!(error.contains("unsupported protocol version"));
+        assert_eq!(&*writes.borrow(), &[vec![CMD_VERSION]]);
+    }
+
+    #[test]
+    fn shared_read_path_stops_and_restores_emulation() {
+        let data = [0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17];
+        let reads = [5, 1, 1].into_iter().chain(data).chain([1]);
+        let (transport, writes) = MockTransport::new(reads);
+        let mut device = FlashDevice::new(transport, ConnectionKind::Ft245, None).unwrap();
+
+        assert_eq!(device.read(0, 8).unwrap(), data);
+        assert_eq!(
+            &*writes.borrow(),
+            &[
+                vec![CMD_VERSION],
+                vec![CMD_STATUS],
+                vec![CMD_STOP],
+                RamHeader::read(0, 1).unwrap().as_bytes().to_vec(),
+                vec![CMD_START],
+            ]
+        );
+    }
+
+    #[test]
+    fn cancelled_streaming_read_still_restores_emulation() {
+        let reads = [1, 1].into_iter().chain([0u8; 8]).chain([1]);
+        let (transport, writes) = MockTransport::new(reads);
+        let mut device =
+            FlashDevice::new(transport, ConnectionKind::Ft245, Some(PROTOCOL_VERSION)).unwrap();
+
+        let error = device
+            .read_chunks(0, 8, |_, _| bail!("cancelled by test"))
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("cancelled by test"));
+        assert_eq!(writes.borrow().last(), Some(&vec![CMD_START]));
+    }
+
+    #[test]
+    fn cancelled_write_session_still_restores_emulation() {
+        let (transport, writes) = MockTransport::new([1, 1, 1, 1]);
+        let mut device =
+            FlashDevice::new(transport, ConnectionKind::Ft245, Some(PROTOCOL_VERSION)).unwrap();
+
+        let mut session = device.begin_write(0, 16).unwrap();
+        session.write_chunk(&[0xaa; 8], |_| Ok(())).unwrap();
+        let error = session
+            .finish(Err(anyhow::anyhow!("cancelled by test")))
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("cancelled by test"));
+        assert_eq!(writes.borrow().last(), Some(&vec![CMD_START]));
     }
 }

--- a/tool/src/device.rs
+++ b/tool/src/device.rs
@@ -1,6 +1,7 @@
 use crate::protocol::*;
 use anyhow::{Context, Result, bail};
 use std::mem::size_of;
+use std::time::{Duration, Instant};
 use zerocopy::IntoBytes;
 
 #[cfg(any(feature = "ftdi", feature = "wasm"))]
@@ -160,16 +161,28 @@ impl FlashDevice {
     }
 
     async fn read_exact(&mut self, buffer: &mut [u8]) -> Result<()> {
+        const MAX_EMPTY_READS: usize = 64;
+        let deadline = Instant::now() + Duration::from_secs(5);
         let mut offset = 0;
+        let mut empty_reads = 0;
+
         while offset < buffer.len() {
             let count = self.transport.read(&mut buffer[offset..]).await?;
             if count == 0 {
+                empty_reads += 1;
+                if empty_reads >= MAX_EMPTY_READS || Instant::now() >= deadline {
+                    bail!(
+                        "transport made no read progress: received {offset} of {} bytes",
+                        buffer.len()
+                    );
+                }
                 continue;
             }
             if count > buffer.len() - offset {
                 bail!("transport returned more bytes than requested");
             }
             offset += count;
+            empty_reads = 0;
         }
         Ok(())
     }
@@ -300,7 +313,7 @@ impl FlashDevice {
         Ok(result)
     }
 
-    async fn read_raw_chunks(
+    pub(crate) async fn read_raw_chunks(
         &mut self,
         address: u32,
         length: u32,
@@ -743,6 +756,17 @@ mod tests {
         fn is_connected(&self) -> bool {
             self.connected
         }
+    }
+
+    #[test]
+    fn repeated_empty_reads_fail_instead_of_hanging() {
+        let (transport, _) = MockTransport::new([]);
+        let mut device =
+            FlashDevice::new(transport, ConnectionKind::Ft245, Some(PROTOCOL_VERSION)).unwrap();
+
+        let error = device.read_ack("test").unwrap_err().to_string();
+
+        assert!(error.contains("made no read progress"));
     }
 
     #[test]

--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -10,3 +10,9 @@ mod device;
 #[cfg(all(feature = "wasm", target_arch = "wasm32"))]
 #[allow(dead_code)]
 mod protocol;
+
+#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+mod web;
+
+#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+pub use web::WebFlashDevice;

--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -4,6 +4,12 @@ compile_error!(
 );
 
 #[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+pub mod chip;
+
+#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+pub mod sfdp;
+
+#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
 #[allow(dead_code)]
 mod device;
 

--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -1,0 +1,12 @@
+#[cfg(all(feature = "cli", feature = "wasm"))]
+compile_error!(
+    "the 'cli' and 'wasm' features are mutually exclusive; build WASM with --no-default-features --features wasm"
+);
+
+#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+#[allow(dead_code)]
+mod device;
+
+#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+#[allow(dead_code)]
+mod protocol;

--- a/tool/src/protocol.rs
+++ b/tool/src/protocol.rs
@@ -7,6 +7,43 @@
 use zerocopy::{Immutable, IntoBytes};
 
 pub const PROTOCOL_VERSION: u8 = 5;
+pub const MIN_SUPPORTED_PROTOCOL_VERSION: u8 = 3;
+
+pub const fn is_supported_protocol_version(version: u8) -> bool {
+    version >= MIN_SUPPORTED_PROTOCOL_VERSION && version <= PROTOCOL_VERSION
+}
+
+pub const fn supports_emulation_control(version: u8) -> bool {
+    version >= 4
+}
+
+pub const fn supports_hold_control(version: u8) -> bool {
+    version >= 4
+}
+
+pub const fn supports_activity_log(version: u8) -> bool {
+    version >= 5
+}
+
+pub const fn supports_toctou(version: u8) -> bool {
+    version >= 5
+}
+
+/// Convert a flash capacity to the FPGA's combined erase-count/address-mask
+/// field. The mask representation only works for power-of-two capacities.
+pub const fn capacity_erase_bursts(total_size: u32) -> Option<u32> {
+    if total_size < 8 || !total_size.is_power_of_two() {
+        return None;
+    }
+
+    let bursts = total_size / 8;
+    let erase_bursts = bursts - 1;
+    if erase_bursts <= 0x007f_ffff {
+        Some(erase_bursts)
+    } else {
+        None
+    }
+}
 
 pub const CMD_VERSION: u8 = 0x30;
 pub const CMD_READ: u8 = 0x31;
@@ -229,6 +266,32 @@ mod tests {
             &[CMD_CHIPCONFIG, 0xef, 0x40, 0x18, 1, 0x12, 0x34, 0x56, 128]
         );
         assert!(ChipConfigHeader::new([0; 3], 0, 0x0080_0000, 0).is_none());
+    }
+
+    #[test]
+    fn capacity_mask_requires_a_representable_power_of_two() {
+        assert_eq!(capacity_erase_bursts(8), Some(0));
+        assert_eq!(capacity_erase_bursts(16 * 1024 * 1024), Some(0x1f_ffff));
+        assert_eq!(capacity_erase_bursts(64 * 1024 * 1024), Some(0x7f_ffff));
+        assert_eq!(capacity_erase_bursts(0), None);
+        assert_eq!(capacity_erase_bursts(4), None);
+        assert_eq!(capacity_erase_bursts(12), None);
+    }
+
+    #[test]
+    fn protocol_capabilities_are_explicit() {
+        assert!(!is_supported_protocol_version(2));
+        assert!(is_supported_protocol_version(3));
+        assert!(is_supported_protocol_version(PROTOCOL_VERSION));
+        assert!(!is_supported_protocol_version(PROTOCOL_VERSION + 1));
+        assert!(!supports_emulation_control(3));
+        assert!(supports_emulation_control(4));
+        assert!(!supports_hold_control(3));
+        assert!(supports_hold_control(4));
+        assert!(!supports_activity_log(4));
+        assert!(supports_activity_log(5));
+        assert!(!supports_toctou(4));
+        assert!(supports_toctou(5));
     }
 
     #[test]

--- a/tool/src/transport.rs
+++ b/tool/src/transport.rs
@@ -68,6 +68,7 @@ impl SerialTransport {
         // stray that arrives *after* the reply (it would be seen as
         // the last byte on the first attempt, forcing a retry).
         const SYNC_ATTEMPTS: u32 = 5;
+        let mut last_unsupported = None;
         for attempt in 0..SYNC_ATTEMPTS {
             port.write_all(&[CMD_VERSION])?;
             port.flush().ok();
@@ -103,14 +104,20 @@ impl SerialTransport {
                     }
                     return Ok(Self { port });
                 }
+                Some(v) if v != 0x00 && v != 0xff => last_unsupported = Some(v),
                 _ => {} // keep trying
             }
         }
-        bail!(
-            "Failed to sync with FPGA on {} after {} attempts (only saw 0x00/0xFF junk)",
-            port_name,
-            SYNC_ATTEMPTS
-        );
+        match last_unsupported {
+            Some(version) => bail!(
+                "Failed to sync with FPGA on {port_name}: unsupported protocol version {version}"
+            ),
+            None => bail!(
+                "Failed to sync with FPGA on {} after {} attempts (only saw 0x00/0xFF junk)",
+                port_name,
+                SYNC_ATTEMPTS
+            ),
+        }
     }
 }
 
@@ -139,6 +146,28 @@ impl Transport for SerialTransport {
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "ftdi")]
+pub(crate) fn open_ft2232h(serial: Option<&str>) -> Result<ftdi_nusb::FtdiDevice> {
+    if let Some(serial) = serial {
+        let filter = ftdi_nusb::DeviceFilter::new(FTDI_VID, FT2232H_PID).serial(serial);
+        return ftdi_nusb::FtdiDevice::open_with_filter(&filter, ftdi_nusb::Interface::A)
+            .with_context(|| format!("No FT2232H with serial '{serial}'"));
+    }
+
+    // DeviceFilter matches the USB product string configured in ft2232h.conf;
+    // the interface is selected separately below.
+    let filter = ftdi_nusb::DeviceFilter::new(FTDI_VID, FT2232H_PID).description("NORbert FT245");
+    ftdi_nusb::FtdiDevice::open_with_filter(&filter, ftdi_nusb::Interface::A)
+        .or_else(|_| {
+            ftdi_nusb::FtdiDevice::open_with_interface(
+                FTDI_VID,
+                FT2232H_PID,
+                ftdi_nusb::Interface::A,
+            )
+        })
+        .context("No FT2232H found")
+}
+
+#[cfg(feature = "ftdi")]
 pub(crate) struct Ft245Transport {
     dev: ftdi_nusb::FtdiDevice,
 }
@@ -146,27 +175,9 @@ pub(crate) struct Ft245Transport {
 #[cfg(feature = "ftdi")]
 impl Ft245Transport {
     pub(crate) fn open(serial: Option<&str>) -> Result<Self> {
-        // Open the FT2232H Channel A.  The EEPROM must already be
-        // configured for "245 FIFO" mode.
-        let mut dev = if let Some(sn) = serial {
-            let filter = ftdi_nusb::DeviceFilter::new(FTDI_VID, FT2232H_PID).serial(sn);
-            ftdi_nusb::FtdiDevice::open_with_filter(&filter, ftdi_nusb::Interface::A)
-                .with_context(|| format!("No FT2232H with serial '{}'", sn))?
-        } else {
-            // Try to find by description first
-            let filter =
-                ftdi_nusb::DeviceFilter::new(FTDI_VID, FT2232H_PID).description("NORbert FT245");
-            ftdi_nusb::FtdiDevice::open_with_filter(&filter, ftdi_nusb::Interface::A)
-                .or_else(|_| {
-                    // Fall back to opening any FT2232H on interface A
-                    ftdi_nusb::FtdiDevice::open_with_interface(
-                        FTDI_VID,
-                        FT2232H_PID,
-                        ftdi_nusb::Interface::A,
-                    )
-                })
-                .context("No FT2232H found")?
-        };
+        // Open the FT2232H Channel A. The EEPROM must already be configured
+        // for "245 FIFO" mode.
+        let mut dev = open_ft2232h(serial)?;
 
         // Reset the FT2232H's internal state and flush FIFOs.
         dev.usb_reset().context("FT2232H reset failed")?;

--- a/tool/src/transport.rs
+++ b/tool/src/transport.rs
@@ -1,39 +1,28 @@
-use crate::protocol::CMD_VERSION;
+use crate::device::{ConnectionKind, FlashDevice, Transport, UART_BAUD_RATE};
+#[cfg(feature = "ftdi")]
+use crate::device::{FT2232H_PID, FTDI_VID};
+use crate::protocol::{CMD_VERSION, is_supported_protocol_version};
+#[cfg(feature = "ftdi")]
 use anyhow::anyhow;
 use anyhow::{Context, Result, bail};
 use serialport::SerialPort;
 use std::io::{Read, Write};
 use std::thread;
 use std::time::Duration;
-use std::time::Instant;
 
-const BAUD_RATE: u32 = 2_000_000;
-// Max bursts per command: 16-bit len field (v3), 8 bytes per burst.
-// 64KB blocks are unreliable -- the FPGA loses a byte during sustained
-// 8192-burst writes (likely a glue/SDRAM timing race under refresh
-// pressure).  16KB is the largest size that passes 10/10 stress tests.
-pub(crate) const BLOCK_SIZE: usize = 16384; // 2048 bursts * 8 bytes
+impl FlashDevice {
+    pub(crate) fn open_serial(port_name: &str) -> Result<Self> {
+        Self::new(
+            SerialTransport::open(port_name)?,
+            ConnectionKind::Uart,
+            None,
+        )
+    }
 
-// UART read block size: must be smaller than BLOCK_SIZE because the
-// glue module inhibits SDRAM refresh for the entire serial-path read
-// duration.  At 2Mbaud (~200KB/s), a 16KB read takes ~82ms -- exceeding
-// the SDRAM's 64ms refresh window and risking data loss.  4KB takes
-// ~20ms, well within budget.  Writes are unaffected (data flows
-// host-to-FPGA, SDRAM writes complete in microseconds).
-pub(crate) const UART_READ_BLOCK_SIZE: usize = 4096; // 512 bursts * 8 bytes
-pub(crate) const SDRAM_SIZE_BYTES: u64 = 64 * 1024 * 1024;
-
-// FT2232H USB identifiers
-pub(crate) const FTDI_VID: u16 = 0x0403;
-pub(crate) const FT2232H_PID: u16 = 0x6010;
-
-// ---------------------------------------------------------------------------
-// Transport trait -- abstracts UART serial vs FT245 FIFO
-// ---------------------------------------------------------------------------
-
-pub(crate) trait Transport {
-    fn write_all(&mut self, data: &[u8]) -> Result<()>;
-    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()>;
+    #[cfg(feature = "ftdi")]
+    pub(crate) fn open_ft245(serial: Option<&str>) -> Result<Self> {
+        Self::new(Ft245Transport::open(serial)?, ConnectionKind::Ft245, None)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -46,7 +35,7 @@ pub(crate) struct SerialTransport {
 
 impl SerialTransport {
     pub(crate) fn open(port_name: &str) -> Result<Self> {
-        let mut port = serialport::new(port_name, BAUD_RATE)
+        let mut port = serialport::new(port_name, UART_BAUD_RATE)
             .timeout(Duration::from_secs(2))
             .open()
             .with_context(|| format!("Failed to open serial port {}", port_name))?;
@@ -97,11 +86,10 @@ impl SerialTransport {
                 }
             }
 
-            // 0x00 is a leaked modem-status zero; 0xFF is the usual
-            // glitch byte.  Anything else is a plausible version reply
-            // (versions 1..=127 are in range for this protocol).
+            // Accept only versions whose command semantics this tool knows.
+            // Any other byte is noise or an incompatible device response.
             match last {
-                Some(v) if v != 0x00 && v != 0xFF => {
+                Some(v) if is_supported_protocol_version(v) => {
                     // Double-check the line is now quiet.
                     port.set_timeout(Duration::from_millis(5))?;
                     while port.read(&mut discard).unwrap_or(0) > 0 {}
@@ -126,42 +114,56 @@ impl SerialTransport {
     }
 }
 
+#[maybe_async::maybe_async(?Send)]
 impl Transport for SerialTransport {
-    fn write_all(&mut self, data: &[u8]) -> Result<()> {
+    async fn write_all(&mut self, data: &[u8]) -> Result<()> {
         self.port.write_all(data)?;
         Ok(())
     }
 
-    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
-        self.port.read_exact(buf)?;
+    async fn read(&mut self, buffer: &mut [u8]) -> Result<usize> {
+        Ok(self.port.read(buffer)?)
+    }
+
+    async fn disconnect(&mut self) -> Result<()> {
         Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        true
     }
 }
 
 // ---------------------------------------------------------------------------
-// FT245 transport -- ftdi-nusb backend (pure Rust)
+// FT245 transport -- ftdi-nusb backend (pure Rust, nusb)
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "ftdi")]
 pub(crate) struct Ft245Transport {
-    dev: ftdi::FtdiDevice,
+    dev: ftdi_nusb::FtdiDevice,
 }
 
+#[cfg(feature = "ftdi")]
 impl Ft245Transport {
     pub(crate) fn open(serial: Option<&str>) -> Result<Self> {
         // Open the FT2232H Channel A.  The EEPROM must already be
         // configured for "245 FIFO" mode.
         let mut dev = if let Some(sn) = serial {
-            let filter = ftdi::DeviceFilter::new(FTDI_VID, FT2232H_PID).serial(sn);
-            ftdi::FtdiDevice::open_with_filter(&filter, ftdi::Interface::A)
+            let filter = ftdi_nusb::DeviceFilter::new(FTDI_VID, FT2232H_PID).serial(sn);
+            ftdi_nusb::FtdiDevice::open_with_filter(&filter, ftdi_nusb::Interface::A)
                 .with_context(|| format!("No FT2232H with serial '{}'", sn))?
         } else {
             // Try to find by description first
             let filter =
-                ftdi::DeviceFilter::new(FTDI_VID, FT2232H_PID).description("NORbert FT245");
-            ftdi::FtdiDevice::open_with_filter(&filter, ftdi::Interface::A)
+                ftdi_nusb::DeviceFilter::new(FTDI_VID, FT2232H_PID).description("NORbert FT245");
+            ftdi_nusb::FtdiDevice::open_with_filter(&filter, ftdi_nusb::Interface::A)
                 .or_else(|_| {
                     // Fall back to opening any FT2232H on interface A
-                    ftdi::FtdiDevice::open_with_interface(FTDI_VID, FT2232H_PID, ftdi::Interface::A)
+                    ftdi_nusb::FtdiDevice::open_with_interface(
+                        FTDI_VID,
+                        FT2232H_PID,
+                        ftdi_nusb::Interface::A,
+                    )
                 })
                 .context("No FT2232H found")?
         };
@@ -205,28 +207,23 @@ impl Ft245Transport {
     }
 }
 
+#[cfg(feature = "ftdi")]
+#[maybe_async::maybe_async(?Send)]
 impl Transport for Ft245Transport {
-    fn write_all(&mut self, data: &[u8]) -> Result<()> {
+    async fn write_all(&mut self, data: &[u8]) -> Result<()> {
         self.dev.write_all(data).map_err(|e| anyhow!(e))?;
         Ok(())
     }
 
-    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
-        let mut pos = 0;
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while pos < buf.len() {
-            if Instant::now() > deadline {
-                bail!("FT245 read timeout: got {} of {} bytes", pos, buf.len());
-            }
-            let n = self
-                .dev
-                .read_data(&mut buf[pos..])
-                .map_err(|e| anyhow!(e))?;
-            if n == 0 {
-                thread::sleep(Duration::from_micros(100));
-            }
-            pos += n;
-        }
+    async fn read(&mut self, buffer: &mut [u8]) -> Result<usize> {
+        self.dev.read_data(buffer).map_err(|e| anyhow!(e))
+    }
+
+    async fn disconnect(&mut self) -> Result<()> {
         Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        true
     }
 }

--- a/tool/src/web.rs
+++ b/tool/src/web.rs
@@ -1,0 +1,681 @@
+use crate::device::{
+    ConnectionKind, FT2232H_PID, FTDI_VID, FlashDevice, Transport, UART_BAUD_RATE,
+};
+use crate::protocol::{CMD_VERSION, is_supported_protocol_version};
+use anyhow::{Result, anyhow, bail};
+use ftdi_nusb::{FtdiDevice, Interface};
+use futures_util::{future::Either, pin_mut};
+use gloo_timers::future::TimeoutFuture;
+use js_sys::{Function, Promise, Reflect, Uint8Array};
+use std::collections::VecDeque;
+use std::future::Future;
+use wasm_bindgen::{JsCast, prelude::*};
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{
+    File, ReadableStreamDefaultReader, SerialOptions, SerialPort, UsbDevice, UsbDeviceFilter,
+    UsbDeviceRequestOptions, WritableStreamDefaultWriter,
+};
+
+const IO_TIMEOUT_MS: u32 = 5_000;
+const SERIAL_QUIET_MS: u32 = 50;
+const FILE_CHUNK_SIZE: usize = 1024 * 1024;
+
+fn js_error(error: impl std::fmt::Display) -> JsValue {
+    JsValue::from_str(&format!("{error:#}"))
+}
+
+fn js_value_text(error: &JsValue) -> String {
+    error.as_string().unwrap_or_else(|| format!("{error:?}"))
+}
+
+fn callback_result(result: JsValue) -> Result<()> {
+    if result.as_bool() == Some(false) {
+        bail!("operation cancelled");
+    }
+    Ok(())
+}
+
+fn with_cleanup_error(primary: anyhow::Error, cleanup: Result<()>) -> anyhow::Error {
+    match cleanup {
+        Ok(()) => primary,
+        Err(cleanup_error) => {
+            anyhow!("{primary:#}; connection cleanup also failed: {cleanup_error:#}")
+        }
+    }
+}
+
+async fn timeout<F, T>(future: F, milliseconds: u32, context: &str) -> Result<T>
+where
+    F: Future<Output = T>,
+{
+    let timer = TimeoutFuture::new(milliseconds);
+    pin_mut!(future);
+    pin_mut!(timer);
+    match futures_util::future::select(future, timer).await {
+        Either::Left((value, _)) => Ok(value),
+        Either::Right(((), _)) => Err(anyhow!("{context} timed out")),
+    }
+}
+
+struct WebSerialTransport {
+    port: SerialPort,
+    reader: Option<ReadableStreamDefaultReader>,
+    writer: Option<WritableStreamDefaultWriter>,
+    pending: VecDeque<u8>,
+    pending_read: Option<Promise>,
+    open: bool,
+}
+
+impl WebSerialTransport {
+    async fn request() -> Result<(Self, u8)> {
+        let window = web_sys::window().ok_or_else(|| anyhow!("window is unavailable"))?;
+        let selected = JsFuture::from(window.navigator().serial().request_port())
+            .await
+            .map_err(|error| anyhow!("Web Serial request failed: {}", js_value_text(&error)))?;
+        let port: SerialPort = selected
+            .dyn_into()
+            .map_err(|_| anyhow!("browser returned an invalid serial port"))?;
+
+        let options = SerialOptions::new(UART_BAUD_RATE);
+        options.set_buffer_size(65_536);
+        // Opening promises cannot be cancelled safely: a timed-out open may
+        // resolve later and leave a port open without an owner to close it.
+        JsFuture::from(port.open(&options)).await.map_err(|error| {
+            anyhow!("opening Web Serial port failed: {}", js_value_text(&error))
+        })?;
+
+        let mut transport = Self {
+            port,
+            reader: None,
+            writer: None,
+            pending: VecDeque::new(),
+            pending_read: None,
+            open: true,
+        };
+
+        let setup = async {
+            transport.reader = Some(
+                ReadableStreamDefaultReader::new(&transport.port.readable())
+                    .map_err(|error| anyhow!(js_value_text(&error)))?,
+            );
+            transport.writer = Some(
+                WritableStreamDefaultWriter::new(&transport.port.writable())
+                    .map_err(|error| anyhow!(js_value_text(&error)))?,
+            );
+            transport.resync().await
+        }
+        .await;
+
+        match setup {
+            Ok(version) => Ok((transport, version)),
+            Err(error) => {
+                let cleanup = transport.shutdown().await;
+                Err(with_cleanup_error(error, cleanup))
+            }
+        }
+    }
+
+    async fn resync(&mut self) -> Result<u8> {
+        // Send exactly one VERSION request. Reading until its supported reply
+        // arrives avoids the old retry race where a late reply from attempt N
+        // was mistaken for attempt N+1 and left another reply queued.
+        TimeoutFuture::new(20).await;
+        self.write_bytes(&[CMD_VERSION]).await?;
+
+        let mut examined = 0usize;
+        let version = loop {
+            let bytes = self
+                .read_chunk(256, IO_TIMEOUT_MS, true)
+                .await?
+                .ok_or_else(|| anyhow!("Web Serial synchronization timed out"))?;
+            examined += bytes.len();
+            if let Some(version) = bytes
+                .iter()
+                .rev()
+                .copied()
+                .find(|version| is_supported_protocol_version(*version))
+            {
+                break version;
+            }
+            if examined > 1024 {
+                bail!("too much startup noise while synchronizing Web Serial");
+            }
+        };
+
+        // Drain late startup glitches until the line has been quiet for a
+        // short period. A timed-out read promise is retained and reused by the
+        // next protocol read, because Web Serial read promises are not
+        // cancellable without closing the stream.
+        loop {
+            match self.read_chunk(256, SERIAL_QUIET_MS, false).await? {
+                Some(_) => continue,
+                None => return Ok(version),
+            }
+        }
+    }
+
+    fn next_read_promise(&mut self) -> Result<Promise> {
+        if let Some(promise) = self.pending_read.take() {
+            return Ok(promise);
+        }
+        let reader = self
+            .reader
+            .as_ref()
+            .ok_or_else(|| anyhow!("Web Serial connection is closed"))?;
+        Ok(reader.read())
+    }
+
+    async fn read_chunk(
+        &mut self,
+        maximum: usize,
+        milliseconds: u32,
+        timeout_is_fatal: bool,
+    ) -> Result<Option<Vec<u8>>> {
+        if !self.pending.is_empty() {
+            let count = maximum.min(self.pending.len());
+            return Ok(Some(self.pending.drain(..count).collect()));
+        }
+
+        let promise = self.next_read_promise()?;
+        let read = timeout(
+            JsFuture::from(promise.clone()),
+            milliseconds,
+            "Web Serial read",
+        )
+        .await;
+        let result = match read {
+            Ok(Ok(result)) => result,
+            Ok(Err(error)) => {
+                let primary = anyhow!("Web Serial read failed: {}", js_value_text(&error));
+                let cleanup = self.shutdown().await;
+                return Err(with_cleanup_error(primary, cleanup));
+            }
+            Err(_error) if !timeout_is_fatal => {
+                self.pending_read = Some(promise);
+                return Ok(None);
+            }
+            Err(error) => {
+                let cleanup = self.shutdown().await;
+                return Err(with_cleanup_error(error, cleanup));
+            }
+        };
+
+        let parsed = (|| -> Result<Option<Vec<u8>>> {
+            let done = Reflect::get(&result, &JsValue::from_str("done"))
+                .map_err(|error| anyhow!(js_value_text(&error)))?
+                .as_bool()
+                .unwrap_or(false);
+            if done {
+                bail!("Web Serial stream closed");
+            }
+
+            let value = Reflect::get(&result, &JsValue::from_str("value"))
+                .map_err(|error| anyhow!(js_value_text(&error)))?;
+            if value.is_null() || value.is_undefined() {
+                return Ok(Some(Vec::new()));
+            }
+            let bytes = Uint8Array::new(&value).to_vec();
+            let count = maximum.min(bytes.len());
+            self.pending.extend(bytes[count..].iter().copied());
+            Ok(Some(bytes[..count].to_vec()))
+        })();
+
+        match parsed {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                let cleanup = self.shutdown().await;
+                Err(with_cleanup_error(error, cleanup))
+            }
+        }
+    }
+
+    async fn write_bytes(&mut self, data: &[u8]) -> Result<()> {
+        let bytes = Uint8Array::from(data);
+        let write = {
+            let writer = self
+                .writer
+                .as_ref()
+                .ok_or_else(|| anyhow!("Web Serial connection is closed"))?;
+            timeout(
+                JsFuture::from(writer.write_with_chunk(bytes.as_ref())),
+                IO_TIMEOUT_MS,
+                "Web Serial write",
+            )
+            .await
+        };
+        match write {
+            Ok(Ok(_)) => Ok(()),
+            Ok(Err(error)) => {
+                let primary = anyhow!("Web Serial write failed: {}", js_value_text(&error));
+                let cleanup = self.shutdown().await;
+                Err(with_cleanup_error(primary, cleanup))
+            }
+            Err(error) => {
+                let cleanup = self.shutdown().await;
+                Err(with_cleanup_error(error, cleanup))
+            }
+        }
+    }
+
+    async fn shutdown(&mut self) -> Result<()> {
+        let mut failures = Vec::new();
+        self.pending.clear();
+        self.pending_read = None;
+
+        if let Some(reader) = self.reader.take() {
+            if let Err(error) = timeout(
+                JsFuture::from(reader.cancel()),
+                IO_TIMEOUT_MS,
+                "cancelling Web Serial reader",
+            )
+            .await
+            .and_then(|result| {
+                result
+                    .map(|_| ())
+                    .map_err(|error| anyhow!(js_value_text(&error)))
+            }) {
+                failures.push(format!("{error:#}"));
+            }
+            reader.release_lock();
+        }
+
+        if let Some(writer) = self.writer.take() {
+            if let Err(error) = timeout(
+                JsFuture::from(writer.abort()),
+                IO_TIMEOUT_MS,
+                "aborting Web Serial writer",
+            )
+            .await
+            .and_then(|result| {
+                result
+                    .map(|_| ())
+                    .map_err(|error| anyhow!(js_value_text(&error)))
+            }) {
+                failures.push(format!("{error:#}"));
+            }
+            writer.release_lock();
+        }
+
+        if self.open {
+            self.open = false;
+            if let Err(error) = timeout(
+                JsFuture::from(self.port.close()),
+                IO_TIMEOUT_MS,
+                "closing Web Serial port",
+            )
+            .await
+            .and_then(|result| {
+                result
+                    .map(|_| ())
+                    .map_err(|error| anyhow!(js_value_text(&error)))
+            }) {
+                failures.push(format!("{error:#}"));
+            }
+        }
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            bail!(failures.join("; "))
+        }
+    }
+}
+
+#[maybe_async::maybe_async(?Send)]
+impl Transport for WebSerialTransport {
+    async fn write_all(&mut self, data: &[u8]) -> Result<()> {
+        self.write_bytes(data).await
+    }
+
+    async fn read(&mut self, buffer: &mut [u8]) -> Result<usize> {
+        loop {
+            let bytes = self
+                .read_chunk(buffer.len(), IO_TIMEOUT_MS, true)
+                .await?
+                .ok_or_else(|| anyhow!("Web Serial read timed out"))?;
+            if bytes.is_empty() {
+                continue;
+            }
+            buffer[..bytes.len()].copy_from_slice(&bytes);
+            return Ok(bytes.len());
+        }
+    }
+
+    async fn disconnect(&mut self) -> Result<()> {
+        self.shutdown().await
+    }
+
+    fn is_connected(&self) -> bool {
+        self.open
+    }
+}
+
+struct WebUsbTransport {
+    device: Option<Box<FtdiDevice>>,
+}
+
+impl WebUsbTransport {
+    async fn request() -> Result<Self> {
+        let window = web_sys::window().ok_or_else(|| anyhow!("window is unavailable"))?;
+        let filter = UsbDeviceFilter::new();
+        filter.set_vendor_id(FTDI_VID);
+        filter.set_product_id(FT2232H_PID);
+        let options = UsbDeviceRequestOptions::new(&[filter]);
+        let selected = JsFuture::from(window.navigator().usb().request_device(&options))
+            .await
+            .map_err(|error| anyhow!("WebUSB request failed: {}", js_value_text(&error)))?;
+        let usb_device: UsbDevice = selected
+            .dyn_into()
+            .map_err(|_| anyhow!("browser returned an invalid USB device"))?;
+        let nusb_device = nusb::Device::from_js(usb_device)
+            .await
+            .map_err(|error| anyhow!("opening WebUSB device failed: {error}"))?;
+        let device = FtdiDevice::open_wasm(nusb_device, Interface::A)
+            .await
+            .map_err(|error| anyhow!("opening FT2232H channel A failed: {error}"))?;
+
+        let mut transport = Self {
+            device: Some(Box::new(device)),
+        };
+        let setup = transport.initialize().await;
+        match setup {
+            Ok(()) => Ok(transport),
+            Err(error) => {
+                let cleanup = transport.shutdown().await;
+                Err(with_cleanup_error(error, cleanup))
+            }
+        }
+    }
+
+    fn device_mut(&mut self) -> Result<&mut FtdiDevice> {
+        self.device
+            .as_deref_mut()
+            .ok_or_else(|| anyhow!("WebUSB connection is closed"))
+    }
+
+    async fn initialize(&mut self) -> Result<()> {
+        let device = self.device_mut()?;
+        timeout(device.usb_reset(), IO_TIMEOUT_MS, "FT2232H reset")
+            .await?
+            .map_err(|error| anyhow!(error))?;
+        timeout(device.flush_all(), IO_TIMEOUT_MS, "FT2232H flush")
+            .await?
+            .map_err(|error| anyhow!(error))?;
+        timeout(
+            device.set_latency_timer(1),
+            IO_TIMEOUT_MS,
+            "setting FT2232H latency timer",
+        )
+        .await?
+        .map_err(|error| anyhow!(error))?;
+        device.set_read_chunksize(65_536);
+        device.set_write_chunksize(65_536);
+
+        TimeoutFuture::new(5).await;
+        timeout(device.flush_all(), IO_TIMEOUT_MS, "FT2232H flush")
+            .await?
+            .map_err(|error| anyhow!(error))?;
+        Ok(())
+    }
+
+    async fn shutdown(&mut self) -> Result<()> {
+        let Some(mut device) = self.device.take() else {
+            return Ok(());
+        };
+        timeout(device.shutdown(), IO_TIMEOUT_MS, "closing WebUSB device").await
+    }
+
+    async fn fail<T>(&mut self, primary: anyhow::Error) -> Result<T> {
+        let cleanup = self.shutdown().await;
+        Err(with_cleanup_error(primary, cleanup))
+    }
+}
+
+#[maybe_async::maybe_async(?Send)]
+impl Transport for WebUsbTransport {
+    async fn write_all(&mut self, data: &[u8]) -> Result<()> {
+        let result = {
+            let device = self.device_mut()?;
+            timeout(device.write_all(data), IO_TIMEOUT_MS, "WebUSB write").await
+        };
+        match result {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(error)) => self.fail(anyhow!("WebUSB write failed: {error}")).await,
+            Err(error) => self.fail(error).await,
+        }
+    }
+
+    async fn read(&mut self, buffer: &mut [u8]) -> Result<usize> {
+        let result = {
+            let device = self.device_mut()?;
+            timeout(device.read_data(buffer), IO_TIMEOUT_MS, "WebUSB read").await
+        };
+        match result {
+            Ok(Ok(count)) => Ok(count),
+            Ok(Err(error)) => self.fail(anyhow!("WebUSB read failed: {error}")).await,
+            Err(error) => self.fail(error).await,
+        }
+    }
+
+    async fn disconnect(&mut self) -> Result<()> {
+        self.shutdown().await
+    }
+
+    fn is_connected(&self) -> bool {
+        self.device.is_some()
+    }
+}
+
+/// Browser connection to NORbert over WebUSB or Web Serial.
+#[wasm_bindgen]
+pub struct WebFlashDevice {
+    inner: FlashDevice,
+}
+
+#[wasm_bindgen]
+impl WebFlashDevice {
+    /// Show the WebUSB picker filtered to FT2232H devices and open channel A.
+    #[wasm_bindgen(js_name = requestUsb)]
+    pub async fn request_usb() -> Result<WebFlashDevice, JsValue> {
+        let transport = WebUsbTransport::request().await.map_err(js_error)?;
+        let inner = FlashDevice::new(transport, ConnectionKind::Ft245, None).map_err(js_error)?;
+        Ok(Self { inner })
+    }
+
+    /// Show the Web Serial picker, open at 2 Mbaud, and synchronize with NORbert.
+    #[wasm_bindgen(js_name = requestSerial)]
+    pub async fn request_serial() -> Result<WebFlashDevice, JsValue> {
+        let (transport, version) = WebSerialTransport::request().await.map_err(js_error)?;
+        let inner =
+            FlashDevice::new(transport, ConnectionKind::Uart, Some(version)).map_err(js_error)?;
+        Ok(Self { inner })
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.inner.is_connected()
+    }
+
+    pub async fn disconnect(&mut self) -> Result<(), JsValue> {
+        self.inner.disconnect().await.map_err(js_error)
+    }
+
+    pub async fn get_version(&mut self) -> Result<u8, JsValue> {
+        self.inner.get_version().await.map_err(js_error)
+    }
+
+    pub async fn supports_emulation_control(&mut self) -> Result<bool, JsValue> {
+        self.inner
+            .capabilities()
+            .await
+            .map(|capabilities| capabilities.emulation_control)
+            .map_err(js_error)
+    }
+
+    pub async fn supports_activity_log(&mut self) -> Result<bool, JsValue> {
+        self.inner
+            .capabilities()
+            .await
+            .map(|capabilities| capabilities.activity_log)
+            .map_err(js_error)
+    }
+
+    pub async fn start(&mut self) -> Result<(), JsValue> {
+        self.inner.start_emulation().await.map_err(js_error)
+    }
+
+    pub async fn stop(&mut self) -> Result<(), JsValue> {
+        self.inner.stop_emulation().await.map_err(js_error)
+    }
+
+    pub async fn status(&mut self) -> Result<bool, JsValue> {
+        self.inner.status().await.map_err(js_error)
+    }
+
+    pub async fn read(&mut self, address: u32, length: u32) -> Result<Vec<u8>, JsValue> {
+        self.inner.read(address, length).await.map_err(js_error)
+    }
+
+    /// Stream read chunks to JavaScript. The callback receives
+    /// `(chunk, completed, total)` and may return `false` to cancel.
+    pub async fn read_chunks(
+        &mut self,
+        address: u32,
+        length: u32,
+        on_chunk: Function,
+    ) -> Result<(), JsValue> {
+        let mut completed = 0usize;
+        self.inner
+            .read_chunks(address, length, |_, chunk| {
+                completed += chunk.len();
+                let bytes = Uint8Array::from(chunk);
+                let result = on_chunk
+                    .call3(
+                        &JsValue::UNDEFINED,
+                        bytes.as_ref(),
+                        &JsValue::from_f64(completed as f64),
+                        &JsValue::from_f64(length as f64),
+                    )
+                    .map_err(|error| anyhow!(js_value_text(&error)))?;
+                callback_result(result)
+            })
+            .await
+            .map_err(js_error)
+    }
+
+    pub async fn write(&mut self, address: u32, data: Vec<u8>) -> Result<(), JsValue> {
+        self.inner.write(address, &data).await.map_err(js_error)
+    }
+
+    /// Read a browser File in bounded chunks and write it through the shared
+    /// transfer session. The callback receives `(completed, total)` and may
+    /// return `false` to cancel.
+    pub async fn write_file(
+        &mut self,
+        address: u32,
+        file: File,
+        on_progress: Function,
+    ) -> Result<(), JsValue> {
+        let size = file.size();
+        if !size.is_finite() || size <= 0.0 || size > u32::MAX as f64 {
+            return Err(js_error("file size must be between 1 byte and 4 GiB"));
+        }
+        let length = size as usize;
+        let mut session = self
+            .inner
+            .begin_write(address, length)
+            .await
+            .map_err(js_error)?;
+        let operation = async {
+            let mut offset = 0usize;
+            let mut completed = 0usize;
+            while offset < length {
+                let end = (offset + FILE_CHUNK_SIZE).min(length);
+                let blob = file
+                    .slice_with_f64_and_f64(offset as f64, end as f64)
+                    .map_err(|error| anyhow!(js_value_text(&error)))?;
+                let buffer = JsFuture::from(blob.array_buffer())
+                    .await
+                    .map_err(|error| anyhow!(js_value_text(&error)))?;
+                let data = Uint8Array::new(&buffer).to_vec();
+                session
+                    .write_chunk(&data, |written| {
+                        completed += written;
+                        let result = on_progress
+                            .call2(
+                                &JsValue::UNDEFINED,
+                                &JsValue::from_f64(completed as f64),
+                                &JsValue::from_f64(length as f64),
+                            )
+                            .map_err(|error| anyhow!(js_value_text(&error)))?;
+                        callback_result(result)
+                    })
+                    .await?;
+                offset = end;
+            }
+            Ok(())
+        }
+        .await;
+        session.finish(operation).await.map_err(js_error)
+    }
+
+    pub async fn configure(
+        &mut self,
+        jedec_id: Vec<u8>,
+        total_size: u32,
+        supports_4byte: bool,
+        sfdp_table: Vec<u8>,
+    ) -> Result<(), JsValue> {
+        let jedec_id: [u8; 3] = jedec_id
+            .try_into()
+            .map_err(|_| js_error("JEDEC ID must contain exactly 3 bytes"))?;
+        self.inner
+            .configure(jedec_id, total_size, supports_4byte, &sfdp_table)
+            .await
+            .map_err(js_error)
+    }
+
+    pub async fn set_hold(&mut self, enabled: bool) -> Result<(), JsValue> {
+        self.inner.set_hold(enabled).await.map_err(js_error)
+    }
+
+    pub async fn log_start(&mut self) -> Result<(), JsValue> {
+        self.inner.log_start().await.map_err(js_error)
+    }
+
+    pub async fn log_stop(&mut self) -> Result<(), JsValue> {
+        self.inner.log_stop().await.map_err(js_error)
+    }
+
+    pub async fn log_poll(&mut self) -> Result<Vec<u8>, JsValue> {
+        self.inner.log_poll().await.map_err(js_error)
+    }
+
+    pub async fn toctou_set(
+        &mut self,
+        index: u8,
+        start: u32,
+        mask: u32,
+        replace: u32,
+    ) -> Result<(), JsValue> {
+        self.inner
+            .toctou_set(index, start, mask, replace)
+            .await
+            .map_err(js_error)
+    }
+
+    pub async fn toctou_arm(&mut self, index: u8) -> Result<(), JsValue> {
+        self.inner.toctou_arm(index).await.map_err(js_error)
+    }
+
+    pub async fn toctou_disarm(&mut self, index: u8) -> Result<(), JsValue> {
+        self.inner.toctou_disarm(index).await.map_err(js_error)
+    }
+
+    pub async fn toctou_reset(&mut self, index: u8) -> Result<(), JsValue> {
+        self.inner.toctou_reset(index).await.map_err(js_error)
+    }
+
+    pub async fn toctou_reset_all(&mut self) -> Result<(), JsValue> {
+        self.inner.toctou_reset_all().await.map_err(js_error)
+    }
+}

--- a/tool/src/web.rs
+++ b/tool/src/web.rs
@@ -20,6 +20,14 @@ const IO_TIMEOUT_MS: u32 = 5_000;
 const SERIAL_QUIET_MS: u32 = 50;
 const FILE_CHUNK_SIZE: usize = 1024 * 1024;
 
+fn file_length(file: &File) -> Result<usize> {
+    let size = file.size();
+    if !size.is_finite() || size <= 0.0 || size > u32::MAX as f64 {
+        bail!("file size must be between 1 byte and 4 GiB");
+    }
+    Ok(size as usize)
+}
+
 fn js_error(error: impl std::fmt::Display) -> JsValue {
     JsValue::from_str(&format!("{error:#}"))
 }
@@ -575,11 +583,7 @@ impl WebFlashDevice {
         file: File,
         on_progress: Function,
     ) -> Result<(), JsValue> {
-        let size = file.size();
-        if !size.is_finite() || size <= 0.0 || size > u32::MAX as f64 {
-            return Err(js_error("file size must be between 1 byte and 4 GiB"));
-        }
-        let length = size as usize;
+        let length = file_length(&file).map_err(js_error)?;
         let mut session = self
             .inner
             .begin_write(address, length)
@@ -616,6 +620,72 @@ impl WebFlashDevice {
         }
         .await;
         session.finish(operation).await.map_err(js_error)
+    }
+
+    /// Verify a browser File against SDRAM without retaining either the full
+    /// file or a full-device readback in WASM memory.
+    pub async fn verify_file(
+        &mut self,
+        address: u32,
+        file: File,
+        on_progress: Function,
+    ) -> Result<(), JsValue> {
+        let length = file_length(&file).map_err(js_error)?;
+        let was_running = self.inner.prepare_stopped().await.map_err(js_error)?;
+        let operation = async {
+            let mut offset = 0usize;
+            let mut completed = 0usize;
+            while offset < length {
+                let end = (offset + FILE_CHUNK_SIZE).min(length);
+                let blob = file
+                    .slice_with_f64_and_f64(offset as f64, end as f64)
+                    .map_err(|error| anyhow!(js_value_text(&error)))?;
+                let buffer = JsFuture::from(blob.array_buffer())
+                    .await
+                    .map_err(|error| anyhow!(js_value_text(&error)))?;
+                let expected = Uint8Array::new(&buffer).to_vec();
+                if expected.len() != end - offset {
+                    bail!("browser returned a truncated file chunk");
+                }
+
+                let chunk_address = address
+                    .checked_add(offset as u32)
+                    .ok_or_else(|| anyhow!("verification address overflow"))?;
+                self.inner
+                    .read_raw_chunks(chunk_address, expected.len() as u32, |actual_address, actual| {
+                        let expected_offset = (actual_address - chunk_address) as usize;
+                        let expected_chunk = &expected[expected_offset..expected_offset + actual.len()];
+                        if let Some((index, (&wanted, &found))) = expected_chunk
+                            .iter()
+                            .zip(actual)
+                            .enumerate()
+                            .find(|(_, (wanted, found))| wanted != found)
+                        {
+                            bail!(
+                                "verification failed at 0x{:08x}: expected 0x{wanted:02x}, got 0x{found:02x}",
+                                actual_address + index as u32
+                            );
+                        }
+                        completed += actual.len();
+                        let result = on_progress
+                            .call2(
+                                &JsValue::UNDEFINED,
+                                &JsValue::from_f64(completed as f64),
+                                &JsValue::from_f64(length as f64),
+                            )
+                            .map_err(|error| anyhow!(js_value_text(&error)))?;
+                        callback_result(result)
+                    })
+                    .await?;
+                offset = end;
+            }
+            Ok(())
+        }
+        .await;
+        self.inner
+            .finish_stopped(was_running, operation)
+            .await
+            .map_err(js_error)
     }
 
     pub async fn configure(

--- a/tool/src/web_main.rs
+++ b/tool/src/web_main.rs
@@ -1,0 +1,1341 @@
+#![cfg(target_arch = "wasm32")]
+
+use egui::Color32;
+use gloo_timers::future::TimeoutFuture;
+use js_sys::{Array, Uint8Array};
+use spi_flash_tool::WebFlashDevice;
+use spi_flash_tool::chip::{FlashChip, FlashChipExt};
+use spi_flash_tool::sfdp::generate_sfdp;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use wasm_bindgen::JsCast;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen_futures::{JsFuture, spawn_local};
+use web_sys::{Blob, BlobPropertyBag, HtmlAnchorElement, HtmlCanvasElement, HtmlInputElement, Url};
+
+#[derive(Default, PartialEq, Clone, Copy)]
+enum Panel {
+    #[default]
+    Device,
+    Activity,
+    Toctou,
+}
+
+#[derive(Default)]
+enum ConnectionState {
+    #[default]
+    Disconnected,
+    Connecting,
+    Connected,
+    Error(String),
+}
+
+struct SharedState {
+    device: Option<WebFlashDevice>,
+    connection: ConnectionState,
+    busy: bool,
+    version: Option<u8>,
+    running: Option<bool>,
+    emulation_control: bool,
+    activity_log: bool,
+    hold_enabled: Option<bool>,
+    status: String,
+    status_error: bool,
+    pending_file: Option<(String, Vec<u8>)>,
+    read_data: Option<Vec<u8>>,
+    log_output: String,
+    log_pending: Vec<u8>,
+    log_txn_count: u32,
+    log_opcode: u8,
+    log_address: u32,
+    log_line_open: bool,
+    log_accesses: HashMap<(u32, u8), u32>,
+    monitoring: bool,
+    configured_chip: Option<Rc<FlashChip>>,
+}
+
+impl Default for SharedState {
+    fn default() -> Self {
+        Self {
+            device: None,
+            connection: ConnectionState::Disconnected,
+            busy: false,
+            version: None,
+            running: None,
+            emulation_control: false,
+            activity_log: false,
+            hold_enabled: None,
+            status: "Choose a transport to connect to NORbert".to_owned(),
+            status_error: false,
+            pending_file: None,
+            read_data: None,
+            log_output: String::new(),
+            log_pending: Vec::new(),
+            log_txn_count: 0,
+            log_opcode: 0,
+            log_address: 0,
+            log_line_open: false,
+            log_accesses: HashMap::new(),
+            monitoring: false,
+            configured_chip: None,
+        }
+    }
+}
+
+struct ChipInfo {
+    chip: Rc<FlashChip>,
+    display_name: String,
+}
+
+struct NorbertWebApp {
+    state: Rc<RefCell<SharedState>>,
+    available_chips: Vec<ChipInfo>,
+    selected_chip: Option<Rc<FlashChip>>,
+    chip_search: String,
+    panel: Panel,
+    read_address: String,
+    read_length: String,
+    write_address: String,
+    upload_name: String,
+    upload_data: Option<Vec<u8>>,
+    verify_upload: bool,
+    toctou_index: String,
+    toctou_start: String,
+    toctou_mask: String,
+    toctou_replace: String,
+}
+
+impl NorbertWebApp {
+    fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+        let available_chips = spi_flash_tool::chip::ChipDatabase::new()
+            .iter()
+            .cloned()
+            .map(|chip| {
+                let display_name = format!("{} {}", chip.vendor, chip.name);
+                ChipInfo {
+                    chip: Rc::new(chip),
+                    display_name,
+                }
+            })
+            .collect();
+
+        Self {
+            state: Rc::new(RefCell::new(SharedState::default())),
+            available_chips,
+            selected_chip: None,
+            chip_search: String::new(),
+            panel: Panel::Device,
+            read_address: "0x000000".to_owned(),
+            read_length: "256".to_owned(),
+            write_address: "0x000000".to_owned(),
+            upload_name: String::new(),
+            upload_data: None,
+            verify_upload: false,
+            toctou_index: "0".to_owned(),
+            toctou_start: "0x001000".to_owned(),
+            toctou_mask: "0xFFF000".to_owned(),
+            toctou_replace: "0x101000".to_owned(),
+        }
+    }
+
+    fn connect(&self, usb: bool, ctx: &egui::Context) {
+        {
+            let mut state = self.state.borrow_mut();
+            state.connection = ConnectionState::Connecting;
+            state.busy = true;
+            state.status = if usb {
+                "Requesting FT245 device access..."
+            } else {
+                "Requesting UART access..."
+            }
+            .to_owned();
+            state.status_error = false;
+        }
+
+        let state = self.state.clone();
+        let repaint = ctx.clone();
+        spawn_local(async move {
+            let result = if usb {
+                WebFlashDevice::request_usb().await
+            } else {
+                WebFlashDevice::request_serial().await
+            };
+
+            match result {
+                Ok(mut device) => {
+                    let details = async {
+                        let version = device.get_version().await?;
+                        let emulation_control = device.supports_emulation_control().await?;
+                        let activity_log = device.supports_activity_log().await?;
+                        let running = if emulation_control {
+                            Some(device.status().await?)
+                        } else {
+                            None
+                        };
+                        Ok::<_, wasm_bindgen::JsValue>((
+                            version,
+                            emulation_control,
+                            activity_log,
+                            running,
+                        ))
+                    }
+                    .await;
+
+                    let mut shared = state.borrow_mut();
+                    match details {
+                        Ok((version, emulation_control, activity_log, running)) => {
+                            shared.device = Some(device);
+                            shared.connection = ConnectionState::Connected;
+                            shared.version = Some(version);
+                            shared.emulation_control = emulation_control;
+                            shared.activity_log = activity_log;
+                            shared.running = running;
+                            shared.status = "Connected successfully".to_owned();
+                            shared.status_error = false;
+                        }
+                        Err(error) => set_error(
+                            &mut shared,
+                            format!("Connection failed: {}", js_error(error)),
+                        ),
+                    }
+                }
+                Err(error) => {
+                    let mut shared = state.borrow_mut();
+                    shared.connection = ConnectionState::Error(js_error(error.clone()));
+                    set_error(
+                        &mut shared,
+                        format!("Connection failed: {}", js_error(error)),
+                    );
+                }
+            }
+            state.borrow_mut().busy = false;
+            repaint.request_repaint();
+        });
+    }
+
+    fn disconnect(&self, ctx: &egui::Context) {
+        let state = self.state.clone();
+        let repaint = ctx.clone();
+        state.borrow_mut().busy = true;
+        spawn_local(async move {
+            let mut device = state.borrow_mut().device.take();
+            let result = match device.as_mut() {
+                Some(device) => device.disconnect().await,
+                None => Ok(()),
+            };
+            let mut shared = state.borrow_mut();
+            shared.busy = false;
+            shared.version = None;
+            shared.running = None;
+            shared.emulation_control = false;
+            shared.activity_log = false;
+            shared.hold_enabled = None;
+            shared.configured_chip = None;
+            shared.connection = ConnectionState::Disconnected;
+            match result {
+                Ok(()) => {
+                    shared.status = "Disconnected".to_owned();
+                    shared.status_error = false;
+                }
+                Err(error) => set_error(
+                    &mut shared,
+                    format!("Disconnect failed: {}", js_error(error)),
+                ),
+            }
+            repaint.request_repaint();
+        });
+    }
+
+    fn set_running(&self, running: bool, ctx: &egui::Context) {
+        let state = self.state.clone();
+        let repaint = ctx.clone();
+        {
+            let mut shared = state.borrow_mut();
+            shared.busy = true;
+            shared.status = if running {
+                "Starting emulation..."
+            } else {
+                "Stopping emulation..."
+            }
+            .to_owned();
+        }
+        spawn_local(async move {
+            let mut device = state.borrow_mut().device.take();
+            let result = match device.as_mut() {
+                Some(device) if running => device.start().await,
+                Some(device) => device.stop().await,
+                None => Err(wasm_bindgen::JsValue::from_str("No device connected")),
+            };
+            let mut shared = state.borrow_mut();
+            shared.device = device;
+            shared.busy = false;
+            match result {
+                Ok(()) => {
+                    shared.running = Some(running);
+                    shared.status = if running {
+                        "Emulation started"
+                    } else {
+                        "Emulation stopped"
+                    }
+                    .to_owned();
+                    shared.status_error = false;
+                }
+                Err(error) => set_error(
+                    &mut shared,
+                    format!("Operation failed: {}", js_error(error)),
+                ),
+            }
+            repaint.request_repaint();
+        });
+    }
+
+    fn refresh(&self, ctx: &egui::Context) {
+        let state = self.state.clone();
+        let repaint = ctx.clone();
+        state.borrow_mut().busy = true;
+        spawn_local(async move {
+            let mut device = state.borrow_mut().device.take();
+            let result = match device.as_mut() {
+                Some(device) => device.status().await,
+                None => Err(wasm_bindgen::JsValue::from_str("No device connected")),
+            };
+            let mut shared = state.borrow_mut();
+            shared.device = device;
+            shared.busy = false;
+            match result {
+                Ok(running) => {
+                    shared.running = Some(running);
+                    shared.status = "Status refreshed".to_owned();
+                    shared.status_error = false;
+                }
+                Err(error) => set_error(&mut shared, format!("Status failed: {}", js_error(error))),
+            }
+            repaint.request_repaint();
+        });
+    }
+
+    fn configure_chip(&self, chip: Rc<FlashChip>, ctx: &egui::Context) {
+        let sfdp = match generate_sfdp(&chip) {
+            Ok(table) => table.to_vec(),
+            Err(error) => {
+                set_error(
+                    &mut self.state.borrow_mut(),
+                    format!("Failed to generate SFDP: {error}"),
+                );
+                return;
+            }
+        };
+        let jedec_id = chip.jedec_id_bytes().to_vec();
+        let total_size = chip.total_size;
+        let supports_4byte = chip.supports_4byte();
+        let state = self.state.clone();
+        let repaint = ctx.clone();
+        {
+            let mut shared = state.borrow_mut();
+            shared.busy = true;
+            shared.configured_chip = None;
+            shared.status = format!("Configuring {} {}...", chip.vendor, chip.name);
+            shared.status_error = false;
+        }
+
+        spawn_local(async move {
+            let mut device = state.borrow_mut().device.take();
+            let result = match device.as_mut() {
+                Some(device) => {
+                    device
+                        .configure(jedec_id, total_size, supports_4byte, sfdp)
+                        .await
+                }
+                None => Err(wasm_bindgen::JsValue::from_str("No device connected")),
+            };
+            let running = if result.is_ok() {
+                match device.as_mut() {
+                    Some(device) => device.status().await.ok(),
+                    None => None,
+                }
+            } else {
+                None
+            };
+            let mut shared = state.borrow_mut();
+            shared.device = device;
+            shared.busy = false;
+            match result {
+                Ok(()) => {
+                    shared.configured_chip = Some(chip.clone());
+                    shared.running = running;
+                    shared.status = format!(
+                        "Configured {} {} ({} MiB, JEDEC {:02X} {:04X})",
+                        chip.vendor,
+                        chip.name,
+                        chip.total_size / (1024 * 1024),
+                        chip.jedec_manufacturer,
+                        chip.jedec_device,
+                    );
+                    shared.status_error = false;
+                }
+                Err(error) => set_error(
+                    &mut shared,
+                    format!("Chip configuration failed: {}", js_error(error)),
+                ),
+            }
+            repaint.request_repaint();
+        });
+    }
+
+    fn select_file(&self) {
+        let document = web_sys::window().unwrap().document().unwrap();
+        let input: HtmlInputElement = document
+            .create_element("input")
+            .unwrap()
+            .dyn_into()
+            .unwrap();
+        input.set_type("file");
+        input.set_accept(".bin,.rom,.img,*");
+        let state = self.state.clone();
+        let onchange = Closure::wrap(Box::new(move |event: web_sys::Event| {
+            let input: HtmlInputElement = event.target().unwrap().dyn_into().unwrap();
+            if let Some(file) = input.files().and_then(|files| files.get(0)) {
+                let filename = file.name();
+                let state = state.clone();
+                spawn_local(async move {
+                    match JsFuture::from(file.array_buffer()).await {
+                        Ok(buffer) => {
+                            let data = Uint8Array::new(&buffer).to_vec();
+                            let mut shared = state.borrow_mut();
+                            shared.pending_file = Some((filename, data));
+                            shared.status = "File loaded".to_owned();
+                            shared.status_error = false;
+                        }
+                        Err(error) => set_error(
+                            &mut state.borrow_mut(),
+                            format!("File read failed: {}", js_error(error)),
+                        ),
+                    }
+                });
+            }
+        }) as Box<dyn FnMut(_)>);
+        input.set_onchange(Some(onchange.as_ref().unchecked_ref()));
+        onchange.forget();
+        input.click();
+    }
+
+    fn write_memory(&self, address: u32, data: Vec<u8>, verify: bool, ctx: &egui::Context) {
+        let state = self.state.clone();
+        let repaint = ctx.clone();
+        state.borrow_mut().busy = true;
+        spawn_local(async move {
+            let mut device = state.borrow_mut().device.take();
+            let result = match device.as_mut() {
+                Some(device) => match device.write(address, data.clone()).await {
+                    Ok(()) if verify => match device.read(address, data.len() as u32).await {
+                        Ok(actual) if actual == data => Ok(()),
+                        Ok(_) => Err(wasm_bindgen::JsValue::from_str(
+                            "Verification failed: device contents differ from the selected file",
+                        )),
+                        Err(error) => Err(error),
+                    },
+                    result => result,
+                },
+                None => Err(wasm_bindgen::JsValue::from_str("No device connected")),
+            };
+            let mut shared = state.borrow_mut();
+            shared.device = device;
+            shared.busy = false;
+            match result {
+                Ok(()) => {
+                    shared.running = Some(true);
+                    shared.status = "Upload complete".to_owned();
+                    shared.status_error = false;
+                }
+                Err(error) => set_error(&mut shared, format!("Upload failed: {}", js_error(error))),
+            }
+            repaint.request_repaint();
+        });
+    }
+
+    fn read_memory(&self, address: u32, length: u32, ctx: &egui::Context) {
+        let state = self.state.clone();
+        let repaint = ctx.clone();
+        state.borrow_mut().busy = true;
+        spawn_local(async move {
+            let mut device = state.borrow_mut().device.take();
+            let result = match device.as_mut() {
+                Some(device) => device.read(address, length).await,
+                None => Err(wasm_bindgen::JsValue::from_str("No device connected")),
+            };
+            let mut shared = state.borrow_mut();
+            shared.device = device;
+            shared.busy = false;
+            match result {
+                Ok(data) => {
+                    shared.read_data = Some(data);
+                    shared.running = Some(true);
+                    shared.status = "Download complete".to_owned();
+                    shared.status_error = false;
+                }
+                Err(error) => {
+                    set_error(&mut shared, format!("Download failed: {}", js_error(error)))
+                }
+            }
+            repaint.request_repaint();
+        });
+    }
+
+    fn set_hold(&self, enabled: bool, ctx: &egui::Context) {
+        let state = self.state.clone();
+        let repaint = ctx.clone();
+        state.borrow_mut().busy = true;
+        spawn_local(async move {
+            let mut device = state.borrow_mut().device.take();
+            let result = match device.as_mut() {
+                Some(device) => device.set_hold(enabled).await,
+                None => Err(wasm_bindgen::JsValue::from_str("No device connected")),
+            };
+            let mut shared = state.borrow_mut();
+            shared.device = device;
+            shared.busy = false;
+            match result {
+                Ok(()) => {
+                    shared.hold_enabled = Some(enabled);
+                    shared.status = if enabled {
+                        "Target flash #HOLD asserted"
+                    } else {
+                        "Target flash #HOLD released"
+                    }
+                    .to_owned();
+                    shared.status_error = false;
+                }
+                Err(error) => set_error(
+                    &mut shared,
+                    format!("Hold control failed: {}", js_error(error)),
+                ),
+            }
+            repaint.request_repaint();
+        });
+    }
+
+    fn toctou_command(&self, command: ToctouCommand, ctx: &egui::Context) {
+        let state = self.state.clone();
+        let repaint = ctx.clone();
+        state.borrow_mut().busy = true;
+        spawn_local(async move {
+            let mut device = state.borrow_mut().device.take();
+            let result = match (device.as_mut(), command) {
+                (
+                    Some(device),
+                    ToctouCommand::Set {
+                        index,
+                        start,
+                        mask,
+                        replace,
+                    },
+                ) => device.toctou_set(index, start, mask, replace).await,
+                (Some(device), ToctouCommand::Arm(index)) => device.toctou_arm(index).await,
+                (Some(device), ToctouCommand::Disarm(index)) => device.toctou_disarm(index).await,
+                (Some(device), ToctouCommand::Reset(index)) => device.toctou_reset(index).await,
+                (Some(device), ToctouCommand::ResetAll) => device.toctou_reset_all().await,
+                (None, _) => Err(wasm_bindgen::JsValue::from_str("No device connected")),
+            };
+            let mut shared = state.borrow_mut();
+            shared.device = device;
+            shared.busy = false;
+            match result {
+                Ok(()) => {
+                    shared.status = "TOCTOU configuration updated".to_owned();
+                    shared.status_error = false;
+                }
+                Err(error) => set_error(
+                    &mut shared,
+                    format!("TOCTOU command failed: {}", js_error(error)),
+                ),
+            }
+            repaint.request_repaint();
+        });
+    }
+
+    fn start_monitor(&self, ctx: &egui::Context) {
+        let state = self.state.clone();
+        let repaint = ctx.clone();
+        {
+            let mut shared = state.borrow_mut();
+            shared.busy = true;
+            shared.monitoring = true;
+            shared.log_pending.clear();
+            shared.log_accesses.clear();
+            shared.log_txn_count = 0;
+            shared.log_line_open = false;
+            shared.status = "Starting SPI activity capture...".to_owned();
+            shared.status_error = false;
+        }
+        spawn_local(async move {
+            let Some(mut device) = state.borrow_mut().device.take() else {
+                let mut shared = state.borrow_mut();
+                shared.busy = false;
+                shared.monitoring = false;
+                set_error(&mut shared, "No device connected".to_owned());
+                return;
+            };
+            if let Err(error) = device.log_start().await {
+                let mut shared = state.borrow_mut();
+                shared.device = Some(device);
+                shared.busy = false;
+                shared.monitoring = false;
+                set_error(
+                    &mut shared,
+                    format!("Failed to start activity capture: {}", js_error(error)),
+                );
+                repaint.request_repaint();
+                return;
+            }
+            state.borrow_mut().status = "SPI activity capture running".to_owned();
+
+            while state.borrow().monitoring {
+                match device.log_poll().await {
+                    Ok(data) if !data.is_empty() => {
+                        decode_log_packets(&mut state.borrow_mut(), &data)
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        let mut shared = state.borrow_mut();
+                        set_error(
+                            &mut shared,
+                            format!("Activity capture failed: {}", js_error(error)),
+                        );
+                        shared.monitoring = false;
+                    }
+                }
+                repaint.request_repaint();
+                TimeoutFuture::new(10).await;
+            }
+
+            let stop_result = device.log_stop().await;
+            let mut shared = state.borrow_mut();
+            shared.device = Some(device);
+            shared.busy = false;
+            shared.monitoring = false;
+            match stop_result {
+                Ok(()) if !shared.status_error => {
+                    shared.status = "SPI activity capture stopped".to_owned();
+                }
+                Ok(()) => {}
+                Err(error) => set_error(
+                    &mut shared,
+                    format!("Failed to stop activity capture: {}", js_error(error)),
+                ),
+            }
+            repaint.request_repaint();
+        });
+    }
+
+    fn stop_monitor(&self) {
+        let mut state = self.state.borrow_mut();
+        state.monitoring = false;
+        state.status = "Stopping SPI activity capture...".to_owned();
+    }
+
+    fn device_panel(&mut self, ui: &mut egui::Ui, ctx: &egui::Context) {
+        ui.heading("Device");
+        ui.separator();
+
+        let state = self.state.borrow();
+        let connected = matches!(state.connection, ConnectionState::Connected);
+        let connecting = matches!(state.connection, ConnectionState::Connecting);
+        let busy = state.busy;
+        let version = state.version;
+        let running = state.running;
+        let emulation_control = state.emulation_control;
+        let configured_chip = state.configured_chip.clone();
+        drop(state);
+
+        ui.horizontal(|ui| {
+            if ui
+                .add_enabled(
+                    !connected && !connecting,
+                    egui::Button::new("Connect FT245 (WebUSB)"),
+                )
+                .clicked()
+            {
+                self.connect(true, ctx);
+            }
+            if ui
+                .add_enabled(
+                    !connected && !connecting,
+                    egui::Button::new("Connect UART (Web Serial)"),
+                )
+                .clicked()
+            {
+                self.connect(false, ctx);
+            }
+            if ui
+                .add_enabled(connected && !busy, egui::Button::new("Disconnect"))
+                .clicked()
+            {
+                self.disconnect(ctx);
+            }
+            if connecting {
+                ui.spinner();
+            }
+        });
+
+        match &self.state.borrow().connection {
+            ConnectionState::Disconnected => {
+                ui.label("No device connected");
+            }
+            ConnectionState::Connecting => {
+                ui.label("Requesting browser device access...");
+            }
+            ConnectionState::Connected => {
+                ui.label(egui::RichText::new("Connected").color(Color32::GREEN));
+            }
+            ConnectionState::Error(error) => {
+                ui.label(egui::RichText::new(error).color(Color32::RED));
+            }
+        }
+
+        if connected {
+            ui.add_space(16.0);
+            ui.separator();
+            ui.heading("Device Information");
+            egui::Grid::new("device_info")
+                .num_columns(2)
+                .spacing([20.0, 4.0])
+                .show(ui, |ui| {
+                    ui.label("Protocol version:");
+                    ui.label(version.map_or_else(|| "Unknown".to_owned(), |v| v.to_string()));
+                    ui.end_row();
+                    ui.label("Emulation:");
+                    ui.label(match running {
+                        Some(true) => "Running",
+                        Some(false) => "Stopped",
+                        None => "Unavailable",
+                    });
+                    ui.end_row();
+                    ui.label("Emulated chip:");
+                    ui.label(configured_chip.as_ref().map_or_else(
+                        || "Not configured".to_owned(),
+                        |chip| format!("{} {}", chip.vendor, chip.name),
+                    ));
+                    ui.end_row();
+                });
+
+            ui.add_space(16.0);
+            ui.separator();
+            ui.heading("Flash Chip");
+            ui.label("Select and configure the flash chip NORbert should emulate.");
+
+            let mut chip_to_configure = None;
+            let popup_id = ui.make_persistent_id("chip_selector_popup");
+            let selected_text = self.selected_chip.as_ref().map_or_else(
+                || "Select chip...".to_owned(),
+                |chip| {
+                    format!(
+                        "{} {} ({} MiB)",
+                        chip.vendor,
+                        chip.name,
+                        chip.total_size / (1024 * 1024),
+                    )
+                },
+            );
+            let response = ui.add_enabled(
+                !busy,
+                egui::Button::new(format!("{selected_text} ▼")).min_size(egui::vec2(500.0, 0.0)),
+            );
+            if response.clicked() {
+                ui.memory_mut(|memory| memory.toggle_popup(popup_id));
+            }
+            let search_id = ui.make_persistent_id("chip_search_field");
+            egui::popup::popup_below_widget(
+                ui,
+                popup_id,
+                &response,
+                egui::popup::PopupCloseBehavior::CloseOnClickOutside,
+                |ui| {
+                    ui.set_min_width(500.0);
+                    ui.add(
+                        egui::TextEdit::singleline(&mut self.chip_search)
+                            .id(search_id)
+                            .hint_text("Search chips..."),
+                    )
+                    .request_focus();
+                    ui.separator();
+                    let search = self.chip_search.to_lowercase();
+                    egui::ScrollArea::vertical()
+                        .max_height(500.0)
+                        .show(ui, |ui| {
+                            for chip_info in &self.available_chips {
+                                if (search.is_empty()
+                                    || chip_info.display_name.to_lowercase().contains(&search))
+                                    && ui
+                                        .selectable_label(
+                                            self.selected_chip.as_ref().is_some_and(|selected| {
+                                                Rc::ptr_eq(selected, &chip_info.chip)
+                                            }),
+                                            &chip_info.display_name,
+                                        )
+                                        .clicked()
+                                {
+                                    chip_to_configure = Some(chip_info.chip.clone());
+                                    ui.memory_mut(|memory| memory.close_popup());
+                                }
+                            }
+                        });
+                },
+            );
+            if let Some(chip) = chip_to_configure {
+                self.configure_chip(chip, ctx);
+            }
+
+            if let Some(chip) = configured_chip.as_ref() {
+                ui.label(format!(
+                    "JEDEC {:02X} {:04X} · {} KiB · {}-byte addressing",
+                    chip.jedec_manufacturer,
+                    chip.jedec_device,
+                    chip.total_size / 1024,
+                    if chip.supports_4byte() { 4 } else { 3 },
+                ));
+            }
+
+            ui.add_space(16.0);
+            ui.separator();
+            ui.heading("Control");
+            ui.horizontal(|ui| {
+                if ui
+                    .add_enabled(
+                        emulation_control && running != Some(true) && !busy,
+                        egui::Button::new("Start"),
+                    )
+                    .clicked()
+                {
+                    self.set_running(true, ctx);
+                }
+                if ui
+                    .add_enabled(
+                        emulation_control && running == Some(true) && !busy,
+                        egui::Button::new("Stop"),
+                    )
+                    .clicked()
+                {
+                    self.set_running(false, ctx);
+                }
+                if ui
+                    .add_enabled(emulation_control && !busy, egui::Button::new("Refresh"))
+                    .clicked()
+                {
+                    self.refresh(ctx);
+                }
+            });
+            ui.horizontal(|ui| {
+                ui.label("Target flash #HOLD:");
+                let hold_enabled = self.state.borrow().hold_enabled;
+                if ui
+                    .add_enabled(
+                        !busy && hold_enabled != Some(true),
+                        egui::Button::new("Assert"),
+                    )
+                    .clicked()
+                {
+                    self.set_hold(true, ctx);
+                }
+                if ui
+                    .add_enabled(
+                        !busy && hold_enabled != Some(false),
+                        egui::Button::new("Release"),
+                    )
+                    .clicked()
+                {
+                    self.set_hold(false, ctx);
+                }
+            });
+
+            ui.add_space(16.0);
+            ui.separator();
+            ui.heading("Memory");
+            ui.label("Upload to Device:");
+            ui.horizontal(|ui| {
+                if ui
+                    .add_enabled(!busy, egui::Button::new("Select File..."))
+                    .clicked()
+                {
+                    self.select_file();
+                }
+                if !self.upload_name.is_empty() {
+                    ui.label(format!(
+                        "{} ({} bytes)",
+                        self.upload_name,
+                        self.upload_data.as_ref().map_or(0, Vec::len)
+                    ));
+                }
+            });
+            ui.horizontal(|ui| {
+                ui.label("Start Address:");
+                ui.add(egui::TextEdit::singleline(&mut self.write_address).desired_width(120.0));
+                let parsed = parse_number(&self.write_address);
+                if ui
+                    .add_enabled(
+                        self.upload_data.is_some() && parsed.is_some() && !busy,
+                        egui::Button::new("Upload"),
+                    )
+                    .clicked()
+                {
+                    self.write_memory(
+                        parsed.unwrap(),
+                        self.upload_data.clone().unwrap(),
+                        self.verify_upload,
+                        ctx,
+                    );
+                }
+            });
+            ui.checkbox(&mut self.verify_upload, "Verify after upload");
+
+            ui.add_space(8.0);
+            ui.separator();
+            ui.label("Download from Device:");
+            ui.horizontal(|ui| {
+                ui.label("Address:");
+                ui.add(egui::TextEdit::singleline(&mut self.read_address).desired_width(120.0));
+                ui.label("Length:");
+                ui.add(egui::TextEdit::singleline(&mut self.read_length).desired_width(120.0));
+                let address = parse_number(&self.read_address);
+                let length = parse_number(&self.read_length);
+                if ui
+                    .add_enabled(
+                        address.is_some() && length.is_some() && !busy,
+                        egui::Button::new("Download"),
+                    )
+                    .clicked()
+                {
+                    self.read_memory(address.unwrap(), length.unwrap(), ctx);
+                }
+            });
+            if let Some(data) = self.state.borrow().read_data.as_ref() {
+                ui.horizontal(|ui| {
+                    ui.label(format!("{} bytes ready", data.len()));
+                    if ui.button("Save As...").clicked() {
+                        save_file(data, "norbert-dump.bin");
+                    }
+                });
+                egui::ScrollArea::vertical()
+                    .max_height(180.0)
+                    .show(ui, |ui| {
+                        ui.code(hex_dump(&data[..data.len().min(4096)], 0));
+                    });
+            }
+        }
+    }
+
+    fn toctou_panel(&mut self, ui: &mut egui::Ui, ctx: &egui::Context) {
+        ui.heading("TOCTOU Traps");
+        ui.separator();
+        let state = self.state.borrow();
+        let connected = matches!(state.connection, ConnectionState::Connected);
+        let busy = state.busy;
+        drop(state);
+        if !connected {
+            ui.label("Connect to a device first.");
+            return;
+        }
+
+        ui.label("Configure one of four address-match traps. The first matching read passes through; subsequent reads are redirected.");
+        egui::Grid::new("toctou_fields")
+            .num_columns(2)
+            .spacing([20.0, 8.0])
+            .show(ui, |ui| {
+                ui.label("Trap index (0-3):");
+                ui.text_edit_singleline(&mut self.toctou_index);
+                ui.end_row();
+                ui.label("Start address:");
+                ui.text_edit_singleline(&mut self.toctou_start);
+                ui.end_row();
+                ui.label("Match mask:");
+                ui.text_edit_singleline(&mut self.toctou_mask);
+                ui.end_row();
+                ui.label("Replacement base:");
+                ui.text_edit_singleline(&mut self.toctou_replace);
+                ui.end_row();
+            });
+
+        let index = parse_number(&self.toctou_index)
+            .and_then(|value| u8::try_from(value).ok())
+            .filter(|value| *value < 4);
+        let start = parse_number(&self.toctou_start);
+        let mask = parse_number(&self.toctou_mask);
+        let replace = parse_number(&self.toctou_replace);
+        ui.horizontal(|ui| {
+            if ui
+                .add_enabled(
+                    index.is_some()
+                        && start.is_some()
+                        && mask.is_some()
+                        && replace.is_some()
+                        && !busy,
+                    egui::Button::new("Set"),
+                )
+                .clicked()
+            {
+                self.toctou_command(
+                    ToctouCommand::Set {
+                        index: index.unwrap(),
+                        start: start.unwrap(),
+                        mask: mask.unwrap(),
+                        replace: replace.unwrap(),
+                    },
+                    ctx,
+                );
+            }
+            if ui
+                .add_enabled(index.is_some() && !busy, egui::Button::new("Arm"))
+                .clicked()
+            {
+                self.toctou_command(ToctouCommand::Arm(index.unwrap()), ctx);
+            }
+            if ui
+                .add_enabled(index.is_some() && !busy, egui::Button::new("Disarm"))
+                .clicked()
+            {
+                self.toctou_command(ToctouCommand::Disarm(index.unwrap()), ctx);
+            }
+            if ui
+                .add_enabled(index.is_some() && !busy, egui::Button::new("Reset trigger"))
+                .clicked()
+            {
+                self.toctou_command(ToctouCommand::Reset(index.unwrap()), ctx);
+            }
+            if ui
+                .add_enabled(!busy, egui::Button::new("Reset all"))
+                .clicked()
+            {
+                self.toctou_command(ToctouCommand::ResetAll, ctx);
+            }
+        });
+        if index.is_none() {
+            ui.label(
+                egui::RichText::new("Trap index must be between 0 and 3.").color(Color32::RED),
+            );
+        }
+    }
+
+    fn activity_panel(&self, ui: &mut egui::Ui, ctx: &egui::Context) {
+        ui.heading("SPI Activity");
+        ui.separator();
+        let state = self.state.borrow();
+        let connected = matches!(state.connection, ConnectionState::Connected);
+        let supported = state.activity_log;
+        let monitoring = state.monitoring;
+        let busy = state.busy;
+        drop(state);
+        if !connected {
+            ui.label("Connect to a device first.");
+            return;
+        }
+        ui.horizontal(|ui| {
+            if ui
+                .add_enabled(supported && !busy, egui::Button::new("Start Capture"))
+                .clicked()
+            {
+                self.start_monitor(ctx);
+            }
+            if ui
+                .add_enabled(monitoring, egui::Button::new("Stop Capture"))
+                .clicked()
+            {
+                self.stop_monitor();
+            }
+            if ui.button("Clear").clicked() {
+                self.state.borrow_mut().log_output.clear();
+            }
+        });
+        egui::ScrollArea::vertical()
+            .stick_to_bottom(true)
+            .show(ui, |ui| {
+                let mut state = self.state.borrow_mut();
+                ui.add(
+                    egui::TextEdit::multiline(&mut state.log_output)
+                        .font(egui::TextStyle::Monospace)
+                        .desired_width(f32::INFINITY)
+                        .interactive(false),
+                );
+            });
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ToctouCommand {
+    Set {
+        index: u8,
+        start: u32,
+        mask: u32,
+        replace: u32,
+    },
+    Arm(u8),
+    Disarm(u8),
+    Reset(u8),
+    ResetAll,
+}
+
+impl eframe::App for NorbertWebApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        self.selected_chip = self.state.borrow().configured_chip.clone();
+
+        if let Some((name, data)) = self.state.borrow_mut().pending_file.take() {
+            self.upload_name = name;
+            self.upload_data = Some(data);
+        }
+
+        egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.heading("NORbert Web Interface");
+                ui.separator();
+                ui.selectable_value(&mut self.panel, Panel::Device, "Device");
+                ui.selectable_value(&mut self.panel, Panel::Activity, "Activity");
+                ui.selectable_value(&mut self.panel, Panel::Toctou, "TOCTOU");
+            });
+        });
+        egui::TopBottomPanel::bottom("bottom_panel").show(ctx, |ui| {
+            let state = self.state.borrow();
+            let color = if state.status_error {
+                Color32::RED
+            } else {
+                Color32::GREEN
+            };
+            ui.label(egui::RichText::new(&state.status).color(color));
+        });
+        egui::CentralPanel::default().show(ctx, |ui| match self.panel {
+            Panel::Device => self.device_panel(ui, ctx),
+            Panel::Activity => self.activity_panel(ui, ctx),
+            Panel::Toctou => self.toctou_panel(ui, ctx),
+        });
+        if self.state.borrow().busy
+            || matches!(self.state.borrow().connection, ConnectionState::Connecting)
+        {
+            ctx.request_repaint_after(std::time::Duration::from_millis(50));
+        }
+    }
+}
+
+fn decode_log_packets(state: &mut SharedState, data: &[u8]) {
+    const LOG_CMD: u8 = 0xA1;
+    const LOG_ADDR: u8 = 0xA2;
+    const LOG_END: u8 = 0xA3;
+    const LOG_TRAP: u8 = 0xA4;
+
+    state.log_pending.extend_from_slice(data);
+    let mut position = 0;
+    while position < state.log_pending.len() {
+        let remaining = state.log_pending.len() - position;
+        match state.log_pending[position] {
+            LOG_CMD if remaining >= 2 => {
+                if state.log_line_open {
+                    state.log_output.push('\n');
+                }
+                state.log_opcode = state.log_pending[position + 1];
+                state.log_txn_count += 1;
+                state.log_output.push_str(&format!(
+                    "{:<6} 0x{:02X} {:<18}",
+                    state.log_txn_count,
+                    state.log_opcode,
+                    spi_opcode_name(state.log_opcode),
+                ));
+                state.log_line_open = true;
+                position += 2;
+            }
+            LOG_ADDR if remaining >= 5 => {
+                let address = u32::from_be_bytes([
+                    state.log_pending[position + 1],
+                    state.log_pending[position + 2],
+                    state.log_pending[position + 3],
+                    state.log_pending[position + 4],
+                ]);
+                state.log_address = address;
+                state.log_output.push_str(&format!(" 0x{address:08X}"));
+                if is_read_opcode(state.log_opcode) {
+                    let count = state
+                        .log_accesses
+                        .entry((address, state.log_opcode))
+                        .or_insert(0);
+                    *count += 1;
+                    if *count == 2 {
+                        state
+                            .log_output
+                            .push_str("  ** DOUBLE READ (TOCTOU candidate)");
+                    } else if *count > 2 {
+                        state.log_output.push_str(&format!("  ** READ #{count}"));
+                    }
+                }
+                state.log_output.push('\n');
+                state.log_line_open = false;
+                position += 5;
+            }
+            LOG_END if remaining >= 4 => {
+                let count = u32::from_be_bytes([
+                    0,
+                    state.log_pending[position + 1],
+                    state.log_pending[position + 2],
+                    state.log_pending[position + 3],
+                ]);
+                if state.log_line_open {
+                    state.log_output.push('\n');
+                    state.log_line_open = false;
+                }
+                if count > 1 {
+                    state.log_output.push_str(&format!(
+                        "       end: {count} bytes from 0x{:08X}\n",
+                        state.log_address,
+                    ));
+                }
+                position += 4;
+            }
+            LOG_TRAP if remaining >= 6 => {
+                let index = state.log_pending[position + 1];
+                let address = u32::from_be_bytes([
+                    0,
+                    state.log_pending[position + 2],
+                    state.log_pending[position + 3],
+                    state.log_pending[position + 4],
+                ]);
+                state.log_output.push_str(&format!(
+                    "!! TOCTOU TRAP #{index} FIRED at 0x{address:06X}\n",
+                ));
+                position += 6;
+            }
+            0xA1..=0xAF => break,
+            _ => position += 1,
+        }
+    }
+    state.log_pending.drain(..position);
+    const MAX_LOG: usize = 2 * 1024 * 1024;
+    if state.log_output.len() > MAX_LOG {
+        let excess = state.log_output.len() - MAX_LOG;
+        let boundary = state.log_output[excess..]
+            .find('\n')
+            .map_or(excess, |offset| excess + offset + 1);
+        state.log_output.drain(..boundary);
+    }
+}
+
+fn spi_opcode_name(opcode: u8) -> &'static str {
+    match opcode {
+        0x01 => "WRITE_STATUS",
+        0x02 => "PAGE_PROGRAM",
+        0x03 => "READ",
+        0x04 => "WRITE_DISABLE",
+        0x05 => "READ_STATUS",
+        0x06 => "WRITE_ENABLE",
+        0x0B => "FAST_READ",
+        0x0C => "FAST_READ_4B",
+        0x12 => "PAGE_PROGRAM_4B",
+        0x13 => "READ_4B",
+        0x20 => "SECTOR_ERASE_4K",
+        0x21 => "SECTOR_ERASE_4K_4B",
+        0x35 => "READ_STATUS2",
+        0x3B => "DUAL_READ",
+        0x3C => "DUAL_READ_4B",
+        0x52 => "BLOCK_ERASE_32K",
+        0x5A => "READ_SFDP",
+        0x60 | 0xC7 => "CHIP_ERASE",
+        0x6B => "QUAD_READ",
+        0x6C => "QUAD_READ_4B",
+        0x9E | 0x9F => "READ_JEDEC_ID",
+        0xB7 => "4BYTE_ENABLE",
+        0xBB => "DUAL_IO_READ",
+        0xBC => "DUAL_IO_READ_4B",
+        0xD8 => "BLOCK_ERASE_64K",
+        0xDC => "BLOCK_ERASE_64K_4B",
+        0xE9 => "4BYTE_DISABLE",
+        0xEB => "QUAD_IO_READ",
+        0xEC => "QUAD_IO_READ_4B",
+        _ => "UNKNOWN",
+    }
+}
+
+fn is_read_opcode(opcode: u8) -> bool {
+    matches!(
+        opcode,
+        0x03 | 0x0B | 0x0C | 0x13 | 0x3B | 0x3C | 0x5A | 0x6B | 0x6C | 0xBB | 0xBC | 0xEB | 0xEC
+    )
+}
+
+fn set_error(state: &mut SharedState, message: String) {
+    state.status = message;
+    state.status_error = true;
+}
+
+fn js_error(error: wasm_bindgen::JsValue) -> String {
+    error.as_string().unwrap_or_else(|| format!("{error:?}"))
+}
+
+fn parse_number(value: &str) -> Option<u32> {
+    let value = value.trim();
+    value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+        .map_or_else(
+            || value.parse().ok(),
+            |hex| u32::from_str_radix(hex, 16).ok(),
+        )
+}
+
+fn hex_dump(data: &[u8], base: u32) -> String {
+    data.chunks(16)
+        .enumerate()
+        .map(|(line, chunk)| {
+            let hex = chunk
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            let ascii: String = chunk
+                .iter()
+                .map(|byte| {
+                    if (32..=126).contains(byte) {
+                        char::from(*byte)
+                    } else {
+                        '.'
+                    }
+                })
+                .collect();
+            format!("{:08x}: {:47} |{}|", base + (line * 16) as u32, hex, ascii)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn save_file(data: &[u8], filename: &str) {
+    let bytes = Uint8Array::from(data);
+    let parts = Array::new();
+    parts.push(&bytes.buffer());
+    let options = BlobPropertyBag::new();
+    options.set_type("application/octet-stream");
+    let blob = Blob::new_with_u8_array_sequence_and_options(&parts, &options).unwrap();
+    let url = Url::create_object_url_with_blob(&blob).unwrap();
+    let document = web_sys::window().unwrap().document().unwrap();
+    let link: HtmlAnchorElement = document.create_element("a").unwrap().dyn_into().unwrap();
+    link.set_href(&url);
+    link.set_download(filename);
+    link.click();
+    Url::revoke_object_url(&url).unwrap();
+}
+
+fn main() {
+    console_error_panic_hook::set_once();
+    tracing_wasm::set_as_global_default();
+    let options = eframe::WebOptions::default();
+    spawn_local(async move {
+        let canvas = web_sys::window()
+            .unwrap()
+            .document()
+            .unwrap()
+            .get_element_by_id("norbert_canvas")
+            .unwrap()
+            .dyn_into::<HtmlCanvasElement>()
+            .unwrap();
+        eframe::WebRunner::new()
+            .start(
+                canvas,
+                options,
+                Box::new(|cc| Ok(Box::new(NorbertWebApp::new(cc)))),
+            )
+            .await
+            .expect("failed to start NORbert web UI");
+    });
+}

--- a/tool/src/web_main.rs
+++ b/tool/src/web_main.rs
@@ -404,7 +404,7 @@ impl NorbertWebApp {
             .dyn_into()
             .unwrap();
         input.set_type("file");
-        input.set_accept(".bin,.rom,.img,*");
+        input.set_accept(".bin,.rom,.img,*/*");
         let state = self.state.clone();
         let onchange = Closure::wrap(Box::new(move |event: web_sys::Event| {
             let input: HtmlInputElement = event.target().unwrap().dyn_into().unwrap();

--- a/tool/src/web_main.rs
+++ b/tool/src/web_main.rs
@@ -46,7 +46,7 @@ struct SharedState {
     status: String,
     status_error: bool,
     pending_file: Option<(String, File)>,
-    read_data: Option<Vec<u8>>,
+    read_data: Option<(u32, Vec<u8>)>,
     log_output: String,
     log_pending: Vec<u8>,
     log_txn_count: u32,
@@ -467,7 +467,7 @@ impl NorbertWebApp {
             shared.busy = false;
             match result {
                 Ok(data) => {
-                    shared.read_data = Some(data);
+                    shared.read_data = Some((address, data));
                     shared.status = "Download complete".to_owned();
                     shared.status_error = false;
                 }
@@ -907,7 +907,7 @@ impl NorbertWebApp {
                     self.read_memory(address.unwrap(), length.unwrap(), ctx);
                 }
             });
-            if let Some(data) = self.state.borrow().read_data.as_ref() {
+            if let Some((base, data)) = self.state.borrow().read_data.as_ref() {
                 ui.horizontal(|ui| {
                     ui.label(format!("{} bytes ready", data.len()));
                     if ui.button("Save As...").clicked() {
@@ -917,7 +917,7 @@ impl NorbertWebApp {
                 egui::ScrollArea::vertical()
                     .max_height(180.0)
                     .show(ui, |ui| {
-                        ui.code(hex_dump(&data[..data.len().min(4096)], 0));
+                        ui.code(hex_dump(&data[..data.len().min(4096)], *base));
                     });
             }
         }
@@ -1330,8 +1330,14 @@ fn save_file(data: &[u8], filename: &str) {
     let link: HtmlAnchorElement = document.create_element("a").unwrap().dyn_into().unwrap();
     link.set_href(&url);
     link.set_download(filename);
+    let body = document.body().unwrap();
+    body.append_child(&link).unwrap();
     link.click();
-    Url::revoke_object_url(&url).unwrap();
+    body.remove_child(&link).unwrap();
+    spawn_local(async move {
+        TimeoutFuture::new(1_000).await;
+        let _ = Url::revoke_object_url(&url);
+    });
 }
 
 fn main() {

--- a/tool/src/web_main.rs
+++ b/tool/src/web_main.rs
@@ -2,7 +2,7 @@
 
 use egui::Color32;
 use gloo_timers::future::TimeoutFuture;
-use js_sys::{Array, Uint8Array};
+use js_sys::{Array, Function, Uint8Array};
 use spi_flash_tool::WebFlashDevice;
 use spi_flash_tool::chip::{FlashChip, FlashChipExt};
 use spi_flash_tool::sfdp::generate_sfdp;
@@ -11,8 +11,10 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::closure::Closure;
-use wasm_bindgen_futures::{JsFuture, spawn_local};
-use web_sys::{Blob, BlobPropertyBag, HtmlAnchorElement, HtmlCanvasElement, HtmlInputElement, Url};
+use wasm_bindgen_futures::spawn_local;
+use web_sys::{
+    Blob, BlobPropertyBag, File, HtmlAnchorElement, HtmlCanvasElement, HtmlInputElement, Url,
+};
 
 #[derive(Default, PartialEq, Clone, Copy)]
 enum Panel {
@@ -43,7 +45,7 @@ struct SharedState {
     hold_enabled: Option<bool>,
     status: String,
     status_error: bool,
-    pending_file: Option<(String, Vec<u8>)>,
+    pending_file: Option<(String, File)>,
     read_data: Option<Vec<u8>>,
     log_output: String,
     log_pending: Vec<u8>,
@@ -99,7 +101,7 @@ struct NorbertWebApp {
     read_length: String,
     write_address: String,
     upload_name: String,
-    upload_data: Option<Vec<u8>>,
+    upload_file: Option<File>,
     verify_upload: bool,
     toctou_index: String,
     toctou_start: String,
@@ -131,7 +133,7 @@ impl NorbertWebApp {
             read_length: "256".to_owned(),
             write_address: "0x000000".to_owned(),
             upload_name: String::new(),
-            upload_data: None,
+            upload_file: None,
             verify_upload: false,
             toctou_index: "0".to_owned(),
             toctou_start: "0x001000".to_owned(),
@@ -183,9 +185,9 @@ impl NorbertWebApp {
                     }
                     .await;
 
-                    let mut shared = state.borrow_mut();
                     match details {
                         Ok((version, emulation_control, activity_log, running)) => {
+                            let mut shared = state.borrow_mut();
                             shared.device = Some(device);
                             shared.connection = ConnectionState::Connected;
                             shared.version = Some(version);
@@ -195,10 +197,20 @@ impl NorbertWebApp {
                             shared.status = "Connected successfully".to_owned();
                             shared.status_error = false;
                         }
-                        Err(error) => set_error(
-                            &mut shared,
-                            format!("Connection failed: {}", js_error(error)),
-                        ),
+                        Err(error) => {
+                            let cleanup = device.disconnect().await;
+                            let message = match cleanup {
+                                Ok(()) => format!("Connection failed: {}", js_error(error)),
+                                Err(cleanup_error) => format!(
+                                    "Connection failed: {}; cleanup also failed: {}",
+                                    js_error(error),
+                                    js_error(cleanup_error)
+                                ),
+                            };
+                            let mut shared = state.borrow_mut();
+                            shared.connection = ConnectionState::Error(message.clone());
+                            set_error(&mut shared, message);
+                        }
                     }
                 }
                 Err(error) => {
@@ -397,23 +409,10 @@ impl NorbertWebApp {
         let onchange = Closure::wrap(Box::new(move |event: web_sys::Event| {
             let input: HtmlInputElement = event.target().unwrap().dyn_into().unwrap();
             if let Some(file) = input.files().and_then(|files| files.get(0)) {
-                let filename = file.name();
-                let state = state.clone();
-                spawn_local(async move {
-                    match JsFuture::from(file.array_buffer()).await {
-                        Ok(buffer) => {
-                            let data = Uint8Array::new(&buffer).to_vec();
-                            let mut shared = state.borrow_mut();
-                            shared.pending_file = Some((filename, data));
-                            shared.status = "File loaded".to_owned();
-                            shared.status_error = false;
-                        }
-                        Err(error) => set_error(
-                            &mut state.borrow_mut(),
-                            format!("File read failed: {}", js_error(error)),
-                        ),
-                    }
-                });
+                let mut shared = state.borrow_mut();
+                shared.pending_file = Some((file.name(), file));
+                shared.status = "File selected".to_owned();
+                shared.status_error = false;
             }
         }) as Box<dyn FnMut(_)>);
         input.set_onchange(Some(onchange.as_ref().unchecked_ref()));
@@ -421,21 +420,20 @@ impl NorbertWebApp {
         input.click();
     }
 
-    fn write_memory(&self, address: u32, data: Vec<u8>, verify: bool, ctx: &egui::Context) {
+    fn write_memory(&self, address: u32, file: File, verify: bool, ctx: &egui::Context) {
         let state = self.state.clone();
         let repaint = ctx.clone();
         state.borrow_mut().busy = true;
         spawn_local(async move {
+            let progress = Closure::<dyn FnMut(f64, f64) -> bool>::new(|_, _| true);
+            let progress_fn: Function = progress.as_ref().unchecked_ref::<Function>().clone();
             let mut device = state.borrow_mut().device.take();
             let result = match device.as_mut() {
-                Some(device) => match device.write(address, data.clone()).await {
-                    Ok(()) if verify => match device.read(address, data.len() as u32).await {
-                        Ok(actual) if actual == data => Ok(()),
-                        Ok(_) => Err(wasm_bindgen::JsValue::from_str(
-                            "Verification failed: device contents differ from the selected file",
-                        )),
-                        Err(error) => Err(error),
-                    },
+                Some(device) => match device
+                    .write_file(address, file.clone(), progress_fn.clone())
+                    .await
+                {
+                    Ok(()) if verify => device.verify_file(address, file, progress_fn).await,
                     result => result,
                 },
                 None => Err(wasm_bindgen::JsValue::from_str("No device connected")),
@@ -445,7 +443,6 @@ impl NorbertWebApp {
             shared.busy = false;
             match result {
                 Ok(()) => {
-                    shared.running = Some(true);
                     shared.status = "Upload complete".to_owned();
                     shared.status_error = false;
                 }
@@ -471,7 +468,6 @@ impl NorbertWebApp {
             match result {
                 Ok(data) => {
                     shared.read_data = Some(data);
-                    shared.running = Some(true);
                     shared.status = "Download complete".to_owned();
                     shared.status_error = false;
                 }
@@ -864,7 +860,9 @@ impl NorbertWebApp {
                     ui.label(format!(
                         "{} ({} bytes)",
                         self.upload_name,
-                        self.upload_data.as_ref().map_or(0, Vec::len)
+                        self.upload_file
+                            .as_ref()
+                            .map_or(0, |file| file.size() as usize)
                     ));
                 }
             });
@@ -874,14 +872,14 @@ impl NorbertWebApp {
                 let parsed = parse_number(&self.write_address);
                 if ui
                     .add_enabled(
-                        self.upload_data.is_some() && parsed.is_some() && !busy,
+                        self.upload_file.is_some() && parsed.is_some() && !busy,
                         egui::Button::new("Upload"),
                     )
                     .clicked()
                 {
                     self.write_memory(
                         parsed.unwrap(),
-                        self.upload_data.clone().unwrap(),
+                        self.upload_file.clone().unwrap(),
                         self.verify_upload,
                         ctx,
                     );
@@ -1078,9 +1076,9 @@ impl eframe::App for NorbertWebApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         self.selected_chip = self.state.borrow().configured_chip.clone();
 
-        if let Some((name, data)) = self.state.borrow_mut().pending_file.take() {
+        if let Some((name, file)) = self.state.borrow_mut().pending_file.take() {
             self.upload_name = name;
-            self.upload_data = Some(data);
+            self.upload_file = Some(file);
         }
 
         egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {

--- a/tool/src/web_main.rs
+++ b/tool/src/web_main.rs
@@ -20,6 +20,7 @@ enum Panel {
     Device,
     Activity,
     Toctou,
+    Wiring,
 }
 
 #[derive(Default)]
@@ -1089,8 +1090,10 @@ impl eframe::App for NorbertWebApp {
                 ui.selectable_value(&mut self.panel, Panel::Device, "Device");
                 ui.selectable_value(&mut self.panel, Panel::Activity, "Activity");
                 ui.selectable_value(&mut self.panel, Panel::Toctou, "TOCTOU");
+                ui.selectable_value(&mut self.panel, Panel::Wiring, "Wiring");
             });
         });
+        set_wiring_visible(self.panel == Panel::Wiring);
         egui::TopBottomPanel::bottom("bottom_panel").show(ctx, |ui| {
             let state = self.state.borrow();
             let color = if state.status_error {
@@ -1104,6 +1107,7 @@ impl eframe::App for NorbertWebApp {
             Panel::Device => self.device_panel(ui, ctx),
             Panel::Activity => self.activity_panel(ui, ctx),
             Panel::Toctou => self.toctou_panel(ui, ctx),
+            Panel::Wiring => {}
         });
         if self.state.borrow().busy
             || matches!(self.state.borrow().connection, ConnectionState::Connecting)
@@ -1111,6 +1115,22 @@ impl eframe::App for NorbertWebApp {
             ctx.request_repaint_after(std::time::Duration::from_millis(50));
         }
     }
+}
+
+fn set_wiring_visible(visible: bool) {
+    let Some(body) = web_sys::window()
+        .and_then(|window| window.document())
+        .and_then(|document| document.body())
+    else {
+        return;
+    };
+
+    let classes = body.class_list();
+    let _ = if visible {
+        classes.add_1("wiring-open")
+    } else {
+        classes.remove_1("wiring-open")
+    };
 }
 
 fn decode_log_packets(state: &mut SharedState, data: &[u8]) {

--- a/web/index.html
+++ b/web/index.html
@@ -15,6 +15,69 @@
 
     <canvas id="norbert_canvas"></canvas>
 
+    <section id="wiring-schematic" aria-labelledby="wiring-title">
+        <h1 id="wiring-title">Dock pinout</h1>
+        <p class="wiring-subtitle">Hover a numbered PMOD pin to highlight its assignment.</p>
+
+        <article class="tang-dock" aria-label="Tang Primer 25K Dock pinout">
+            <div class="sdram-module">
+                <div class="memory-chip">SDRAM</div>
+                <div class="memory-chip">SDRAM</div>
+            </div>
+            <div class="dock-main">
+                <div class="usb-host">USB</div>
+                <div class="tang-core">
+                    <small>Sipeed</small>
+                    <strong>TANG <em>25K</em></strong>
+                </div>
+                <div class="dock-controls">
+                    <span class="button">S0</span>
+                    <span class="button">S1</span>
+                    <span class="usb-c">USB-C</span>
+                </div>
+            </div>
+
+            <div class="pmod-row">
+                <section class="pmod-card pmod-ft-data">
+                    <h2>J7 <small>FT245 data</small></h2>
+                    <div class="pmod" aria-label="J7 FT245 data PMOD">
+                        <span class="pin power">3V3</span><span class="pin power">GND</span><span class="pin">H5</span><span class="pin">H8</span><span class="pin">G7</span><span class="pin">F5</span>
+                        <span class="pin power">3V3</span><span class="pin power">GND</span><span class="pin">J5</span><span class="pin">H7</span><span class="pin">G8</span><span class="pin">G5</span>
+                    </div>
+                    <ol class="pin-legend">
+                        <li><b>3V3</b><span>3V3</span></li><li><b>GND</b><span>GND</span></li><li><b>H5</b><span>D0</span></li><li><b>H8</b><span>D1</span></li><li><b>G7</b><span>D2</span></li><li><b>F5</b><span>D3</span></li>
+                        <li><b>3V3</b><span>3V3</span></li><li><b>GND</b><span>GND</span></li><li><b>J5</b><span>D7</span></li><li><b>H7</b><span>D4</span></li><li><b>G8</b><span>D5</span></li><li><b>G5</b><span>D6</span></li>
+                    </ol>
+                </section>
+
+                <section class="pmod-card pmod-ft-control">
+                    <h2>J6 <small>FT245 control</small></h2>
+                    <div class="pmod" aria-label="J6 FT245 control PMOD">
+                        <span class="pin power">3V3</span><span class="pin power">GND</span><span class="pin">L5</span><span class="pin">K11</span><span class="pin">E11</span><span class="pin">A11</span>
+                        <span class="pin power">3V3</span><span class="pin power">GND</span><span class="pin spare">K5</span><span class="pin spare">L11</span><span class="pin spare">E10</span><span class="pin spare">A10</span>
+                    </div>
+                    <ol class="pin-legend">
+                        <li><b>3V3</b><span>3V3</span></li><li><b>GND</b><span>GND</span></li><li><b>L5</b><span>WR#</span></li><li><b>K11</b><span>RD#</span></li><li><b>E11</b><span>TXE#</span></li><li><b>A11</b><span>RXF#</span></li>
+                        <li><b>3V3</b><span>3V3</span></li><li><b>GND</b><span>GND</span></li><li><b>K5</b><span>spare</span></li><li><b>L11</b><span>spare</span></li><li><b>E10</b><span>spare</span></li><li><b>A10</b><span>spare</span></li>
+                    </ol>
+                </section>
+
+                <section class="pmod-card pmod-spi">
+                    <h2>J5 <small>SPI flash · USB-C side</small></h2>
+                    <div class="pmod" aria-label="J5 SPI flash PMOD">
+                        <span class="pin power">3V3</span><span class="pin power">GND</span><span class="pin">C11</span><span class="pin">B11</span><span class="pin">D11</span><span class="pin">G11</span>
+                        <span class="pin power">3V3</span><span class="pin power">GND</span><span class="pin">C10</span><span class="pin">B10</span><span class="pin">D10</span><span class="pin">G10</span>
+                    </div>
+                    <ol class="pin-legend">
+                        <li><b>3V3</b><span>3V3</span></li><li><b>GND</b><span>GND</span></li><li><b>C11</b><span>IO1 / MISO</span></li><li><b>B11</b><span>IO0 / MOSI</span></li><li><b>D11</b><span>CLK</span></li><li><b>G11</b><span>CS#</span></li>
+                        <li><b>3V3</b><span>3V3</span></li><li><b>GND</b><span>GND</span></li><li><b>C10</b><span>DEBUG</span></li><li><b>B10</b><span>POWER</span></li><li><b>D10</b><span>IO3 / HOLD#</span></li><li><b>G10</b><span>IO2 / WP#</span></li>
+                    </ol>
+                </section>
+            </div>
+            <div class="dock-label">Tang Primer 25K Dock</div>
+        </article>
+    </section>
+
     <link data-trunk rel="rust" href="../tool/Cargo.toml" data-bin="norbert-web" data-cargo-no-default-features data-cargo-features="wasm" data-wasm-opt="s">
 
     <script>

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>NORbert Control</title>
+    <link data-trunk rel="css" href="style.css">
+</head>
+<body>
+    <div id="loading">
+        <h1>NORbert Control</h1>
+        <div class="spinner"></div>
+        <p>Loading WebAssembly...</p>
+    </div>
+
+    <canvas id="norbert_canvas"></canvas>
+
+    <link data-trunk rel="rust" href="../tool/Cargo.toml" data-bin="norbert-web" data-cargo-no-default-features data-cargo-features="wasm" data-wasm-opt="s">
+
+    <script>
+        window.addEventListener("TrunkApplicationStarted", function () {
+            document.body.classList.add("loaded");
+        });
+    </script>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NORbert Control</title>
     <link data-trunk rel="css" href="style.css">
 </head>

--- a/web/style.css
+++ b/web/style.css
@@ -43,3 +43,295 @@ html, body {
 body.loaded #loading {
     display: none;
 }
+
+#wiring-schematic {
+    --data: #4aa8ff;
+    --control: #f2a93b;
+    --spi: #74c991;
+    position: fixed;
+    z-index: 2;
+    inset: 45px 0 29px;
+    display: none;
+    box-sizing: border-box;
+    overflow: auto;
+    padding: 24px clamp(18px, 4vw, 48px) 48px;
+    color: #e8e8e8;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+body.wiring-open #wiring-schematic {
+    display: block;
+}
+
+#wiring-schematic h1 {
+    margin: 0;
+    font-size: 24px;
+    font-weight: 600;
+}
+
+.wiring-subtitle {
+    margin: 4px 0 22px;
+    color: #9a9a9a;
+    font-size: 14px;
+}
+
+.tang-dock {
+    position: relative;
+    width: min(1040px, 100%);
+    min-width: 820px;
+    margin: 0 auto;
+    padding: 18px;
+    box-sizing: border-box;
+    border: 2px solid #59615d;
+    border-radius: 8px;
+    background: #202927;
+    box-shadow: 0 10px 22px rgba(0, 0, 0, 0.22);
+}
+
+.sdram-module {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    width: 500px;
+    height: 92px;
+    margin: 0 auto 10px;
+    box-sizing: border-box;
+    padding: 13px 16px;
+    border: 1px solid #4b5551;
+    background: #242a29;
+}
+
+.memory-chip {
+    display: grid;
+    place-items: center;
+    border: 1px solid #555b59;
+    color: #7f8784;
+    background: #171918;
+    font: 9px ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.dock-main {
+    position: relative;
+    width: 500px;
+    height: 205px;
+    margin: auto;
+    border: 1px solid #38423f;
+    background: #25302d;
+}
+
+.usb-host {
+    position: absolute;
+    top: 52px;
+    left: -9px;
+    display: grid;
+    place-items: center;
+    width: 60px;
+    height: 76px;
+    border: 2px solid #aeb5b2;
+    border-radius: 3px;
+    color: #292929;
+    background: #c9cecc;
+    font-size: 9px;
+    font-weight: 800;
+}
+
+.tang-core {
+    position: absolute;
+    top: 42px;
+    left: 50%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    width: 170px;
+    height: 116px;
+    box-sizing: border-box;
+    padding: 16px;
+    border: 2px solid #d4b65e;
+    border-radius: 6px;
+    color: #e8e2c9;
+    background: #1c2422;
+    transform: translateX(-50%) rotate(-1deg);
+}
+
+.tang-core small { font-weight: 700; }
+
+.tang-core strong {
+    font-size: 20px;
+    letter-spacing: 0.06em;
+}
+
+.tang-core em {
+    padding: 2px 4px;
+    border: 1px solid #e8e2c9;
+    font-size: 11px;
+    font-style: normal;
+}
+
+.dock-controls {
+    position: absolute;
+    top: 12px;
+    right: 10px;
+    display: grid;
+    justify-items: center;
+    gap: 9px;
+}
+
+.button {
+    display: grid;
+    place-items: center;
+    width: 24px;
+    height: 24px;
+    border: 2px solid #aeb4b1;
+    border-radius: 4px;
+    color: #777;
+    background: #e0e3e2;
+    font-size: 8px;
+}
+
+.usb-c {
+    display: grid;
+    place-items: center;
+    width: 39px;
+    height: 18px;
+    margin-top: 8px;
+    border: 2px solid #aeb4b1;
+    border-radius: 5px;
+    color: #222;
+    background: #cbd0ce;
+    font-size: 7px;
+    font-weight: 800;
+}
+
+.pmod-row {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 12px;
+    margin-top: 28px;
+}
+
+.pmod-card {
+    min-width: 0;
+    padding: 12px;
+    border: 1px solid #444d49;
+    border-radius: 6px;
+    background: rgba(15, 18, 17, 0.38);
+}
+
+.pmod-card h2 {
+    margin: 0 0 9px;
+    color: #e5e8e6;
+    font: 700 13px ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.pmod-card h2 small {
+    margin-left: 5px;
+    color: #999f9c;
+    font-size: 10px;
+    font-weight: 500;
+}
+
+.pmod {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(30px, 1fr));
+    gap: 8px;
+    padding: 11px;
+    border: 2px solid #080909;
+    border-radius: 4px;
+    background: #111313;
+}
+
+.pin {
+    display: grid;
+    place-items: center;
+    aspect-ratio: 1;
+    box-sizing: border-box;
+    border: 2px solid #5c625f;
+    border-radius: 50%;
+    color: #bcc2bf;
+    background: #070808;
+    font: 9px ui-monospace, SFMono-Regular, Menlo, monospace;
+    cursor: default;
+    transition: border-color 100ms, box-shadow 100ms, color 100ms;
+}
+
+.pmod-ft-data .pin:not(.power) { --pin-color: var(--data); }
+.pmod-ft-control .pin:not(.power):not(.spare) { --pin-color: var(--control); }
+.pmod-spi .pin:not(.power) { --pin-color: var(--spi); }
+.pin.power { --pin-color: #b1b1b1; }
+.pin.spare { --pin-color: #777; }
+
+.pin:hover {
+    border-color: var(--pin-color);
+    color: #fff;
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--pin-color) 25%, transparent);
+}
+
+.pin-legend {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: 5px;
+    margin: 10px 0 0;
+    padding: 0;
+    list-style: none;
+}
+
+.pin-legend li {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 36px;
+    padding: 3px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    color: #aeb3b0;
+    font-size: 8px;
+    text-align: center;
+    transition: border-color 100ms, background-color 100ms, color 100ms;
+}
+
+.pin-legend b {
+    color: #777d7a;
+    font: 700 9px ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.pin-legend span {
+    font-weight: 700;
+    line-height: 1.1;
+}
+
+.pmod-card:has(.pin:nth-child(1):hover) .pin-legend li:nth-child(1),
+.pmod-card:has(.pin:nth-child(2):hover) .pin-legend li:nth-child(2),
+.pmod-card:has(.pin:nth-child(3):hover) .pin-legend li:nth-child(3),
+.pmod-card:has(.pin:nth-child(4):hover) .pin-legend li:nth-child(4),
+.pmod-card:has(.pin:nth-child(5):hover) .pin-legend li:nth-child(5),
+.pmod-card:has(.pin:nth-child(6):hover) .pin-legend li:nth-child(6),
+.pmod-card:has(.pin:nth-child(7):hover) .pin-legend li:nth-child(7),
+.pmod-card:has(.pin:nth-child(8):hover) .pin-legend li:nth-child(8),
+.pmod-card:has(.pin:nth-child(9):hover) .pin-legend li:nth-child(9),
+.pmod-card:has(.pin:nth-child(10):hover) .pin-legend li:nth-child(10),
+.pmod-card:has(.pin:nth-child(11):hover) .pin-legend li:nth-child(11),
+.pmod-card:has(.pin:nth-child(12):hover) .pin-legend li:nth-child(12) {
+    border-color: var(--pin-color, #aaa);
+    color: #fff;
+    background: rgba(255, 255, 255, 0.07);
+}
+
+.pmod-ft-data { --pin-color: var(--data); }
+.pmod-ft-control { --pin-color: var(--control); }
+.pmod-spi { --pin-color: var(--spi); }
+
+.dock-label {
+    margin-top: 13px;
+    color: #d8ddd9;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-align: center;
+}
+
+@media (max-width: 900px) {
+    .tang-dock {
+        margin: 0;
+    }
+}

--- a/web/style.css
+++ b/web/style.css
@@ -48,6 +48,7 @@ body.loaded #loading {
     --data: #4aa8ff;
     --control: #f2a93b;
     --spi: #74c991;
+
     position: fixed;
     z-index: 2;
     inset: 45px 0 29px;

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,45 @@
+html, body {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    background-color: #1a1a1a;
+}
+
+#loading {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    color: #ffffff;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+#loading h1 {
+    margin-bottom: 20px;
+}
+
+.spinner {
+    width: 50px;
+    height: 50px;
+    border: 3px solid #333;
+    border-top-color: #3498db;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin: 0 auto;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+#norbert_canvas {
+    width: 100%;
+    height: 100%;
+}
+
+body.loaded #loading {
+    display: none;
+}


### PR DESCRIPTION
Stacked on #24, which removes the proprietary D2XX backend in favor of the published `ftdi-nusb` crate.

This adds a lightweight static Web UI backed by a shared Rust/WASM protocol library. It supports the FT2232H FT245 interface through WebUSB and the dock UART through Web Serial, with capability-aware status and control operations, SDRAM reads and writes, activity logging, and bounded streaming transfers with progress and cancellation.

The CLI and browser paths share protocol framing, range validation, emulation stop/restore handling, and transport-independent device logic. `make webui` builds the WASM bindings beside the frontend.

The CodeRabbit findings are addressed, including connection cleanup, unsupported-version diagnostics, transfer state preservation, accessible viewport settings, reliable downloads, and use of streaming upload/download bindings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a browser-based NORbert Control interface with WebUSB and Web Serial support.
  * Added flash reading, writing, verification, configuration, file transfers, progress reporting, and cancellation.
  * Added emulation, hold, activity logging, TOCTOU controls, wiring diagrams, and device status displays.
  * Added automated web builds and GitHub Pages deployment.
  * Added development commands for building and serving the web interface.
* **Bug Fixes**
  * Improved protocol compatibility checks and mismatch reporting.
* **Documentation**
  * Documented WebAssembly tooling, browser requirements, connection methods, and updated protocol details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->