### PR TITLE
fix(spi): make boot reads reliable

### DIFF
--- a/src/sdram.v
+++ b/src/sdram.v
@@ -51,6 +51,7 @@ module sdram(
     inout wire [15:0] dq_io,     // Bidirectional data bus (directly to pins)
     
     // Control signals from spi_trx (directly from SPI clock domain)
+    input wire spi_active,
     input wire spi_inhibit_refresh,
     input wire spi_cmd_activate,
     input wire spi_cmd_read,
@@ -113,9 +114,11 @@ module sdram(
         STA_WRITE           = 8,
         STA_INIT_CHIP2      = 9,   // Init second chip
         STA_INIT_PRECHARGE2 = 10,
-        STA_INIT_REFRESH2   = 11,
-        STA_SETMODE2        = 12,
-        STA_REFRESH2        = 13;  // Refresh second chip
+        STA_INIT_REFRESH2      = 11,
+        STA_SETMODE2           = 12,
+        STA_REFRESH2           = 13,  // Refresh second chip
+        STA_SPI_ABORT_WAIT     = 14,  // Wait tRAS before closing an abandoned row
+        STA_SPI_ABORT_PRECHARGE = 15; // Precharge row opened by an aborted SPI read
 
     // Burst mode encoding
     localparam [2:0] BURST_MODE =
@@ -136,12 +139,16 @@ module sdram(
     reg refresh_chip;
     
     // Buffer control signals from SPI domain
+    reg [2:0] spi_active_buf;
     reg [1:0] spi_inhibit_refresh_buf;
     reg [1:0] spi_cmd_activate_buf;
     reg [1:0] spi_cmd_read_buf;
     
     reg spi_cmd_activate_ack;
     reg spi_cmd_read_ack;
+    reg spi_abort_pending;
+
+    wire spi_deselect_event = !spi_active_buf[1] && spi_active_buf[2];
     
     // Track whether ACTIVATE has been dispatched for the current SPI burst.
     // READ must not dispatch until this is set, preventing a race where
@@ -157,16 +164,15 @@ module sdram(
     //   [21:9]  = row (13 bits)
     //   [8:7]   = bank (2 bits)
     //   [6:0]   = column burst index (col[8:2])
-    // Latch the multi-bit SPI address in the system clock domain when the
-    // synchronized activate request is accepted, then use only the latched
-    // value for ACTIVATE/READ.  spi_trx holds spi_addr stable across the
-    // request handshake; this avoids using a live cross-domain bus later in
-    // the SDRAM command sequence.
+    // Latch the row/bank portion when ACTIVATE is accepted. The column bits
+    // arrive later in the SPI address phase, so READ samples them from the
+    // live SPI address bus after its synchronized request arrives. spi_trx
+    // holds each portion stable across the corresponding handshake.
     reg [22:0] spi_addr_latched;
     wire spi_chip_sel  = spi_addr_latched[22];
     wire [12:0] spi_row  = spi_addr_latched[21:9];
     wire [1:0]  spi_bank = spi_addr_latched[8:7];
-    wire [8:0]  spi_col  = {spi_addr_latched[6:0], 2'b00};  // Burst-4 aligned
+    wire [8:0]  spi_col  = {spi_addr[6:0], 2'b00};  // Burst-4 aligned
 
     // Serial/glue path: 25-bit address = {chip, row, bank, col}
     //   [24]     = chip select
@@ -181,6 +187,7 @@ module sdram(
     reg [4:0] readcount;
     reg [1:0] rdbuf_write_ptr;
     reg [2:0] wrbuf_read_ptr;
+    reg [63:0] read_buffer_work;
 
     // Read data capture: DQ sampled on aux_clk (phase-shifted for proper timing)
     // then used directly in the main clock domain read logic.
@@ -215,28 +222,42 @@ module sdram(
             refresh_chip <= 0;
             
             read_buffer <= 0;
+            read_buffer_work <= 0;
             read_busy <= 0;
             readcount <= 0;
 
             rdbuf_write_ptr <= 0;
             wrbuf_read_ptr <= 0;
             
+            spi_active_buf <= 0;
             spi_inhibit_refresh_buf <= 0;
             spi_cmd_activate_buf <= 0;
             spi_cmd_read_buf <= 0;
             
             spi_cmd_activate_ack <= 0;
             spi_cmd_read_ack <= 0;
+            spi_abort_pending <= 0;
             spi_activate_done <= 0;
             spi_addr_latched <= 0;
         end
         else begin
             refreshcount <= refreshcount + 1;
             
-            // Synchronize SPI control signals
-            spi_inhibit_refresh_buf <= {spi_inhibit_refresh_buf[0], spi_inhibit_refresh};
-            spi_cmd_activate_buf <= {spi_cmd_activate_buf[0], spi_cmd_activate};
-            spi_cmd_read_buf <= {spi_cmd_read_buf[0], spi_cmd_read};
+            // Synchronize SPI control signals. Gate requests with active CS so
+            // a master that stops the clock while deasserting CS cannot leave
+            // refresh inhibition or command requests asserted indefinitely.
+            spi_active_buf <= {spi_active_buf[1:0], spi_active};
+            spi_inhibit_refresh_buf <= {spi_inhibit_refresh_buf[0],
+                                        spi_inhibit_refresh && spi_active};
+            spi_cmd_activate_buf <= {spi_cmd_activate_buf[0],
+                                     spi_cmd_activate && spi_active};
+            spi_cmd_read_buf <= {spi_cmd_read_buf[0],
+                                 spi_cmd_read && spi_active};
+
+            // If CS drops after ACTIVATE was accepted but before READ was
+            // dispatched, close the open row once tRAS has safely elapsed.
+            if (spi_deselect_event && spi_activate_done && !spi_cmd_read_ack)
+                spi_abort_pending <= 1;
             
             if (spi_cmd_activate_ack && !spi_cmd_activate_buf[1]) begin
                 spi_cmd_activate_ack <= 0;
@@ -452,6 +473,40 @@ module sdram(
                     we_o <= 1;
                     dqm_o <= 2'b11;
                 end
+                else if (state == STA_SPI_ABORT_WAIT) begin
+                    // The aborted ACTIVATE has satisfied tRAS; close only the
+                    // bank opened for this SPI request.
+                    state <= STA_SPI_ABORT_PRECHARGE;
+                    cmdtarget <= tRP;
+
+                    cs_o <= spi_chip_sel;
+                    ras_o <= 0;
+                    cas_o <= 1;
+                    we_o <= 0;
+                    ba_o <= spi_bank;
+                    a_o <= 0;
+                    a_o[10] <= 0;
+                    dqm_o <= 2'b11;
+                end
+                else if (state == STA_SPI_ABORT_PRECHARGE) begin
+                    state <= STA_IDLE;
+                    cmdtarget <= 1;
+                    ras_o <= 1;
+                    cas_o <= 1;
+                    we_o <= 1;
+                    dqm_o <= 2'b11;
+                end
+                else if (spi_abort_pending) begin
+                    // Wait a full tRAS from abort detection. This is slightly
+                    // conservative but guarantees PRECHARGE is never early.
+                    spi_abort_pending <= 0;
+                    state <= STA_SPI_ABORT_WAIT;
+                    cmdtarget <= tRAS;
+                    ras_o <= 1;
+                    cas_o <= 1;
+                    we_o <= 1;
+                    dqm_o <= 2'b11;
+                end
                 else if (spi_cmd_activate_buf[1] && !spi_cmd_activate_ack) begin
                     // SPI fast-path activate
                     state <= STA_ACTIVATE;
@@ -572,17 +627,27 @@ module sdram(
             // cases) so they take priority over SPI and serial command
             // dispatches in the same cycle.
             
-            // Read data capture (de-interleave 16-bit data to 64-bit buffer)
-            // Uses aux_clk-captured data (dq_captured) for reliable sampling.
+            // Read data capture (de-interleave 16-bit data to 64-bit buffer).
+            // Assemble the burst in a private work register and publish all
+            // 64 bits only when the final SDRAM beat arrives. This prevents
+            // the SPI clock domain from observing a partially-updated buffer.
             if ((readcount > tCAS + RD_PIPELINE_DELAY) && (readcount <= tCAS + RD_PIPELINE_DELAY + BURST_LEN)) begin
-                // Capture read data and de-interleave from 16-bit bus
-                // rdbuf_write_ptr counts 0..3 (4 words in burst)
-                for (i = 0; i < 8; i = i + 1) begin
-                    read_buffer[i*8 + 7 - rdbuf_write_ptr*2] <= dq_captured[i];
-                    read_buffer[i*8 + 6 - rdbuf_write_ptr*2] <= dq_captured[i+8];
+                // rdbuf_write_ptr counts 0..3 (4 words in burst).
+                if (rdbuf_write_ptr == BURST_LEN - 1) begin
+                    read_buffer <= read_buffer_work;
+                    for (i = 0; i < 8; i = i + 1) begin
+                        read_buffer[i*8 + 1] <= dq_captured[i];
+                        read_buffer[i*8]     <= dq_captured[i+8];
+                    end
+                    read_busy <= 0;
                 end
-                
-                if (rdbuf_write_ptr == BURST_LEN - 1) read_busy <= 0;
+                else begin
+                    for (i = 0; i < 8; i = i + 1) begin
+                        read_buffer_work[i*8 + 7 - rdbuf_write_ptr*2] <= dq_captured[i];
+                        read_buffer_work[i*8 + 6 - rdbuf_write_ptr*2] <= dq_captured[i+8];
+                    end
+                end
+
                 rdbuf_write_ptr <= rdbuf_write_ptr + 1;
             end
             else

--- a/src/spi_trx.v
+++ b/src/spi_trx.v
@@ -521,19 +521,21 @@ module spi_trx(
                     // ram_addr is 23-bit burst address = byte_addr[25:3]
                     // addr_count counts down from 23 (or 31 for 4-byte) to 0
                     
-                    // SDRAM pipeline (skipped for SFDP reads which use internal table)
+                    // SDRAM pipeline (skipped for SFDP reads which use internal table).
+                    // Row and bank are complete several clocks before the column;
+                    // issue ACTIVATE early, then post READ when address bit 3 arrives.
                     if (!is_sfdp_read) begin
-                        if (addr_count == 7) begin
+                        if (addr_count == 15) begin
                             ram_inhibit_refresh <= 1;
                         end
-                        else if (addr_count == 4) begin
+                        else if (addr_count == 9) begin
                             ram_activate <= 1;
-                            ram_addr[22:4] <= addr[25:7] & cfg_chip_erase_bursts[22:4];
+                            ram_addr[22:7] <= addr[25:10] & cfg_chip_erase_bursts[22:7];
                         end
                         else if (addr_count == 3) begin
                             ram_read <= 1;
-                            ram_addr[3:0] <= {addr[6:4], spi_io0_in} &
-                                             cfg_chip_erase_bursts[3:0];
+                            ram_addr[6:0] <= {addr[9:4], spi_io0_in} &
+                                             cfg_chip_erase_bursts[6:0];
                         end
                     end
                     
@@ -606,37 +608,48 @@ module spi_trx(
                     end
                 end
                 else if (state == STA_READ) begin
-                    // Advance the read
-                    
-                    if (addr[2:0] == 7) begin
-                        // Reaching end of burst, start reading new one
-                        
+                    // Prefetch the next burst while byte 6 is shifted out.
+                    // Save byte 7 first because the completed SDRAM read will
+                    // replace ram_read_buffer before byte 7 is transmitted.
+                    if (addr[2:0] == 6) begin
                         if (bit_count_in == 7) begin
                             ram_inhibit_refresh <= 1;
-                        end
-                        else if (bit_count_in == 4) begin
                             ram_activate <= 1;
                             ram_addr <= wrap_burst_addr(ram_addr + 1'b1);
+                            saved_last_byte <= ram_read_buffer[7*8 +: 8];
                         end
-                        else if (bit_count_in == 3) begin
+                        else if (bit_count_in == 6) begin
                             ram_read <= 1;
+                        end
+                    end
+
+                    if (addr[2:0] == 7) begin
+                        if (bit_count_in == 7 && !ram_activate) begin
+                            // Fallback when a read starts directly at byte 7.
+                            ram_inhibit_refresh <= 1;
+                            ram_activate <= 1;
+                            ram_read <= 1;
+                            ram_addr <= wrap_burst_addr(ram_addr + 1'b1);
+                            saved_last_byte <= ram_read_buffer[7*8 +: 8];
                         end
                         else if (bit_count_in == 0) begin
                             ram_inhibit_refresh <= 0;
                             ram_activate <= 0;
                             ram_read <= 0;
-                            
                             fresh_read <= 1;
                         end
                     end
-                    
+
                     if (bit_count_in == 0) begin
-                        miso_byte <= ram_read_buffer[(addr[2:0]+1)*8 +: 8];
+                        if (addr[2:0] == 6)
+                            miso_byte <= saved_last_byte;
+                        else if (addr[2:0] != 7)
+                            miso_byte <= ram_read_buffer[(addr[2:0]+1)*8 +: 8];
                         addr <= addr + 1;
                         log_byte_count <= log_byte_count + 1;
                     end
-                    
-                    if (fresh_read) 
+
+                    if (fresh_read)
                         miso_byte <= ram_read_buffer[addr[2:0]*8 +: 8];
                 end
                 else if (state == STA_READID) begin
@@ -753,18 +766,20 @@ module spi_trx(
                 // ---------------------------------------------------------
                 else if (state == STA_ADDR_READ_DUAL) begin
                     
-                    // SDRAM pipeline during last address clocks
-                    if (addr_count == 7) begin
+                    // SDRAM pipeline during the address phase. Activate as
+                    // soon as row/bank are complete; the column is supplied
+                    // later when the READ request is posted.
+                    if (addr_count == 15) begin
                         ram_inhibit_refresh <= 1;
                     end
-                    else if (addr_count == 3) begin
+                    else if (addr_count == 9) begin
                         ram_activate <= 1;
-                        ram_addr[22:4] <= addr[25:7] & cfg_chip_erase_bursts[22:4];
+                        ram_addr[22:7] <= addr[25:10] & cfg_chip_erase_bursts[22:7];
                     end
-                    else if (addr_count == 1) begin
+                    else if (addr_count == 3) begin
                         ram_read <= 1;
-                        // addr[6:3] all received by prior clocks
-                        ram_addr[3:0] <= addr[6:3] & cfg_chip_erase_bursts[3:0];
+                        ram_addr[6:0] <= {addr[9:4], spi_io1_in} &
+                                         cfg_chip_erase_bursts[6:0];
                     end
                     
                     // Receive 2 address bits per clock
@@ -903,21 +918,21 @@ module spi_trx(
                 // ---------------------------------------------------------
                 else if (state == STA_ADDR_READ_QUAD) begin
                     
-                    // SDRAM pipeline during last address clocks
-                    if (addr_count == 11) begin
+                    // SDRAM pipeline during the address phase. At count 11,
+                    // IO3/IO2 carry byte-address bits 11/10, completing the
+                    // row and bank. The final column bit arrives at count 3.
+                    if (addr_count == 15) begin
                         ram_inhibit_refresh <= 1;
                     end
-                    else if (addr_count == 7) begin
-                        // addr[25:8] available from prior clocks; addr[7] = IO3 now
-                        ram_addr[22:4] <= {addr[25:8], spi_io3_in} &
-                                         cfg_chip_erase_bursts[22:4];
+                    else if (addr_count == 11) begin
+                        ram_activate <= 1;
+                        ram_addr[22:7] <= {addr[25:12], spi_io3_in, spi_io2_in} &
+                                         cfg_chip_erase_bursts[22:7];
                     end
                     else if (addr_count == 3) begin
-                        ram_activate <= 1;
                         ram_read <= 1;
-                        // addr[6:4] available from prior clock; addr[3] = IO3 now
-                        ram_addr[3:0] <= {addr[6:4], spi_io3_in} &
-                                        cfg_chip_erase_bursts[3:0];
+                        ram_addr[6:0] <= {addr[9:4], spi_io3_in} &
+                                        cfg_chip_erase_bursts[6:0];
                     end
                     
                     // Receive 4 address bits per clock

--- a/src/spi_trx.v
+++ b/src/spi_trx.v
@@ -114,6 +114,17 @@ module spi_trx(
     
     // JEDEC ID and 4-byte addressing are driven by cfg_jedec_id and cfg_4byte
     // from glue.v (configured at runtime via serial CHIPCONFIG command).
+    //
+    // cfg_chip_erase_bursts is both the chip-erase length and the burst-address
+    // mask. SPI NOR capacities are powers of two, and the configured value is
+    // (capacity_bytes / 8) - 1. Mask every SDRAM-facing address so unimplemented
+    // high address bits alias into the configured flash array like real chips.
+    function [22:0] wrap_burst_addr;
+        input [22:0] burst_addr;
+        begin
+            wrap_burst_addr = burst_addr & cfg_chip_erase_bursts;
+        end
+    endfunction
     
     // SPI Flash command definitions
     localparam
@@ -468,7 +479,7 @@ module spi_trx(
                                 state <= STA_AAI_DATA;
                                 write_cmd <= 1;
                                 write_type <= 2'd2;
-                                write_addr <= addr[25:3];
+                                write_addr <= wrap_burst_addr(addr[25:3]);
                                 write_len <= 0;
                                 status_reg[0] <= 1;
                             end
@@ -517,11 +528,12 @@ module spi_trx(
                         end
                         else if (addr_count == 4) begin
                             ram_activate <= 1;
-                            ram_addr[22:4] <= addr[25:7];
+                            ram_addr[22:4] <= addr[25:7] & cfg_chip_erase_bursts[22:4];
                         end
                         else if (addr_count == 3) begin
                             ram_read <= 1;
-                            ram_addr[3:0] <= {addr[6:4], spi_io0_in};
+                            ram_addr[3:0] <= {addr[6:4], spi_io0_in} &
+                                             cfg_chip_erase_bursts[3:0];
                         end
                     end
                     
@@ -604,7 +616,7 @@ module spi_trx(
                         end
                         else if (bit_count_in == 4) begin
                             ram_activate <= 1;
-                            ram_addr <= ram_addr + 1;
+                            ram_addr <= wrap_burst_addr(ram_addr + 1'b1);
                         end
                         else if (bit_count_in == 3) begin
                             ram_read <= 1;
@@ -650,11 +662,11 @@ module spi_trx(
                         // Align address based on erase size
                         // write_addr is 23-bit burst address = byte_addr[25:3]
                         if (write_len == 20'h01FFF)
-                            write_addr <= {addr[25:16], 13'b0};  // 64KB aligned
+                            write_addr <= wrap_burst_addr({addr[25:16], 13'b0});  // 64KB aligned
                         else if (write_len == 20'h00FFF)
-                            write_addr <= {addr[25:15], 12'b0};  // 32KB aligned
+                            write_addr <= wrap_burst_addr({addr[25:15], 12'b0});  // 32KB aligned
                         else
-                            write_addr <= {addr[25:12], 9'b0};   // 4KB aligned
+                            write_addr <= wrap_burst_addr({addr[25:12], 9'b0});   // 4KB aligned
                             
                         status_reg[1] <= 0;
                         status_reg[0] <= 1;
@@ -683,7 +695,7 @@ module spi_trx(
                             state <= STA_AAI_DATA;
                             write_cmd <= 1;
                             write_type <= 2'd2;
-                            write_addr <= addr[25:3];
+                            write_addr <= wrap_burst_addr(addr[25:3]);
                             write_len <= 0;
                             status_reg[0] <= 1;
                         end else begin
@@ -693,7 +705,7 @@ module spi_trx(
 
                             // Page-aligned address in 8-byte burst units
                             // byte_addr[25:3] -> burst address, page = 256 bytes = 32 bursts
-                            write_addr <= {addr[25:8], 5'b0};
+                            write_addr <= wrap_burst_addr({addr[25:8], 5'b0});
 
                             status_reg[1] <= 0;
                             status_reg[0] <= 1;
@@ -747,12 +759,12 @@ module spi_trx(
                     end
                     else if (addr_count == 3) begin
                         ram_activate <= 1;
-                        ram_addr[22:4] <= addr[25:7];
+                        ram_addr[22:4] <= addr[25:7] & cfg_chip_erase_bursts[22:4];
                     end
                     else if (addr_count == 1) begin
                         ram_read <= 1;
                         // addr[6:3] all received by prior clocks
-                        ram_addr[3:0] <= addr[6:3];
+                        ram_addr[3:0] <= addr[6:3] & cfg_chip_erase_bursts[3:0];
                     end
                     
                     // Receive 2 address bits per clock
@@ -847,7 +859,7 @@ module spi_trx(
                         ram_inhibit_refresh <= 1;  // Also here for short first bursts
                         ram_activate <= 1;
                         ram_read <= 1;
-                        ram_addr <= ram_addr + 1;
+                        ram_addr <= wrap_burst_addr(ram_addr + 1'b1);
                     end
                     
                     // Pipeline phase 3: deassert during last byte
@@ -858,7 +870,7 @@ module spi_trx(
                             ram_inhibit_refresh <= 1;
                             ram_activate <= 1;
                             ram_read <= 1;
-                            ram_addr <= ram_addr + 1;
+                            ram_addr <= wrap_burst_addr(ram_addr + 1'b1);
                             saved_last_byte <= ram_read_buffer[7*8 +: 8];
                         end
                         else if (bit_count_in == 0) begin
@@ -897,13 +909,15 @@ module spi_trx(
                     end
                     else if (addr_count == 7) begin
                         // addr[25:8] available from prior clocks; addr[7] = IO3 now
-                        ram_addr[22:4] <= {addr[25:8], spi_io3_in};
+                        ram_addr[22:4] <= {addr[25:8], spi_io3_in} &
+                                         cfg_chip_erase_bursts[22:4];
                     end
                     else if (addr_count == 3) begin
                         ram_activate <= 1;
                         ram_read <= 1;
                         // addr[6:4] available from prior clock; addr[3] = IO3 now
-                        ram_addr[3:0] <= {addr[6:4], spi_io3_in};
+                        ram_addr[3:0] <= {addr[6:4], spi_io3_in} &
+                                        cfg_chip_erase_bursts[3:0];
                     end
                     
                     // Receive 4 address bits per clock
@@ -953,7 +967,7 @@ module spi_trx(
                         ram_inhibit_refresh <= 1;
                         ram_activate <= 1;
                         ram_read <= 1;
-                        ram_addr <= ram_addr + 1;
+                        ram_addr <= wrap_burst_addr(ram_addr + 1'b1);
                     end
                     
                     // Pipeline phase 3: deassert during last byte
@@ -963,7 +977,7 @@ module spi_trx(
                             ram_inhibit_refresh <= 1;
                             ram_activate <= 1;
                             ram_read <= 1;
-                            ram_addr <= ram_addr + 1;
+                            ram_addr <= wrap_burst_addr(ram_addr + 1'b1);
                             saved_last_byte <= ram_read_buffer[7*8 +: 8];
                         end
                         else if (bit_count_in == 0) begin

--- a/src/top.v
+++ b/src/top.v
@@ -389,6 +389,7 @@ module top(
         .dq_io(IO_sdram_dq),
         
         // SPI fast-path control (address passes through TOCTOU redirect mux)
+        .spi_active(spi_active),
         .spi_inhibit_refresh(spi_ram_inhibit_refresh),
         .spi_cmd_activate(spi_ram_activate),
         .spi_cmd_read(spi_ram_read),

--- a/src/top.v
+++ b/src/top.v
@@ -128,19 +128,12 @@ module top(
     
     // SPI input signals
     //
-    // Keep the debounced CS path feeding spi_trx.  It rejects short CS
-    // glitches caused by SSO/ground-bounce during quad transfers; removing
-    // it can reset the SPI state machine mid-transaction.  Top-level output
-    // enables are additionally gated with the raw CS pin below so the FPGA
-    // still releases the bus immediately when the real CS deasserts.
-    reg [3:0] spi_cs_filter = 4'hF;
-    reg spi_cs_debounced = 1;
-    always @(posedge clk) begin
-        spi_cs_filter <= {spi_cs_filter[2:0], spi_cs_pin};
-        if (&spi_cs_filter)         spi_cs_debounced <= 1;  // all 1s: CS released
-        else if (~(|spi_cs_filter)) spi_cs_debounced <= 0;  // all 0s: CS asserted
-    end
-    wire spi_cs_in = spi_cs_debounced;
+    // Use raw CS for transaction framing. The previous four-sample debounce
+    // was an FT4222/quad-transfer workaround, but it delayed both CS edges by
+    // roughly 40 ns and could lose the beginning of tightly-timed commands.
+    // Output enables are also gated with raw CS below, so bus release remains
+    // immediate on deassertion.
+    wire spi_cs_in = spi_cs_pin;
     wire spi_clk_in = spi_clk_pin;
     wire spi_power_in = spi_power_pin;
     

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -1846,6 +1846,7 @@ fn cmd_monitor(cli: &Cli) -> Result<()> {
     let mut txn_count: u32 = 0;
     let mut current_opcode: u8 = 0;
     let mut current_addr: u32 = 0;
+    let mut command_line_open = false;
 
     // Poll loop: ask the FPGA for log data every ~5ms.  Every poll
     // response is self-delimited (ends with LOG_POLL_TERMINATOR) so
@@ -1865,6 +1866,10 @@ fn cmd_monitor(cli: &Cli) -> Result<()> {
             let remaining = pending.len() - pos;
             match pending[pos] {
                 LOG_CMD if remaining >= 2 => {
+                    if command_line_open {
+                        println!();
+                    }
+
                     let opcode = pending[pos + 1];
                     current_opcode = opcode;
                     txn_count += 1;
@@ -1874,6 +1879,8 @@ fn cmd_monitor(cli: &Cli) -> Result<()> {
                         opcode,
                         spi_opcode_name(opcode)
                     );
+                    std::io::stdout().flush()?;
+                    command_line_open = true;
                     pos += 2;
                 }
                 LOG_ADDR if remaining >= 5 => {
@@ -1901,16 +1908,23 @@ fn cmd_monitor(cli: &Cli) -> Result<()> {
                         }
                     }
                     println!();
+                    command_line_open = false;
                     pos += 5;
                 }
                 LOG_END if remaining >= 4 => {
-                    let count = ((pending[pos + 1] as u32) << 16)
+                    let byte_count = ((pending[pos + 1] as u32) << 16)
                         | ((pending[pos + 2] as u32) << 8)
                         | (pending[pos + 3] as u32);
-                    // +1 because the counter starts at 0 for the first byte
-                    let byte_count = count + 1;
+
+                    // Addressless commands do not receive a LOG_ADDR packet,
+                    // so terminate their command row when the transaction ends.
+                    if command_line_open {
+                        println!();
+                        command_line_open = false;
+                    }
+
                     if byte_count > 1 {
-                        eprintln!(
+                        println!(
                             "       end: {} bytes from 0x{:06X}",
                             byte_count, current_addr
                         );


### PR DESCRIPTION
## Summary

- wrap SDRAM addresses to the configured emulated flash capacity
- pipeline ACTIVATE/READ commands earlier in the SPI address phase
- publish SDRAM bursts atomically and prefetch across burst boundaries
- gate pipelined SDRAM requests with active CS and precharge aborted ACTIVATEs
- use raw chip select so tightly timed boot commands are not truncated
- correct SPI monitor line handling and byte counts

## Review notes

The original changes included a `CLOCK_LOC` constraint on the SPI input port. Gowin PnR rejects that constraint with `CT1020`, so it was removed while splitting and reviewing the stack.

The read-ahead pipeline originally could leave refresh inhibited if CS was deasserted after prefetch started but before its normal cleanup clock. SDRAM requests are now gated with active CS, and an ACTIVATE abandoned before READ is safely precharged after `tRAS`.

This branch is based directly on `master` and is independent of the flake fix in #14.

## Validation

- Hardware: SPI boot works with these timing changes
- `nix develop -c env -u DISPLAY QT_QPA_PLATFORM=offscreen make build`
- `cargo test --manifest-path tool/Cargo.toml`
