### PR TITLE
Document PMOD and FT245 wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,34 @@ NORbert uses a [Sipeed Tang Primer 25K](https://wiki.sipeed.com/hardware/en/tang
 
 - [Sipeed Tang Primer 25K](https://wiki.sipeed.com/hardware/en/tang/tang-primer-25k/primer-25k.html) (Gowin GW5A-LV25MG121)
 - Tang Primer 25K Dock ext-board (provides SDRAM and USB-UART)
-- SPI signals exposed on PMOD connector J5
+- All three PMOD headers are used: SPI on PMOD 1 and the optional FT245 transport on PMOD 2 and PMOD 3
 - **Optional:** FT2232H breakout board for FT245 high-speed transport (e.g., CJMCU-FT2232H or any FT2232H module)
+
+### PMOD pinout
+
+The headers are shown in their physical left-to-right order when looking toward the Dock from the cable/module side: PMOD 3, PMOD 2, then PMOD 1. The thick bottom edge is the PCB, making it clear which row is nearest the board. Connector names follow the [Tang Primer 25K Dock schematic](https://dl.sipeed.com/fileList/TANG/Primer_25K/02_Schematic/Tang_Primer_25K_Dock_60033_Schematic.pdf). FPGA balls are shown in parentheses.
+
+```text
+ PMOD 3 / J6 — FT245 data
+ +------------+------------+------------+------------+--------+--------+
+ | D6  (G5)   | D5  (G8)   | D4  (H7)   | D7  (J5)   | GND    | 3V3    |
+ | D3  (F5)   | D2  (G7)   | D1  (H8)   | D0  (H5)   | GND    | 3V3    |
+ +=========================== PCB / BOARD =============================+
+
+ PMOD 2 / J5 — FT245 control
+ +------------+------------+------------+------------+--------+--------+
+ | NC  (A10)  | NC  (E10)  | NC  (L11)  | NC  (K5)   | GND    | 3V3    |
+ | RXF# (A11) | TXE# (E11) | RD# (K11)  | WR# (L5)   | GND    | 3V3    |
+ +=========================== PCB / BOARD =============================+
+
+ PMOD 1 / J4 — SPI
+ +------------+------------+------------+------------+--------+--------+
+ | #WP (G10)  | #HOLD(D10) | POWER(B10) | DEBUG(C10) | GND    | 3V3    |
+ | #CS (G11)  | SCLK (D11) | MOSI (B11) | MISO (C11) | GND    | 3V3    |
+ +=========================== PCB / BOARD =============================+
+```
+
+`#WP` and `#HOLD` become the extra IO2 and IO3 data lines in quad-SPI mode. `POWER` is an active-high target-power sense input: connect it to the target's 3.3 V rail so NORbert only drives the bus while the target is powered. It is not a power output. Always connect a common ground; `DEBUG` is optional.
 
 ## Building
 
@@ -37,6 +63,7 @@ nix develop    # or let direnv handle it
 This provides the Gowin IDE (Education Edition), yosys, openFPGALoader, verilator, and the Rust toolchain.
 
 Without Nix, you'll need:
+
 - [Gowin IDE Education Edition](https://www.gowinsemi.com/en/support/home/) v1.9.11.03 (`gw_sh` on PATH)
 - [openFPGALoader](https://github.com/trabucayre/openFPGALoader)
 - [yosys](https://github.com/YosysHQ/yosys) (optional, for linting)
@@ -166,15 +193,15 @@ The FT2232H is used in asynchronous 245 FIFO mode. This requires a **one-time EE
 
 **Wiring:** Connect the FT2232H Channel A pins to the FPGA dock as follows:
 
-| FT2232H Pin | Signal   | FPGA Pin | Dock Location    |
-|-------------|----------|----------|------------------|
-| AD0-AD7     | D[0:7]   | H5, H8, G7, F5, H7, G8, G5, F3 | PMOD J7 |
-| RXF#        | ft_rxf_n | D10      | PMOD J6 top      |
-| TXE#        | ft_txe_n | G10      | PMOD J6 top      |
-| RD#         | ft_rd_n  | B10      | PMOD J6 top      |
-| WR#         | ft_wr_n  | H11      | Button S0 (core board) |
+| FT2232H Pin | NORbert signal | Dock location |
+|-------------|----------------|---------------|
+| AD0-AD7     | D0-D7          | PMOD 3 / J6   |
+| RXF#        | RXF#           | PMOD 2 / J5   |
+| TXE#        | TXE#           | PMOD 2 / J5   |
+| RD#         | RD#            | PMOD 2 / J5   |
+| WR#         | WR#            | PMOD 2 / J5   |
 
-Note: H11 is a core board button pin, repurposed for FT245 (buttons are unused by NORbert). CLKOUT and OE# are not used in async mode. All signals are 3.3V LVCMOS.
+CLKOUT and OE# are not used in async mode. All signals are 3.3 V LVCMOS. See the PMOD diagram above for the physical order and FPGA ball assignments.
 
 ## SPI read performance
 


### PR DESCRIPTION
Add physical pinouts for all three PMOD headers, clarify target
power-sense and debug connections, and update FT2232H wiring
instructions with the new dock locations.