### PR TITLE
remove QT related settings from flake.nix to make gowin_sh work

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -111,11 +111,7 @@
             echo "Setup complete!"
           fi
 
-          unset QT_QPA_PLATFORMTHEME QT_STYLE_OVERRIDE
-          export QT_QPA_PLATFORM=offscreen
-          export QT_XCB_GL_INTEGRATION=none
-
-          exec ${gowinFhs}/bin/gowin-fhs -c "cd '$(pwd)' && QT_QPA_PLATFORM=offscreen LD_LIBRARY_PATH='$WORKSPACE_DIR/IDE/lib':\"$LD_LIBRARY_PATH\" '$WORKSPACE_DIR/IDE/bin/gw_sh' $*"
+          exec ${gowinFhs}/bin/gowin-fhs -c "cd '$(pwd)' &&  LD_LIBRARY_PATH='$WORKSPACE_DIR/IDE/lib':\"$LD_LIBRARY_PATH\" '$WORKSPACE_DIR/IDE/bin/gw_sh' $*"
         '';
       in
       {


### PR DESCRIPTION
As i previously mentioned here: https://github.com/ArthurHeymans/NORbert/issues/11

With the environment variables set and present, the Gowin IDE works but the gw_sh fails with QT related errors.
Only removing the settings here restored the sh to working state for me.

Like this, sh and IDE are working for me, no further issues.
