### PR TITLE
Extract FPGA protocol definitions into a reusable module

### DIFF
--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -701,6 +701,7 @@ dependencies = [
  "libftd2xx",
  "rflasher-chips",
  "serialport",
+ "zerocopy",
 ]
 
 [[package]]
@@ -930,3 +931,23 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -18,3 +18,4 @@ anyhow = "1.0"
 indicatif = "0.17"
 rflasher-chips = { git = "https://github.com/ArthurHeymans/rflasher.git", rev = "1879f3819cb4f3d9fde76447198346cae3e2b40d", features = ["static-chips"] }
 ctrlc = "3.4"
+zerocopy = { version = "=0.8.55", features = ["derive"] }

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -1,10 +1,12 @@
 mod chip;
+mod protocol;
 mod sfdp;
 
-use chip::FlashChipExt;
 use anyhow::{Context, Result, anyhow, bail};
+use chip::FlashChipExt;
 use clap::{Parser, Subcommand};
 use indicatif::{ProgressBar, ProgressStyle};
+use protocol::*;
 use serialport::SerialPort;
 use std::fs::File;
 use std::io::{Read, Write};
@@ -13,6 +15,7 @@ use std::thread;
 use std::time::Duration;
 #[cfg(any(feature = "d2xx", feature = "ftdi"))]
 use std::time::Instant;
+use zerocopy::IntoBytes;
 
 const BAUD_RATE: u32 = 2_000_000;
 // Max bursts per command: 16-bit len field (v3), 8 bytes per burst.
@@ -29,40 +32,6 @@ const BLOCK_SIZE: usize = 16384; // 2048 bursts * 8 bytes
 // host-to-FPGA, SDRAM writes complete in microseconds).
 const UART_READ_BLOCK_SIZE: usize = 4096; // 512 bursts * 8 bytes
 const SDRAM_SIZE_BYTES: u64 = 64 * 1024 * 1024;
-
-const PROTOCOL_VERSION: u8 = 5;
-
-// Protocol commands (shared between UART and FT245 transports)
-const CMD_VERSION: u8 = 0x30;
-const CMD_READ: u8 = 0x31;
-const CMD_WRITE: u8 = 0x32;
-const CMD_CHIPCONFIG: u8 = 0x33;
-const CMD_START: u8 = 0x34; // Enable SPI emulation (protocol v4+)
-const CMD_STOP: u8 = 0x35; // Disable SPI emulation (protocol v4+)
-const CMD_STATUS: u8 = 0x36; // Query emulation state (protocol v4+)
-const CMD_HOLDCTL: u8 = 0x37; // Target flash #HOLD control (protocol v5+)
-const CMD_LOGCTL: u8 = 0x38; // Enable/disable SPI bus logging capture (protocol v5+)
-const CMD_TOCTOU: u8 = 0x39; // TOCTOU trap management (protocol v5+)
-const CMD_LOGPOLL: u8 = 0x3A; // Drain logger ring FIFO (protocol v5+)
-
-// CMD_LOGPOLL framing. Raw log bytes equal to 0xA0 or 0xA5 are escaped
-// by the FPGA as 0xA5 0x00 or 0xA5 0x05 respectively, leaving 0xA0 as an
-// unambiguous end-of-poll marker.
-const LOG_POLL_TERMINATOR: u8 = 0xA0;
-const LOG_POLL_ESCAPE: u8 = 0xA5;
-
-// TOCTOU sub-commands
-const TOCTOU_SET: u8 = 0x01;
-const TOCTOU_ARM: u8 = 0x02;
-const TOCTOU_DISARM: u8 = 0x03;
-const TOCTOU_RESET: u8 = 0x04;
-const TOCTOU_RESET_ALL: u8 = 0x05;
-
-// Log packet type markers
-const LOG_CMD: u8 = 0xA1;
-const LOG_ADDR: u8 = 0xA2;
-const LOG_END: u8 = 0xA3;
-const LOG_TRAP: u8 = 0xA4;
 
 // FT2232H USB identifiers
 #[cfg(any(feature = "d2xx", feature = "ftdi"))]
