### PR TITLE
Replace custom chip database with rflasher-chips crate

### DIFF
--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -95,6 +95,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +269,25 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -510,6 +535,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +560,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rflasher-chip-types"
+version = "0.1.0"
+source = "git+https://github.com/ArthurHeymans/rflasher.git?rev=1879f3819cb4f3d9fde76447198346cae3e2b40d#1879f3819cb4f3d9fde76447198346cae3e2b40d"
+dependencies = [
+ "bitflags 2.11.1",
+ "heapless",
+]
+
+[[package]]
+name = "rflasher-chips"
+version = "0.1.0"
+source = "git+https://github.com/ArthurHeymans/rflasher.git?rev=1879f3819cb4f3d9fde76447198346cae3e2b40d#1879f3819cb4f3d9fde76447198346cae3e2b40d"
+dependencies = [
+ "once_cell",
+ "rflasher-chip-types",
+ "rflasher-chips-codegen",
+ "ron",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "rflasher-chips-codegen"
+version = "0.1.0"
+source = "git+https://github.com/ArthurHeymans/rflasher.git?rev=1879f3819cb4f3d9fde76447198346cae3e2b40d#1879f3819cb4f3d9fde76447198346cae3e2b40d"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "ron",
+ "serde",
+ "syn",
 ]
 
 [[package]]
