### PR TITLE
fix(flake): unset DISPLAY for offscreen gw_sh to avoid GLX crash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -111,11 +111,16 @@
             echo "Setup complete!"
           fi
 
+          # Offscreen mode: unset DISPLAY and use Qt offscreen platform to
+          # avoid GLX initialization failures in headless/server environments.
+          # GOWIN's PnR tool internally uses Qt OpenGL widgets, which fail
+          # with "Could not initialize GLX" if a DISPLAY is set without a
+          # working GLX implementation (e.g. over Xvfb without Mesa swrast).
+          unset DISPLAY
           unset QT_QPA_PLATFORMTHEME QT_STYLE_OVERRIDE
           export QT_QPA_PLATFORM=offscreen
-          export QT_XCB_GL_INTEGRATION=none
 
-          exec ${gowinFhs}/bin/gowin-fhs -c "cd '$(pwd)' && QT_QPA_PLATFORM=offscreen LD_LIBRARY_PATH='$WORKSPACE_DIR/IDE/lib':\"$LD_LIBRARY_PATH\" '$WORKSPACE_DIR/IDE/bin/gw_sh' $*"
+          exec ${gowinFhs}/bin/gowin-fhs -c "cd '$(pwd)' && unset DISPLAY QT_QPA_PLATFORMTHEME QT_STYLE_OVERRIDE && QT_QPA_PLATFORM=offscreen LD_LIBRARY_PATH='$WORKSPACE_DIR/IDE/lib':\"$LD_LIBRARY_PATH\" '$WORKSPACE_DIR/IDE/bin/gw_sh' $*"
         '';
       in
       {


### PR DESCRIPTION
Closes: #11

When running `make build` in a headless NixOS environment via `nix develop`, the Gowin EDA PnR tool crashes with:

    Could not initialize GLX
    make: *** [Makefile:36: impl/pnr/spi_flash.fs] Error 134

**Root cause:** The Gowin PnR binary uses Qt OpenGL widgets internally. Even with `QT_QPA_PLATFORM=offscreen`, Qt attempts GLX initialization whenever `DISPLAY` is set — including from an inherited X session or from `xvfb-run`. The FHS environment's Mesa lacks a working software rasterizer (`swrast_dri.so`) bound to GLX, so GLX fails.

**Fix:** `unset DISPLAY` before invoking `gw_sh`. Without any display and with `QT_QPA_PLATFORM=offscreen`, Qt skips GLX entirely and the tool runs fully headlessly — synthesis and PnR both complete.

Also dropped stale environment variables (`QT_XCB_GL_INTEGRATION`, `QT_QPA_PLATFORMTHEME`, `QT_STYLE_OVERRIDE`).

Reported-by: Norman (Ragebone)