@@ -550,16 +519,11 @@ impl FlashDevice {
         let len_units = length / 8;
 
         // v3 header: cmd + 3 addr bytes + 2 len bytes (big-endian)
-        let cmd = [
-            CMD_READ,
-            ((addr_units >> 16) & 0xFF) as u8,
-            ((addr_units >> 8) & 0xFF) as u8,
-            (addr_units & 0xFF) as u8,
-            ((len_units >> 8) & 0xFF) as u8,
-            (len_units & 0xFF) as u8,
-        ];
+        let len_units = u16::try_from(len_units).context("read burst count exceeds 16 bits")?;
+        let header =
+            RamHeader::read(addr_units, len_units).context("read burst address exceeds 24 bits")?;
 
-        self.transport.write_all(&cmd)?;
+        self.transport.write_all(header.as_bytes())?;
 
         let mut buf = vec![0u8; length];
         self.transport.read_exact(&mut buf)?;
@@ -585,15 +549,11 @@ impl FlashDevice {
         // Combine header and data into a single write to avoid
         // transfer gaps that could trigger the FPGA's idle timeout.
         // v3 header: cmd + 3 addr bytes + 2 len bytes (big-endian)
-        let mut buf = Vec::with_capacity(6 + data.len());
-        buf.extend_from_slice(&[
-            CMD_WRITE,
-            ((addr_units >> 16) & 0xFF) as u8,
-            ((addr_units >> 8) & 0xFF) as u8,
-            (addr_units & 0xFF) as u8,
-            ((len_units >> 8) & 0xFF) as u8,
-            (len_units & 0xFF) as u8,
-        ]);
+        let len_units = u16::try_from(len_units).context("write burst count exceeds 16 bits")?;
+        let header = RamHeader::write(addr_units, len_units)
+            .context("write burst address exceeds 24 bits")?;
+        let mut buf = Vec::with_capacity(size_of::<RamHeader>() + data.len());
+        buf.extend_from_slice(header.as_bytes());
         buf.extend_from_slice(data);
         self.transport.write_all(&buf)?;
 
@@ -673,17 +633,13 @@ impl FlashDevice {
             );
         }
 
-        // Build the full command in one buffer to avoid USB transfer gaps
-        let mut buf = Vec::with_capacity(9 + sfdp_len);
-        buf.push(CMD_CHIPCONFIG);
-        buf.push(jedec[0]); // manufacturer
-        buf.push(jedec[1]); // device high
-        buf.push(jedec[2]); // device low
-        buf.push(flags);
-        buf.push(((erase_bursts >> 16) & 0x7F) as u8);
-        buf.push(((erase_bursts >> 8) & 0xFF) as u8);
-        buf.push((erase_bursts & 0xFF) as u8);
-        buf.push(sfdp_len as u8);
+        let sfdp_len = u8::try_from(sfdp_len).context("SFDP table length exceeds 8 bits")?;
+        let header = ChipConfigHeader::new(jedec, flags, erase_bursts, sfdp_len)
+            .context("chip erase burst count exceeds the protocol's 23-bit field")?;
+
+        // Build the full command in one buffer to avoid USB transfer gaps.
+        let mut buf = Vec::with_capacity(size_of::<ChipConfigHeader>() + sfdp_table.len());
+        buf.extend_from_slice(header.as_bytes());
         buf.extend_from_slice(sfdp_table);
         self.transport.write_all(&buf)?;
 
@@ -705,8 +661,8 @@ impl FlashDevice {
     ///   Byte 1: 0x01 = assert hold, 0x00 = release hold
     ///   Response: 0x01 on success.
     fn set_hold(&mut self, enable: bool) -> Result<()> {
-        let data = if enable { 0x01u8 } else { 0x00u8 };
-        self.transport.write_all(&[CMD_HOLDCTL, data])?;
+        self.transport
+            .write_all(ControlRequest::hold(enable).as_bytes())?;
 
         // Wait for ack (skip modem status bytes, see write_block)
         let mut resp = [0u8; 1];
@@ -728,7 +684,8 @@ impl FlashDevice {
     }
 
     fn log_start(&mut self) -> Result<()> {
-        self.transport.write_all(&[CMD_LOGCTL, 0x01])?;
+        self.transport
+            .write_all(ControlRequest::log(true).as_bytes())?;
         let ack = self.read_ack("log start")?;
         if ack != 0x01 {
             bail!("LOGCTL start failed: unexpected response 0x{:02x}", ack);
@@ -737,7 +694,8 @@ impl FlashDevice {
     }
 
     fn log_stop(&mut self) -> Result<()> {
-        self.transport.write_all(&[CMD_LOGCTL, 0x00])?;
+        self.transport
+            .write_all(ControlRequest::log(false).as_bytes())?;
         let ack = self.read_ack("log stop")?;
         if ack != 0x01 {
             bail!("LOGCTL stop failed: unexpected response 0x{:02x}", ack);
@@ -787,21 +745,9 @@ impl FlashDevice {
     }
 
     fn toctou_set(&mut self, index: u8, start: u32, mask: u32, replace: u32) -> Result<()> {
-        let buf = [
-            CMD_TOCTOU,
-            TOCTOU_SET,
-            index & 0x03,
-            ((start >> 16) & 0xFF) as u8,
-            ((start >> 8) & 0xFF) as u8,
-            (start & 0xFF) as u8,
-            ((mask >> 16) & 0xFF) as u8,
-            ((mask >> 8) & 0xFF) as u8,
-            (mask & 0xFF) as u8,
-            ((replace >> 16) & 0xFF) as u8,
-            ((replace >> 8) & 0xFF) as u8,
-            (replace & 0xFF) as u8,
-        ];
-        self.transport.write_all(&buf)?;
+        let request = ToctouSetRequest::new(index, start, mask, replace)
+            .context("TOCTOU addresses and masks must fit in 24 bits")?;
+        self.transport.write_all(request.as_bytes())?;
         let resp = self.read_ack("TOCTOU set")?;
         if resp != 0x01 {
             bail!("TOCTOU set failed: unexpected response 0x{:02x}", resp);
@@ -811,7 +757,7 @@ impl FlashDevice {
 
     fn toctou_arm(&mut self, index: u8) -> Result<()> {
         self.transport
-            .write_all(&[CMD_TOCTOU, TOCTOU_ARM, index & 0x03])?;
+            .write_all(ToctouIndexRequest::arm(index).as_bytes())?;
         let resp = self.read_ack("TOCTOU arm")?;
         if resp != 0x01 {
             bail!("TOCTOU arm failed: unexpected response 0x{:02x}", resp);
@@ -821,7 +767,7 @@ impl FlashDevice {
 
     fn toctou_disarm(&mut self, index: u8) -> Result<()> {
         self.transport
-            .write_all(&[CMD_TOCTOU, TOCTOU_DISARM, index & 0x03])?;
+            .write_all(ToctouIndexRequest::disarm(index).as_bytes())?;
         let resp = self.read_ack("TOCTOU disarm")?;
         if resp != 0x01 {
             bail!("TOCTOU disarm failed: unexpected response 0x{:02x}", resp);
@@ -831,7 +777,7 @@ impl FlashDevice {
 
     fn toctou_reset(&mut self, index: u8) -> Result<()> {
         self.transport
-            .write_all(&[CMD_TOCTOU, TOCTOU_RESET, index & 0x03])?;
+            .write_all(ToctouIndexRequest::reset(index).as_bytes())?;
         let resp = self.read_ack("TOCTOU reset")?;
         if resp != 0x01 {
             bail!("TOCTOU reset failed: unexpected response 0x{:02x}", resp);
@@ -840,7 +786,8 @@ impl FlashDevice {
     }
 
     fn toctou_reset_all(&mut self) -> Result<()> {
-        self.transport.write_all(&[CMD_TOCTOU, TOCTOU_RESET_ALL])?;
+        self.transport
+            .write_all(ControlRequest::toctou_reset_all().as_bytes())?;
         let resp = self.read_ack("TOCTOU reset-all")?;
         if resp != 0x01 {
             bail!(
@@ -1815,10 +1762,11 @@ fn spi_opcode_name(opcode: u8) -> &'static str {
 }
 
 fn is_read_opcode(opcode: u8) -> bool {
-    matches!(
-        opcode,
-        0x03 | 0x0B | 0x0C | 0x13 | 0x3B | 0x3C | 0x5A | 0x6B | 0x6C | 0xBB | 0xBC | 0xEB | 0xEC
-    )
+    match opcode {
+        0x03 | 0x0B | 0x0C | 0x13 | 0x3B | 0x3C | 0x5A | 0x6B | 0x6C | 0xBB | 0xBC | 0xEB
+        | 0xEC => true,
+        _ => false,
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tool/src/protocol.rs
+++ b/tool/src/protocol.rs
@@ -1,0 +1,254 @@
+//! Host-side definitions of the byte-level FPGA protocol.
+//!
+//! These types intentionally contain only byte arrays and `u8` fields. This
+//! makes their `repr(C)` layout identical to the wire format, while zerocopy's
+//! derives verify that the complete value can safely be viewed as bytes.
+
+use zerocopy::{Immutable, IntoBytes};
+
+pub const PROTOCOL_VERSION: u8 = 5;
+
+pub const CMD_VERSION: u8 = 0x30;
+pub const CMD_READ: u8 = 0x31;
+pub const CMD_WRITE: u8 = 0x32;
+pub const CMD_CHIPCONFIG: u8 = 0x33;
+pub const CMD_START: u8 = 0x34;
+pub const CMD_STOP: u8 = 0x35;
+pub const CMD_STATUS: u8 = 0x36;
+pub const CMD_HOLDCTL: u8 = 0x37;
+pub const CMD_LOGCTL: u8 = 0x38;
+pub const CMD_TOCTOU: u8 = 0x39;
+pub const CMD_LOGPOLL: u8 = 0x3A;
+
+pub const LOG_POLL_TERMINATOR: u8 = 0xA0;
+pub const LOG_POLL_ESCAPE: u8 = 0xA5;
+
+pub const TOCTOU_ARM: u8 = 0x02;
+pub const TOCTOU_DISARM: u8 = 0x03;
+pub const TOCTOU_RESET: u8 = 0x04;
+pub const TOCTOU_RESET_ALL: u8 = 0x05;
+
+pub const LOG_CMD: u8 = 0xA1;
+pub const LOG_ADDR: u8 = 0xA2;
+pub const LOG_END: u8 = 0xA3;
+pub const LOG_TRAP: u8 = 0xA4;
+
+#[derive(Clone, Copy, Debug, Eq, Immutable, IntoBytes, PartialEq)]
+#[repr(transparent)]
+struct BeU16([u8; 2]);
+
+impl BeU16 {
+    const fn new(value: u16) -> Self {
+        Self(value.to_be_bytes())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Immutable, IntoBytes, PartialEq)]
+#[repr(transparent)]
+struct BeU24([u8; 3]);
+
+impl BeU24 {
+    const MAX: u32 = 0x00ff_ffff;
+
+    const fn new(value: u32) -> Self {
+        let bytes = value.to_be_bytes();
+        Self([bytes[1], bytes[2], bytes[3]])
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Immutable, IntoBytes, PartialEq)]
+#[repr(C)]
+pub struct RamHeader {
+    command: u8,
+    address_bursts: BeU24,
+    length_bursts: BeU16,
+}
+
+impl RamHeader {
+    pub fn read(address_bursts: u32, length_bursts: u16) -> Option<Self> {
+        Self::new(CMD_READ, address_bursts, length_bursts)
+    }
+
+    pub fn write(address_bursts: u32, length_bursts: u16) -> Option<Self> {
+        Self::new(CMD_WRITE, address_bursts, length_bursts)
+    }
+
+    fn new(command: u8, address_bursts: u32, length_bursts: u16) -> Option<Self> {
+        (address_bursts <= BeU24::MAX).then(|| Self {
+            command,
+            address_bursts: BeU24::new(address_bursts),
+            length_bursts: BeU16::new(length_bursts),
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Immutable, IntoBytes, PartialEq)]
+#[repr(C)]
+pub struct ChipConfigHeader {
+    command: u8,
+    jedec_id: [u8; 3],
+    flags: u8,
+    erase_bursts: BeU24,
+    sfdp_length: u8,
+}
+
+impl ChipConfigHeader {
+    pub fn new(jedec_id: [u8; 3], flags: u8, erase_bursts: u32, sfdp_length: u8) -> Option<Self> {
+        // The FPGA stores this field in 23 bits; bit 23 is not part of the
+        // count even though the wire representation occupies three bytes.
+        (erase_bursts <= 0x007f_ffff).then(|| Self {
+            command: CMD_CHIPCONFIG,
+            jedec_id,
+            flags,
+            erase_bursts: BeU24::new(erase_bursts),
+            sfdp_length,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Immutable, IntoBytes, PartialEq)]
+#[repr(C)]
+pub struct ControlRequest {
+    command: u8,
+    value: u8,
+}
+
+impl ControlRequest {
+    pub const fn hold(enable: bool) -> Self {
+        Self {
+            command: CMD_HOLDCTL,
+            value: enable as u8,
+        }
+    }
+
+    pub const fn log(enable: bool) -> Self {
+        Self {
+            command: CMD_LOGCTL,
+            value: enable as u8,
+        }
+    }
+
+    pub const fn toctou_reset_all() -> Self {
+        Self {
+            command: CMD_TOCTOU,
+            value: TOCTOU_RESET_ALL,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Immutable, IntoBytes, PartialEq)]
+#[repr(C)]
+pub struct ToctouIndexRequest {
+    command: u8,
+    subcommand: u8,
+    index: u8,
+}
+
+impl ToctouIndexRequest {
+    pub const fn arm(index: u8) -> Self {
+        Self::new(TOCTOU_ARM, index)
+    }
+
+    pub const fn disarm(index: u8) -> Self {
+        Self::new(TOCTOU_DISARM, index)
+    }
+
+    pub const fn reset(index: u8) -> Self {
+        Self::new(TOCTOU_RESET, index)
+    }
+
+    const fn new(subcommand: u8, index: u8) -> Self {
+        Self {
+            command: CMD_TOCTOU,
+            subcommand,
+            index: index & 0x03,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Immutable, IntoBytes, PartialEq)]
+#[repr(C)]
+pub struct ToctouSetRequest {
+    command: u8,
+    subcommand: u8,
+    index: u8,
+    start: BeU24,
+    mask: BeU24,
+    replace: BeU24,
+}
+
+impl ToctouSetRequest {
+    pub fn new(index: u8, start: u32, mask: u32, replace: u32) -> Option<Self> {
+        (start <= BeU24::MAX && mask <= BeU24::MAX && replace <= BeU24::MAX).then(|| Self {
+            command: CMD_TOCTOU,
+            subcommand: 0x01,
+            index: index & 0x03,
+            start: BeU24::new(start),
+            mask: BeU24::new(mask),
+            replace: BeU24::new(replace),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_struct_sizes_have_no_padding() {
+        assert_eq!(size_of::<RamHeader>(), 6);
+        assert_eq!(size_of::<ChipConfigHeader>(), 9);
+        assert_eq!(size_of::<ControlRequest>(), 2);
+        assert_eq!(size_of::<ToctouIndexRequest>(), 3);
+        assert_eq!(size_of::<ToctouSetRequest>(), 12);
+    }
+
+    #[test]
+    fn ram_headers_match_the_existing_wire_format() {
+        assert_eq!(
+            RamHeader::read(0x12_3456, 0x789a).unwrap().as_bytes(),
+            &[CMD_READ, 0x12, 0x34, 0x56, 0x78, 0x9a]
+        );
+        assert_eq!(
+            RamHeader::write(0x00_00ff, 0xffff).unwrap().as_bytes(),
+            &[CMD_WRITE, 0x00, 0x00, 0xff, 0xff, 0xff]
+        );
+        assert!(RamHeader::read(0x0100_0000, 1).is_none());
+    }
+
+    #[test]
+    fn chip_config_header_matches_the_existing_wire_format() {
+        let header = ChipConfigHeader::new([0xef, 0x40, 0x18], 1, 0x12_3456, 128).unwrap();
+        assert_eq!(
+            header.as_bytes(),
+            &[CMD_CHIPCONFIG, 0xef, 0x40, 0x18, 1, 0x12, 0x34, 0x56, 128]
+        );
+        assert!(ChipConfigHeader::new([0; 3], 0, 0x0080_0000, 0).is_none());
+    }
+
+    #[test]
+    fn control_requests_match_the_existing_wire_format() {
+        assert_eq!(ControlRequest::hold(true).as_bytes(), &[CMD_HOLDCTL, 1]);
+        assert_eq!(ControlRequest::log(false).as_bytes(), &[CMD_LOGCTL, 0]);
+        assert_eq!(
+            ControlRequest::toctou_reset_all().as_bytes(),
+            &[CMD_TOCTOU, TOCTOU_RESET_ALL]
+        );
+        assert_eq!(
+            ToctouIndexRequest::arm(5).as_bytes(),
+            &[CMD_TOCTOU, TOCTOU_ARM, 1]
+        );
+    }
+
+    #[test]
+    fn toctou_set_request_matches_the_existing_wire_format() {
+        let request = ToctouSetRequest::new(5, 0x12_3456, 0xff_f000, 0xab_cdef).unwrap();
+        assert_eq!(
+            request.as_bytes(),
+            &[
+                CMD_TOCTOU, 0x01, 0x01, 0x12, 0x34, 0x56, 0xff, 0xf0, 0x00, 0xab, 0xcd, 0xef,
+            ]
+        );
+        assert!(ToctouSetRequest::new(0, 0x0100_0000, 0, 0).is_none());
+    }
+}


### PR DESCRIPTION
Move protocol constants and command header structs into a new `protocol.rs`
module, using `zerocopy` for safe, zero-cost byte views.  Refactor `main.rs`
to construct requests through typed structs instead of hand-assembled byte
arrays, adding range validation and new unit tests.