@@ -629,10 +699,15 @@ dependencies = [
  "ftdi-nusb",
  "indicatif",
  "libftd2xx",
- "ron",
- "serde",
+ "rflasher-chips",
  "serialport",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -16,6 +16,5 @@ ftdi = { package = "ftdi-nusb", version = "0.1.0", optional = true }
 clap = { version = "4.4", features = ["derive"] }
 anyhow = "1.0"
 indicatif = "0.17"
-serde = { version = "1.0", features = ["derive"] }
-ron = "0.8"
+rflasher-chips = { git = "https://github.com/ArthurHeymans/rflasher.git", rev = "1879f3819cb4f3d9fde76447198346cae3e2b40d", features = ["static-chips"] }
 ctrlc = "3.4"

--- a/tool/src/chip.rs
+++ b/tool/src/chip.rs
@@ -1,327 +1,110 @@
-//! Chip definition types for loading rflasher-compatible RON files.
-//!
-//! These types mirror the RON schema used by rflasher's chip database,
-//! allowing NORbert to reuse the same chip definition files.
-
-#![allow(dead_code)]
+//! Flash chip database access backed by rflasher.
 
 use anyhow::{Context, Result, bail};
-use serde::Deserialize;
+pub use rflasher_chips::{ChipDatabase, EraseBlock, Features, FlashChip};
 use std::path::Path;
 
-// ---------------------------------------------------------------------------
-// RON deserialization types (must match rflasher's schema exactly)
-// ---------------------------------------------------------------------------
+pub trait FlashChipExt {
+    /// Full 3-byte JEDEC ID: [manufacturer, device_hi, device_lo].
+    fn jedec_id_bytes(&self) -> [u8; 3];
 
-#[derive(Debug, Deserialize)]
-pub struct VendorDef {
-    pub vendor: String,
-    pub manufacturer_id: u8,
-    pub chips: Vec<ChipDef>,
+    /// Number of 8-byte SDRAM bursts needed to erase the whole chip, minus 1.
+    fn chip_erase_bursts(&self) -> u32;
+
+    /// Whether the chip supports 4-byte addressing as advertised by rflasher.
+    fn supports_4byte(&self) -> bool;
+
+    fn supports_dual(&self) -> bool;
+    fn supports_quad(&self) -> bool;
+    fn aai_word(&self) -> bool;
+    fn write_byte(&self) -> bool;
+    fn supports_sfdp(&self) -> bool;
+
+    /// Erase operations sorted by block size, excluding chip erase.
+    fn sector_erase_ops(&self) -> Vec<&EraseBlock>;
 }
 
-#[derive(Debug, Deserialize)]
-pub struct ChipDef {
-    pub name: String,
-    pub device_id: u16,
-    pub total_size: Size,
-    #[serde(default = "default_page_size")]
-    pub page_size: u16,
-    #[serde(default)]
-    pub features: FeaturesDef,
-    #[serde(default)]
-    pub voltage: VoltageDef,
-    #[serde(default)]
-    pub write_granularity: WriteGranularityDef,
-    pub erase_blocks: Vec<EraseBlockDef>,
-    #[serde(default)]
-    pub tested: TestStatusesDef,
-}
-
-fn default_page_size() -> u16 {
-    256
-}
-
-#[derive(Debug, Clone, Copy, Deserialize)]
-pub enum Size {
-    B(u32),
-    KiB(u32),
-    MiB(u32),
-}
-
-impl Size {
-    pub fn to_bytes(self) -> u32 {
-        match self {
-            Size::B(n) => n,
-            Size::KiB(n) => n * 1024,
-            Size::MiB(n) => n * 1024 * 1024,
-        }
-    }
-}
-
-#[derive(Debug, Default, Deserialize)]
-pub struct FeaturesDef {
-    #[serde(default)]
-    pub wrsr_wren: bool,
-    #[serde(default)]
-    pub wrsr_ewsr: bool,
-    #[serde(default)]
-    pub wrsr_ext: bool,
-    #[serde(default)]
-    pub fast_read: bool,
-    #[serde(default)]
-    pub dual_io: bool,
-    #[serde(default)]
-    pub quad_io: bool,
-    #[serde(default)]
-    pub four_byte_addr: bool,
-    #[serde(default)]
-    pub four_byte_enter: bool,
-    #[serde(default)]
-    pub four_byte_native: bool,
-    #[serde(default)]
-    pub ext_addr_reg: bool,
-    #[serde(default)]
-    pub otp: bool,
-    #[serde(default)]
-    pub qpi: bool,
-    #[serde(default)]
-    pub security_reg: bool,
-    #[serde(default)]
-    pub sfdp: bool,
-    #[serde(default)]
-    pub write_byte: bool,
-    #[serde(default)]
-    pub aai_word: bool,
-    #[serde(default)]
-    pub status_reg_2: bool,
-    #[serde(default)]
-    pub status_reg_3: bool,
-    #[serde(default)]
-    pub qe_sr2: bool,
-    #[serde(default)]
-    pub deep_power_down: bool,
-    #[serde(default)]
-    pub wp_tb: bool,
-    #[serde(default)]
-    pub wp_sec: bool,
-    #[serde(default)]
-    pub wp_cmp: bool,
-    #[serde(default)]
-    pub wp_srl: bool,
-    #[serde(default)]
-    pub wp_volatile: bool,
-    #[serde(default)]
-    pub wp_bp3: bool,
-    #[serde(default)]
-    pub wp_wps: bool,
-    #[serde(default)]
-    pub sst26_bpr: bool,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct VoltageDef {
-    #[serde(default = "default_voltage_min")]
-    pub min: u16,
-    #[serde(default = "default_voltage_max")]
-    pub max: u16,
-}
-
-fn default_voltage_min() -> u16 {
-    2700
-}
-fn default_voltage_max() -> u16 {
-    3600
-}
-
-impl Default for VoltageDef {
-    fn default() -> Self {
-        Self {
-            min: 2700,
-            max: 3600,
-        }
-    }
-}
-
-#[derive(Debug, Default, Deserialize)]
-pub enum WriteGranularityDef {
-    Bit,
-    Byte,
-    #[default]
-    Page,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct EraseBlockDef {
-    pub opcode: u8,
-    pub regions: Vec<RegionDef>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct RegionDef {
-    pub size: Size,
-    pub count: u32,
-}
-
-#[derive(Debug, Default, Deserialize)]
-pub enum TestStatusDef {
-    #[default]
-    Untested,
-    Ok,
-    Bad,
-    Na,
-}
-
-#[derive(Debug, Default, Deserialize)]
-pub struct TestStatusesDef {
-    #[serde(default)]
-    pub probe: TestStatusDef,
-    #[serde(default)]
-    pub read: TestStatusDef,
-    #[serde(default)]
-    pub erase: TestStatusDef,
-    #[serde(default)]
-    pub write: TestStatusDef,
-    #[serde(default)]
-    pub wp: TestStatusDef,
-}
-
-// ---------------------------------------------------------------------------
-// Runtime chip representation (converted from RON types)
-// ---------------------------------------------------------------------------
-
-/// Erase operation: an SPI opcode and the block size it erases.
-#[derive(Debug, Clone)]
-pub struct EraseOp {
-    pub opcode: u8,
-    pub block_size: u32, // in bytes (from the first/only uniform region)
-}
-
-/// Resolved chip definition ready for use.
-#[derive(Debug, Clone)]
-pub struct FlashChip {
-    pub vendor: String,
-    pub name: String,
-    pub jedec_manufacturer: u8,
-    pub jedec_device: u16,
-    pub total_size: u32,
-    pub page_size: u16,
-    pub supports_4byte: bool,
-    pub supports_dual: bool,
-    pub supports_quad: bool,
-    pub supports_fast_read: bool,
-    pub aai_word: bool,
-    pub write_byte: bool,
-    pub supports_sfdp: bool,
-    pub erase_ops: Vec<EraseOp>,
-}
-
-impl FlashChip {
-    /// Full 3-byte JEDEC ID: [manufacturer, device_hi, device_lo]
-    pub fn jedec_id_bytes(&self) -> [u8; 3] {
+impl FlashChipExt for FlashChip {
+    fn jedec_id_bytes(&self) -> [u8; 3] {
         [
             self.jedec_manufacturer,
             (self.jedec_device >> 8) as u8,
-            (self.jedec_device & 0xFF) as u8,
+            self.jedec_device as u8,
         ]
     }
 
-    /// Number of 8-byte SDRAM bursts needed to erase the whole chip, minus 1.
-    pub fn chip_erase_bursts(&self) -> u32 {
+    fn chip_erase_bursts(&self) -> u32 {
         (self.total_size / 8).saturating_sub(1)
     }
 
-    /// Erase operations sorted by block size (smallest first), excluding chip erase.
-    pub fn sector_erase_ops(&self) -> Vec<&EraseOp> {
-        let mut ops: Vec<&EraseOp> = self
-            .erase_ops
+    fn supports_4byte(&self) -> bool {
+        self.features
+            .intersects(Features::FOUR_BYTE_ADDR | Features::FOUR_BYTE_ENTER)
+    }
+
+    fn supports_dual(&self) -> bool {
+        self.features.contains(Features::DUAL_IO)
+    }
+
+    fn supports_quad(&self) -> bool {
+        self.features.contains(Features::QUAD_IO)
+    }
+
+    fn aai_word(&self) -> bool {
+        self.features.contains(Features::AAI_WORD)
+    }
+
+    fn write_byte(&self) -> bool {
+        self.features.contains(Features::WRITE_BYTE)
+    }
+
+    fn supports_sfdp(&self) -> bool {
+        self.features.contains(Features::SFDP)
+    }
+
+    fn sector_erase_ops(&self) -> Vec<&EraseBlock> {
+        let mut ops: Vec<&EraseBlock> = self
+            .erase_blocks
             .iter()
-            .filter(|op| op.block_size < self.total_size)
+            .filter(|erase| {
+                erase_block_size(erase).is_some_and(|block_size| block_size < self.total_size)
+            })
             .collect();
-        ops.sort_by_key(|op| op.block_size);
+        ops.sort_by_key(|erase| erase_block_size(erase).unwrap_or(0));
         ops
     }
 }
 
-// ---------------------------------------------------------------------------
-// Loading
-// ---------------------------------------------------------------------------
-
-/// Load all RON chip files from a directory, returning a flat list of chips.
-pub fn load_chip_db(dir: &Path) -> Result<Vec<FlashChip>> {
-    let mut chips = Vec::new();
-
-    let entries: Vec<_> = std::fs::read_dir(dir)
-        .with_context(|| format!("Failed to read chip database directory: {}", dir.display()))?
-        .collect::<std::io::Result<Vec<_>>>()
-        .with_context(|| format!("Failed to list {}", dir.display()))?;
-
-    for entry in entries {
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("ron") {
-            continue;
-        }
-
-        let content = std::fs::read_to_string(&path)
-            .with_context(|| format!("Failed to read {}", path.display()))?;
-
-        let vendor_def: VendorDef = ron::from_str(&content)
-            .with_context(|| format!("Failed to parse {}", path.display()))?;
-
-        for chip_def in &vendor_def.chips {
-            let mut erase_ops = Vec::new();
-            for eb in &chip_def.erase_blocks {
-                // Use the first region's size as the block size.
-                // Non-uniform erase layouts (boot sector chips) are rare;
-                // for emulation we only need the uniform block size.
-                if let Some(region) = eb.regions.first() {
-                    erase_ops.push(EraseOp {
-                        opcode: eb.opcode,
-                        block_size: region.size.to_bytes(),
-                    });
-                }
-            }
-
-            chips.push(FlashChip {
-                vendor: vendor_def.vendor.clone(),
-                name: chip_def.name.clone(),
-                jedec_manufacturer: vendor_def.manufacturer_id,
-                jedec_device: chip_def.device_id,
-                total_size: chip_def.total_size.to_bytes(),
-                page_size: chip_def.page_size,
-                supports_4byte: chip_def.features.four_byte_addr
-                    || chip_def.features.four_byte_enter,
-                supports_dual: chip_def.features.dual_io,
-                supports_quad: chip_def.features.quad_io,
-                supports_fast_read: chip_def.features.fast_read,
-                aai_word: chip_def.features.aai_word,
-                write_byte: chip_def.features.write_byte,
-                supports_sfdp: chip_def.features.sfdp,
-                erase_ops,
-            });
-        }
-    }
-
-    Ok(chips)
+/// Return the first region's block size, matching NORbert's uniform-chip use.
+pub fn erase_block_size(erase: &EraseBlock) -> Option<u32> {
+    erase.regions.first().map(|region| region.size)
 }
 
-/// Find a chip by name (case-insensitive substring match).
-pub fn find_chip_by_name<'a>(chips: &'a [FlashChip], name: &str) -> Result<&'a FlashChip> {
+/// Load rflasher's compiled-in chip database, or an explicit directory override.
+pub fn load_chip_db(dir: Option<&Path>) -> Result<ChipDatabase> {
+    match dir {
+        Some(dir) => ChipDatabase::from_dir(dir).with_context(|| {
+            format!("Failed to load chip database directory: {}", dir.display())
+        }),
+        None => Ok(ChipDatabase::new()),
+    }
+}
+
+/// Find a chip by name (case-insensitive exact or substring match).
+pub fn find_chip_by_name<'a>(db: &'a ChipDatabase, name: &str) -> Result<&'a FlashChip> {
     let name_lower = name.to_lowercase();
 
-    // Try exact match first
-    let exact: Vec<_> = chips
+    let exact: Vec<_> = db
         .iter()
-        .filter(|c| c.name.to_lowercase() == name_lower)
+        .filter(|chip| chip.name.to_lowercase() == name_lower)
         .collect();
     if exact.len() == 1 {
         return Ok(exact[0]);
     }
 
-    // Try substring match
-    let matches: Vec<_> = chips
+    let matches: Vec<_> = db
         .iter()
-        .filter(|c| c.name.to_lowercase().contains(&name_lower))
+        .filter(|chip| chip.name.to_lowercase().contains(&name_lower))
         .collect();
 
     match matches.len() {
@@ -330,7 +113,7 @@ pub fn find_chip_by_name<'a>(chips: &'a [FlashChip], name: &str) -> Result<&'a F
         n => {
             let names: Vec<_> = matches
                 .iter()
-                .map(|c| format!("  {} ({})", c.name, c.vendor))
+                .map(|chip| format!("  {} ({})", chip.name, chip.vendor))
                 .collect();
             bail!(
                 "Ambiguous chip name '{}', {} matches:\n{}",

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -1,6 +1,7 @@
 mod chip;
 mod sfdp;
 
+use chip::FlashChipExt;
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{Parser, Subcommand};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -658,7 +659,7 @@ impl FlashDevice {
     fn send_chip_config(&mut self, chip: &chip::FlashChip, sfdp_table: &[u8]) -> Result<()> {
         let jedec = chip.jedec_id_bytes();
         let erase_bursts = chip.chip_erase_bursts();
-        let flags: u8 = if chip.supports_4byte { 0x01 } else { 0x00 };
+        let flags: u8 = if chip.supports_4byte() { 0x01 } else { 0x00 };
 
         let sfdp_len = sfdp_table.len();
         if sfdp_len > 128 {
@@ -967,9 +968,10 @@ enum Commands {
 
     /// Configure the emulated flash chip identity
     Configure {
-        /// Path to rflasher chip database directory (containing .ron files)
-        #[arg(long, default_value = "~/src/rflasher/chips/vendors")]
-        chip_db: String,
+        /// Path to a chip database directory (containing .ron files).
+        /// By default, use rflasher's compiled-in chip database.
+        #[arg(long, value_name = "DIR")]
+        chip_db: Option<PathBuf>,
 
         /// Chip name to emulate (substring match, e.g. "W25Q128.V")
         #[arg(short, long)]
@@ -1316,19 +1318,23 @@ fn cmd_dump(cli: &Cli, file: &Path, address: u32, length: u32) -> Result<()> {
     cmd_read(cli, address, length, Some(file.to_path_buf()))
 }
 
-fn cmd_configure(cli: &Cli, chip_db_path: &str, chip_name: &str) -> Result<()> {
-    // Expand ~ in path
-    let expanded = if let Some(stripped) = chip_db_path.strip_prefix("~/") {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-        format!("{}/{}", home, stripped)
-    } else {
-        chip_db_path.to_string()
-    };
-    let db_path = std::path::Path::new(&expanded);
+fn cmd_configure(cli: &Cli, chip_db_path: Option<&Path>, chip_name: &str) -> Result<()> {
+    let chip_db_path = chip_db_path.map(|path| {
+        let path_string = path.to_string_lossy();
+        if let Some(stripped) = path_string.strip_prefix("~/") {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+            PathBuf::from(format!("{home}/{stripped}"))
+        } else {
+            path.to_path_buf()
+        }
+    });
 
-    // Load chip database
-    eprintln!("Loading chip database from {}...", db_path.display());
-    let chips = chip::load_chip_db(db_path)?;
+    if let Some(path) = chip_db_path.as_deref() {
+        eprintln!("Loading chip database override from {}...", path.display());
+    } else {
+        eprintln!("Loading rflasher's compiled-in chip database...");
+    }
+    let chips = chip::load_chip_db(chip_db_path.as_deref())?;
     eprintln!("Loaded {} chip definitions", chips.len());
 
     // Find requested chip
@@ -1344,30 +1350,32 @@ fn cmd_configure(cli: &Cli, chip_db_path: &str, chip_name: &str) -> Result<()> {
         chip.total_size / (1024 * 1024),
     );
     eprintln!("  Page size:  {} bytes", chip.page_size);
-    eprintln!("  4-byte addr: {}", chip.supports_4byte);
-    eprintln!("  Dual I/O:   {}", chip.supports_dual);
-    eprintln!("  Quad I/O:   {}", chip.supports_quad);
-    if chip.aai_word {
+    eprintln!("  4-byte addr: {}", chip.supports_4byte());
+    eprintln!("  Dual I/O:   {}", chip.supports_dual());
+    eprintln!("  Quad I/O:   {}", chip.supports_quad());
+    if chip.aai_word() {
         eprintln!("  Write mode: AAI Word Program (0xAD)");
     }
-    if chip.write_byte {
+    if chip.write_byte() {
         eprintln!("  Write mode: Byte program");
     }
 
     let erase_ops = chip.sector_erase_ops();
     for op in &erase_ops {
-        eprintln!(
-            "  Erase:      0x{:02X} ({} KB)",
-            op.opcode,
-            op.block_size / 1024
-        );
+        if let Some(block_size) = chip::erase_block_size(op) {
+            eprintln!(
+                "  Erase:      0x{:02X} ({} KB)",
+                op.opcode,
+                block_size / 1024
+            );
+        }
     }
 
     // Generate SFDP table.  For chips that do not support SFDP in real
     // hardware (e.g. older SST25VFxxx), the table is all-0xFF so SFDP
     // probes see no valid signature, matching the real part.
     let sfdp_table = sfdp::generate_sfdp(chip);
-    if chip.supports_sfdp {
+    if chip.supports_sfdp() {
         eprintln!("  SFDP table: {} bytes (valid)", sfdp_table.len());
     } else {
         eprintln!(
@@ -2120,7 +2128,7 @@ fn main() -> Result<()> {
             address,
             length,
         } => cmd_dump(&cli, file, *address, *length),
-        Commands::Configure { chip_db, chip } => cmd_configure(&cli, chip_db, chip),
+        Commands::Configure { chip_db, chip } => cmd_configure(&cli, chip_db.as_deref(), chip),
         Commands::Hold { state } => cmd_hold(&cli, state),
         Commands::Monitor => cmd_monitor(&cli),
         Commands::Toctou { action } => cmd_toctou(&cli, action),

--- a/tool/src/sfdp.rs
+++ b/tool/src/sfdp.rs
@@ -8,7 +8,7 @@
 //!   0x08..0x0F  Parameter Header 0 / BFPT (8 bytes)
 //!   0x10..0x4F  Basic Flash Parameter Table (16 DWORDs = 64 bytes)
 
-use crate::chip::FlashChip;
+use crate::chip::{erase_block_size, FlashChip, FlashChipExt};
 
 /// Size of the generated SFDP table in bytes.
 pub const SFDP_TABLE_SIZE: usize = 80;
@@ -28,7 +28,7 @@ const BFPT_DWORDS: u8 = 16; // JESD216A/B
 pub fn generate_sfdp(chip: &FlashChip) -> [u8; SFDP_TABLE_SIZE] {
     let mut table = [0xFFu8; SFDP_TABLE_SIZE];
 
-    if !chip.supports_sfdp {
+    if !chip.supports_sfdp() {
         return table;
     }
 
@@ -82,12 +82,15 @@ fn write_bfpt(chip: &FlashChip, table: &mut [u8; SFDP_TABLE_SIZE]) {
     // ------------------------------------------------------------------
     // 1st DWORD: erase granularity, write info, address bytes, read modes
     // ------------------------------------------------------------------
-    let has_4k_erase = chip.erase_ops.iter().any(|e| e.block_size == 4096);
-    let erase_4k_opcode = chip
-        .erase_ops
+    let has_4k_erase = chip
+        .erase_blocks
         .iter()
-        .find(|e| e.block_size == 4096)
-        .map(|e| e.opcode)
+        .any(|erase| erase_block_size(erase) == Some(4096));
+    let erase_4k_opcode = chip
+        .erase_blocks
+        .iter()
+        .find(|erase| erase_block_size(erase) == Some(4096))
+        .map(|erase| erase.opcode)
         .unwrap_or(0xFF);
 
     let mut dw1: u32 = 0;
@@ -103,7 +106,7 @@ fn write_bfpt(chip: &FlashChip, table: &mut [u8; SFDP_TABLE_SIZE]) {
     // here.  Tools that rely solely on SFDP then fall back to byte
     // programming via 0x02; tools with a hardcoded chip table (e.g.
     // flashprog) will use their own AAI path regardless.
-    let large_buffer = chip.page_size >= 64 && !chip.aai_word && !chip.write_byte;
+    let large_buffer = chip.page_size >= 64 && !chip.aai_word() && !chip.write_byte();
     if large_buffer {
         dw1 |= 1 << 2;
     }
@@ -116,24 +119,24 @@ fn write_bfpt(chip: &FlashChip, table: &mut [u8; SFDP_TABLE_SIZE]) {
     // [15:8] 4KB erase opcode
     dw1 |= (erase_4k_opcode as u32) << 8;
     // [17:16] Address bytes: 00=3-byte only, 01=3 or 4 byte
-    if chip.supports_4byte {
+    if chip.supports_4byte() {
         dw1 |= 0x01 << 16;
     }
     // [18] DTR: not supported
     // [19] 1-1-2 Fast Read
-    if chip.supports_dual {
+    if chip.supports_dual() {
         dw1 |= 1 << 19;
     }
     // [20] 1-2-2 Fast Read
-    if chip.supports_dual {
+    if chip.supports_dual() {
         dw1 |= 1 << 20;
     }
     // [21] 1-4-4 Fast Read
-    if chip.supports_quad {
+    if chip.supports_quad() {
         dw1 |= 1 << 21;
     }
     // [22] 1-1-4 Fast Read
-    if chip.supports_quad {
+    if chip.supports_quad() {
         dw1 |= 1 << 22;
     }
     put_dword(table, base, dw1);
@@ -154,7 +157,7 @@ fn write_bfpt(chip: &FlashChip, table: &mut [u8; SFDP_TABLE_SIZE]) {
     // ------------------------------------------------------------------
     // 3rd DWORD: 1-4-4 and 1-1-4 Fast Read parameters
     // ------------------------------------------------------------------
-    let dw3 = if chip.supports_quad {
+    let dw3 = if chip.supports_quad() {
         // 1-4-4 (0xEB): 4 dummy clocks after 2 mode clocks
         let wait_144: u32 = 4; // dummy clocks
         let mode_144: u32 = 2; // mode clocks
@@ -177,7 +180,7 @@ fn write_bfpt(chip: &FlashChip, table: &mut [u8; SFDP_TABLE_SIZE]) {
     // ------------------------------------------------------------------
     // 4th DWORD: 1-2-2 and 1-1-2 Fast Read parameters
     // ------------------------------------------------------------------
-    let dw4 = if chip.supports_dual {
+    let dw4 = if chip.supports_dual() {
         // 1-2-2 (0xBB): 0 dummy clocks, 4 mode clocks
         let wait_122: u32 = 0;
         let mode_122: u32 = 4;
@@ -216,8 +219,10 @@ fn write_bfpt(chip: &FlashChip, table: &mut [u8; SFDP_TABLE_SIZE]) {
     let erase_ops = chip.sector_erase_ops();
 
     let encode_erase = |idx: usize| -> u16 {
-        if let Some(op) = erase_ops.get(idx) {
-            let n = op.block_size.trailing_zeros() as u8;
+        if let Some(op) = erase_ops.get(idx)
+            && let Some(block_size) = erase_block_size(op)
+        {
+            let n = block_size.trailing_zeros() as u8;
             (n as u16) | ((op.opcode as u16) << 8)
         } else {
             0
@@ -296,7 +301,7 @@ fn write_bfpt(chip: &FlashChip, table: &mut [u8; SFDP_TABLE_SIZE]) {
     //   101 = QE is bit 1 of SR2, set via 0x01 with 2 data bytes (Winbond)
     // [31:7] Reserved
     // ------------------------------------------------------------------
-    let dw14 = if chip.supports_quad {
+    let dw14 = if chip.supports_quad() {
         // Use method 5 (0b101): QE = SR2 bit 1, write via 0x01 with 2 bytes
         // This matches Winbond W25Q and many other common chips
         0x05 << 4
@@ -312,7 +317,7 @@ fn write_bfpt(chip: &FlashChip, table: &mut [u8; SFDP_TABLE_SIZE]) {
     //   bit 1: issue 0xB7 to enter 4-byte mode
     // [31:8] Exit methods
     // ------------------------------------------------------------------
-    let dw15 = if chip.supports_4byte {
+    let dw15 = if chip.supports_4byte() {
         0x02 // Enter via 0xB7 (EN4B)
     } else {
         0


### PR DESCRIPTION
Remove the hand-rolled RON deserialization types and add a `FlashChipExt`
trait that delegates to rflasher's types. The `--chip-db` argument is now
optional; when omitted the compilation-time static database is used.