### PR TITLE
Remove the proprietary D2XX backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CST_FILE = tangprimer25k.cst
 # Gowin IDE output
 BITSTREAM = impl/pnr/spi_flash.fs
 
-.PHONY: all build lint prog flash clean tool tool-d2xx ftdi-setup help
+.PHONY: all build lint prog flash clean tool ftdi-setup help
 
 all: build
 
@@ -61,11 +61,6 @@ tool:
 	cargo build --release --manifest-path tool/Cargo.toml
 	@echo "Tool built: tool/target/release/spi-flash-tool"
 
-# Build with D2XX backend (requires ftdi_sio unbind, proprietary C library)
-tool-d2xx:
-	cargo build --release --manifest-path tool/Cargo.toml --no-default-features --features d2xx
-	@echo "Tool built (D2XX backend): tool/target/release/spi-flash-tool"
-
 help:
 	@echo "Tang Primer 25K SPI Flash Emulator"
 	@echo ""
@@ -74,6 +69,6 @@ help:
 	@echo "  make flash   - Program to flash (persistent)"
 	@echo "  make lint    - Lint Verilog with yosys"
 	@echo "  make tool    - Build spi-flash-tool (rs-ftdi backend, default)"
-	@echo "  make tool-d2xx - Build spi-flash-tool (D2XX backend)"
+
 	@echo "  make ftdi-setup - Program FT2232H EEPROM for 245 FIFO"
 	@echo "  make clean   - Clean build artifacts"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Without Nix, you'll need:
 - [openFPGALoader](https://github.com/trabucayre/openFPGALoader)
 - [yosys](https://github.com/YosysHQ/yosys) (optional, for linting)
 - Rust toolchain (for the host tool)
-- FTDI D2XX driver/library (only if using FT245 transport)
+
 
 ### FPGA bitstream
 
@@ -162,7 +162,7 @@ spi-flash-tool --ft245 configure W25Q128JV --chips-dir ~/src/rflasher/chips/vend
 spi-flash-tool --ft245 --ft-serial FT6XXXXX load firmware.bin
 ```
 
-The FT2232H is used in asynchronous 245 FIFO mode. This requires a **one-time EEPROM configuration** to set Channel A to "245 FIFO" mode using [FT_PROG](https://ftdichip.com/utilities/#ft_prog) (Windows) or `ftd2xx_eeprom` (Linux). No special BitMode is set at runtime -- the host tool just opens the device and reads/writes normally.
+The FT2232H is used in asynchronous 245 FIFO mode. This requires a **one-time EEPROM configuration** to set Channel A to "245 FIFO" mode using [FT_PROG](https://ftdichip.com/utilities/#ft_prog) (Windows) or `ftdi_eeprom` (Linux). No special BitMode is set at runtime -- the host tool just opens the device and reads/writes normally.
 
 **Wiring:** Connect the FT2232H Channel A pins to the FPGA dock as follows:
 

--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -226,15 +226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ftdi-mpsse"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd2c246fb727197d284bf7273718ed6b1c9a94a128bb618b97f13daec658a12"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
 name = "ftdi-nusb"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,28 +341,6 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
-
-[[package]]
-name = "libftd2xx"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e09fe202b49276fc72160c27c8af5ff34e6ee3db78625bbfe3bd9c2b2e595af6"
-dependencies = [
- "ftdi-mpsse",
- "libftd2xx-ffi",
- "log",
- "paste",
- "static_assertions",
-]
-
-[[package]]
-name = "libftd2xx-ffi"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd82d23ae0cbbf0fb65ad0310b474e45ddfdece8aa03a34130c59c04333c701"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "libudev"
@@ -501,12 +470,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
@@ -690,7 +653,6 @@ dependencies = [
  "ctrlc",
  "ftdi-nusb",
  "indicatif",
- "libftd2xx",
  "rflasher-chips",
  "serialport",
  "zerocopy",
@@ -701,12 +663,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "ftdi-nusb"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af3dcfe070584d05ef4a2bccb461dd176bfa699861e1114c8dad482c54938bf"
+checksum = "76e3391b248c458fce989a635a3afdd2297764e17645172c1d5fabc1779231de"
 dependencies = [
  "log",
  "maybe-async",
@@ -428,19 +428,23 @@ dependencies = [
 
 [[package]]
 name = "nusb"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1553b6f47685e4c658b2100a6d7262abdc73cb97f423453546ca020155ae9"
+checksum = "18ef13beb3b3a8fc16fd7aea912ebd3d45dde00a9a5b968d0742297468065845"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "futures-core",
  "io-kit-sys 0.5.0",
+ "js-sys",
  "linux-raw-sys",
  "log",
  "once_cell",
  "rustix",
  "slab",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -759,6 +763,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +802,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -4,13 +4,9 @@ version = "0.2.0"
 edition = "2024"
 description = "Tool for loading data into the Tang Primer 25K SPI Flash Emulator (UART + FT245)"
 
-[features]
-default = ["ftdi"]
-ftdi = ["dep:ftdi"]
-
 [dependencies]
 serialport = "4.9"
-ftdi = { package = "ftdi-nusb", version = "0.1.0", optional = true }
+ftdi = { package = "ftdi-nusb", version = "0.1.0" }
 clap = { version = "4.6", features = ["derive"] }
 anyhow = "1.0"
 indicatif = "0.18"

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -6,12 +6,10 @@ description = "Tool for loading data into the Tang Primer 25K SPI Flash Emulator
 
 [features]
 default = ["ftdi"]
-d2xx = ["libftd2xx"]
 ftdi = ["dep:ftdi"]
 
 [dependencies]
 serialport = "4.9"
-libftd2xx = { version = "0.33", optional = true }
 ftdi = { package = "ftdi-nusb", version = "0.1.0", optional = true }
 clap = { version = "4.6", features = ["derive"] }
 anyhow = "1.0"

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -6,7 +6,7 @@ description = "Tool for loading data into the Tang Primer 25K SPI Flash Emulator
 
 [dependencies]
 serialport = "4.9"
-ftdi = { package = "ftdi-nusb", version = "0.1.0" }
+ftdi = { package = "ftdi-nusb", version = "0.2.0" }
 clap = { version = "4.6", features = ["derive"] }
 anyhow = "1.0"
 indicatif = "0.18"

--- a/tool/src/commands.rs
+++ b/tool/src/commands.rs
@@ -9,7 +9,7 @@ use crate::cli::{Cli, HoldState, ToctouAction};
 use crate::device::FlashDevice;
 use crate::protocol::*;
 use crate::sfdp;
-#[cfg(any(feature = "d2xx", feature = "ftdi"))]
+#[cfg(feature = "ftdi")]
 use crate::transport::{FT2232H_PID, FTDI_VID};
 use anyhow::{Context, Result, anyhow, bail};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -50,20 +50,13 @@ fn decode_hex(s: &str) -> Result<Vec<u8>, String> {
 
 fn open_device(cli: &Cli) -> Result<FlashDevice> {
     if cli.ft245 {
-        #[cfg(any(feature = "d2xx", feature = "ftdi"))]
+        #[cfg(feature = "ftdi")]
         {
-            let backend = if cfg!(feature = "d2xx") {
-                "D2XX"
-            } else {
-                "rs-ftdi"
-            };
-            eprintln!("Opening FT2232H in async FIFO mode ({})...", backend);
+            eprintln!("Opening FT2232H in async FIFO mode (ftdi-nusb)...");
             return FlashDevice::open_ft245(cli.ft_serial.as_deref());
         }
-        #[cfg(not(any(feature = "d2xx", feature = "ftdi")))]
-        bail!(
-            "--ft245 requires the 'd2xx' or 'ftdi' feature (build with --features d2xx, --features ftdi, or --no-default-features --features d2xx)"
-        );
+        #[cfg(not(feature = "ftdi"))]
+        bail!("--ft245 requires the 'ftdi' feature (enabled by default)");
     }
     FlashDevice::open_serial(&cli.port)
 }

--- a/tool/src/commands.rs
+++ b/tool/src/commands.rs
@@ -9,7 +9,6 @@ use crate::cli::{Cli, HoldState, ToctouAction};
 use crate::device::FlashDevice;
 use crate::protocol::*;
 use crate::sfdp;
-#[cfg(feature = "ftdi")]
 use crate::transport::{FT2232H_PID, FTDI_VID};
 use anyhow::{Context, Result, anyhow, bail};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -50,13 +49,8 @@ fn decode_hex(s: &str) -> Result<Vec<u8>, String> {
 
 fn open_device(cli: &Cli) -> Result<FlashDevice> {
     if cli.ft245 {
-        #[cfg(feature = "ftdi")]
-        {
-            eprintln!("Opening FT2232H in async FIFO mode (ftdi-nusb)...");
-            return FlashDevice::open_ft245(cli.ft_serial.as_deref());
-        }
-        #[cfg(not(feature = "ftdi"))]
-        bail!("--ft245 requires the 'ftdi' feature (enabled by default)");
+        eprintln!("Opening FT2232H in async FIFO mode (ftdi-nusb)...");
+        return FlashDevice::open_ft245(cli.ft_serial.as_deref());
     }
     FlashDevice::open_serial(&cli.port)
 }

--- a/tool/src/commands/diagnostics.rs
+++ b/tool/src/commands/diagnostics.rs
@@ -4,7 +4,6 @@ use super::*;
 // Probe command -- ftdi-nusb backend
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "ftdi")]
 pub(super) fn cmd_probe(cli: &Cli) -> Result<()> {
     // Open FT2232H via rs-ftdi
     eprintln!("Opening FT2232H for probe (ftdi-nusb)...");
@@ -143,19 +142,9 @@ pub(super) fn cmd_probe(cli: &Cli) -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
-// Probe command -- no FT245 backend
-// ---------------------------------------------------------------------------
-
-#[cfg(not(feature = "ftdi"))]
-pub(super) fn cmd_probe(_cli: &Cli) -> Result<()> {
-    bail!("Probe requires the 'ftdi' feature");
-}
-
-// ---------------------------------------------------------------------------
 // FT-list command
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "ftdi")]
 pub(super) fn cmd_ft_list() -> Result<()> {
     let devices = ftdi::find_devices(FTDI_VID, FT2232H_PID)
         .map_err(|e| anyhow!(e))
@@ -185,9 +174,4 @@ pub(super) fn cmd_ft_list() -> Result<()> {
     println!("Use --ft-serial <SERIAL> to select a specific device.");
     println!("Channel A is used by default for async FIFO.");
     Ok(())
-}
-
-#[cfg(not(feature = "ftdi"))]
-pub(super) fn cmd_ft_list() -> Result<()> {
-    bail!("ft-list requires the 'ftdi' feature");
 }

--- a/tool/src/commands/diagnostics.rs
+++ b/tool/src/commands/diagnostics.rs
@@ -1,162 +1,13 @@
 use super::*;
 
 // ---------------------------------------------------------------------------
-// Probe command -- D2XX backend
+// Probe command -- ftdi-nusb backend
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "d2xx")]
-pub(super) fn cmd_probe(cli: &Cli) -> Result<()> {
-    use libftd2xx::FtdiCommon;
-
-    // We need raw access to the FT2232H, not the Transport abstraction,
-    // because we want short timeouts per-probe and queue_status checks.
-    eprintln!("Opening FT2232H for probe (D2XX)...");
-    let serial = cli.ft_serial.as_deref();
-    let mut ft = if let Some(sn) = serial {
-        libftd2xx::Ft2232h::with_serial_number(sn)
-            .with_context(|| format!("No FT2232H with serial '{}'", sn))?
-    } else {
-        libftd2xx::Ft2232h::with_description("NORbert FT245 A")
-            .context("No FT2232H found (looking for 'NORbert FT245 A')")?
-    };
-
-    ft.reset().context("FT2232H reset failed")?;
-    ft.purge_all().context("FT2232H purge failed")?;
-    ft.set_usb_parameters(65536)?;
-    ft.set_latency_timer(Duration::from_millis(2))?;
-    ft.set_timeouts(Duration::from_millis(500), Duration::from_secs(5))?;
-
-    // Drain stale data
-    let mut trash = [0u8; 4096];
-    loop {
-        let n = ft.queue_status()?;
-        if n == 0 {
-            break;
-        }
-        let to_read = std::cmp::min(n, trash.len());
-        let _ = ft.read(&mut trash[..to_read]);
-    }
-
-    // Test bytes: mix of valid commands, diagnostics, and non-commands
-    let probes: Vec<(u8, &str, Option<u8>)> = vec![
-        (0x30, "CMD_VERSION", Some(PROTOCOL_VERSION)),
-        (0x00, "NOP / zero", None),
-        (0x55, "non-command 0x55", None),
-        (0xAA, "non-command 0xAA", None),
-        (0xFF, "non-command 0xFF", None),
-    ];
-
-    println!("FT245 probe (D2XX): send 1 byte, wait 200ms, read back\n");
-    println!("{:<30} {:>4}   {:>8}  Response", "Test", "Sent", "Expected");
-    println!("{}", "-".repeat(70));
-
-    for (byte, label, expected) in &probes {
-        // Purge before each probe
-        ft.purge_all()?;
-        thread::sleep(Duration::from_millis(50));
-
-        // Drain anything residual
-        loop {
-            let n = ft.queue_status()?;
-            if n == 0 {
-                break;
-            }
-            let to_read = std::cmp::min(n, trash.len());
-            let _ = ft.read(&mut trash[..to_read]);
-        }
-
-        // Send the byte
-        ft.write_all(&[*byte])?;
-
-        // Wait for response
-        thread::sleep(Duration::from_millis(200));
-
-        // Check what came back
-        let n = ft.queue_status()?;
-        let exp_str = match expected {
-            Some(v) => format!("0x{:02X}", v),
-            None => "none".to_string(),
-        };
-        if n == 0 {
-            let status = if expected.is_none() {
-                "OK"
-            } else {
-                "FAIL(none)"
-            };
-            println!(
-                "{:<30} 0x{:02X}   {:>8}  (no response) {}",
-                label, byte, exp_str, status
-            );
-        } else {
-            let to_read = std::cmp::min(n, 32);
-            let mut buf = vec![0u8; to_read];
-            let got = ft.read(&mut buf)?;
-            buf.truncate(got);
-            let hex_str: Vec<String> = buf.iter().map(|b| format!("0x{:02X}", b)).collect();
-            let status = match expected {
-                Some(v) if got == 1 && buf[0] == *v => "OK",
-                Some(_) if got == 1 && buf[0] == *byte => "FAIL(echo)",
-                _ => "FAIL",
-            };
-            println!(
-                "{:<30} 0x{:02X}   {:>8}  {} bytes: [{}] {}",
-                label,
-                byte,
-                exp_str,
-                got,
-                hex_str.join(", "),
-                status,
-            );
-        }
-    }
-
-    // Bonus: send multiple bytes at once and see what comes back
-    println!("\n--- Multi-byte test ---");
-    ft.purge_all()?;
-    thread::sleep(Duration::from_millis(50));
-    loop {
-        let n = ft.queue_status()?;
-        if n == 0 {
-            break;
-        }
-        let to_read = std::cmp::min(n, trash.len());
-        let _ = ft.read(&mut trash[..to_read]);
-    }
-
-    let multi = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
-    ft.write_all(&multi)?;
-    thread::sleep(Duration::from_millis(200));
-    let n = ft.queue_status()?;
-    if n == 0 {
-        println!("Sent {:?}: (no response)", multi);
-    } else {
-        let to_read = std::cmp::min(n, 64);
-        let mut buf = vec![0u8; to_read];
-        let got = ft.read(&mut buf)?;
-        buf.truncate(got);
-        let hex_str: Vec<String> = buf.iter().map(|b| format!("0x{:02X}", b)).collect();
-        let is_echo = buf == multi[..got];
-        println!(
-            "Sent {} bytes: {:02X?}\nGot  {} bytes: [{}]{}",
-            multi.len(),
-            multi,
-            got,
-            hex_str.join(", "),
-            if is_echo { " << EXACT ECHO" } else { "" },
-        );
-    }
-
-    Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Probe command -- rs-ftdi backend
-// ---------------------------------------------------------------------------
-
-#[cfg(all(feature = "ftdi", not(feature = "d2xx")))]
+#[cfg(feature = "ftdi")]
 pub(super) fn cmd_probe(cli: &Cli) -> Result<()> {
     // Open FT2232H via rs-ftdi
-    eprintln!("Opening FT2232H for probe (rs-ftdi)...");
+    eprintln!("Opening FT2232H for probe (ftdi-nusb)...");
     let serial = cli.ft_serial.as_deref();
     let mut dev = if let Some(sn) = serial {
         let filter = ftdi::DeviceFilter::new(FTDI_VID, FT2232H_PID).serial(sn);
@@ -295,39 +146,16 @@ pub(super) fn cmd_probe(cli: &Cli) -> Result<()> {
 // Probe command -- no FT245 backend
 // ---------------------------------------------------------------------------
 
-#[cfg(not(any(feature = "d2xx", feature = "ftdi")))]
+#[cfg(not(feature = "ftdi"))]
 pub(super) fn cmd_probe(_cli: &Cli) -> Result<()> {
-    bail!("Probe requires the 'd2xx' or 'ftdi' feature");
+    bail!("Probe requires the 'ftdi' feature");
 }
 
 // ---------------------------------------------------------------------------
 // FT-list command
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "d2xx")]
-pub(super) fn cmd_ft_list() -> Result<()> {
-    let devices = libftd2xx::list_devices().context("Failed to enumerate FTDI devices")?;
-
-    if devices.is_empty() {
-        println!("No FTDI devices found");
-        println!(
-            "Hint: FT2232H has VID:PID {:04x}:{:04x}",
-            FTDI_VID, FT2232H_PID
-        );
-        return Ok(());
-    }
-
-    println!("FTDI devices ({} found):", devices.len());
-    for (i, dev) in devices.iter().enumerate() {
-        println!("  [{}] {:?}", i, dev);
-    }
-    println!();
-    println!("Use --ft-serial <SERIAL> to select a specific device.");
-    println!("Channel A is used by default for async FIFO.");
-    Ok(())
-}
-
-#[cfg(all(feature = "ftdi", not(feature = "d2xx")))]
+#[cfg(feature = "ftdi")]
 pub(super) fn cmd_ft_list() -> Result<()> {
     let devices = ftdi::find_devices(FTDI_VID, FT2232H_PID)
         .map_err(|e| anyhow!(e))
@@ -359,7 +187,7 @@ pub(super) fn cmd_ft_list() -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(any(feature = "d2xx", feature = "ftdi")))]
+#[cfg(not(feature = "ftdi"))]
 pub(super) fn cmd_ft_list() -> Result<()> {
-    bail!("ft-list requires the 'd2xx' or 'ftdi' feature");
+    bail!("ft-list requires the 'ftdi' feature");
 }

--- a/tool/src/device.rs
+++ b/tool/src/device.rs
@@ -1,6 +1,5 @@
 use crate::chip::{self, FlashChipExt};
 use crate::protocol::*;
-#[cfg(feature = "ftdi")]
 use crate::transport::Ft245Transport;
 use crate::transport::{
     BLOCK_SIZE, SDRAM_SIZE_BYTES, SerialTransport, Transport, UART_READ_BLOCK_SIZE,
@@ -42,7 +41,6 @@ impl FlashDevice {
         })
     }
 
-    #[cfg(feature = "ftdi")]
     pub(crate) fn open_ft245(serial: Option<&str>) -> Result<Self> {
         Ok(Self {
             transport: Box::new(Ft245Transport::open(serial)?),

--- a/tool/src/device.rs
+++ b/tool/src/device.rs
@@ -1,6 +1,6 @@
 use crate::chip::{self, FlashChipExt};
 use crate::protocol::*;
-#[cfg(any(feature = "d2xx", feature = "ftdi"))]
+#[cfg(feature = "ftdi")]
 use crate::transport::Ft245Transport;
 use crate::transport::{
     BLOCK_SIZE, SDRAM_SIZE_BYTES, SerialTransport, Transport, UART_READ_BLOCK_SIZE,
@@ -42,7 +42,7 @@ impl FlashDevice {
         })
     }
 
-    #[cfg(any(feature = "d2xx", feature = "ftdi"))]
+    #[cfg(feature = "ftdi")]
     pub(crate) fn open_ft245(serial: Option<&str>) -> Result<Self> {
         Ok(Self {
             transport: Box::new(Ft245Transport::open(serial)?),
@@ -56,7 +56,7 @@ impl FlashDevice {
     }
 
     /// Read one response byte, transparently skipping stray 0x00 bytes
-    /// that the FT2232H 245 FIFO mode occasionally leaks through D2XX
+    /// that the FT2232H 245 FIFO mode can occasionally leak from USB
     /// (the 2-byte USB IN modem status header).  Used by all single-
     /// byte-ack commands.
     pub(crate) fn read_ack(&mut self, context: &str) -> Result<u8> {

--- a/tool/src/transport.rs
+++ b/tool/src/transport.rs
@@ -1,12 +1,12 @@
 use crate::protocol::CMD_VERSION;
-#[cfg(all(feature = "ftdi", not(feature = "d2xx")))]
+#[cfg(feature = "ftdi")]
 use anyhow::anyhow;
 use anyhow::{Context, Result, bail};
 use serialport::SerialPort;
 use std::io::{Read, Write};
 use std::thread;
 use std::time::Duration;
-#[cfg(any(feature = "d2xx", feature = "ftdi"))]
+#[cfg(feature = "ftdi")]
 use std::time::Instant;
 
 const BAUD_RATE: u32 = 2_000_000;
@@ -26,9 +26,9 @@ pub(crate) const UART_READ_BLOCK_SIZE: usize = 4096; // 512 bursts * 8 bytes
 pub(crate) const SDRAM_SIZE_BYTES: u64 = 64 * 1024 * 1024;
 
 // FT2232H USB identifiers
-#[cfg(any(feature = "d2xx", feature = "ftdi"))]
+#[cfg(feature = "ftdi")]
 pub(crate) const FTDI_VID: u16 = 0x0403;
-#[cfg(any(feature = "d2xx", feature = "ftdi"))]
+#[cfg(feature = "ftdi")]
 pub(crate) const FT2232H_PID: u16 = 0x6010;
 
 // ---------------------------------------------------------------------------
@@ -143,110 +143,19 @@ impl Transport for SerialTransport {
 }
 
 // ---------------------------------------------------------------------------
-// FT245 transport -- D2XX backend (FTDI's proprietary driver)
+// FT245 transport -- ftdi-nusb backend (pure Rust)
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "d2xx")]
-pub(crate) struct Ft245Transport {
-    ft: libftd2xx::Ft2232h,
-}
-
-#[cfg(feature = "d2xx")]
-impl Ft245Transport {
-    pub(crate) fn open(serial: Option<&str>) -> Result<Self> {
-        use libftd2xx::FtdiCommon;
-
-        // FT2232H EEPROM must be configured for "245 FIFO" on Channel A
-        // (one-time setup using FT_PROG).  No special BitMode is needed
-        // for async FIFO -- just open, reset, and read/write.
-        let mut ft = if let Some(sn) = serial {
-            libftd2xx::Ft2232h::with_serial_number(sn)
-                .with_context(|| format!("No FT2232H with serial '{}'", sn))?
-        } else {
-            // Default: open Channel A by its standard description.
-            // If EEPROM was reprogrammed with a custom description,
-            // use --ft-serial to select by serial number instead.
-            libftd2xx::Ft2232h::with_description("NORbert FT245 A")
-                .context("No FT2232H found (looking for 'NORbert FT245 A')")?
-        };
-
-        ft.reset().context("FT2232H reset failed")?;
-        ft.purge_all().context("FT2232H purge failed")?;
-
-        // Set USB transfer size for bulk throughput
-        ft.set_usb_parameters(65536)
-            .context("Failed to set USB parameters")?;
-
-        // Minimum latency timer -- each ACK/response byte sits in the
-        // FT2232H TX FIFO until either a full USB packet fills or this
-        // timer fires.  1ms is the FT2232H minimum.
-        ft.set_latency_timer(Duration::from_millis(1))
-            .context("Failed to set latency timer")?;
-
-        // D2XX read/write timeouts (prevents infinite blocking)
-        ft.set_timeouts(Duration::from_secs(5), Duration::from_secs(5))
-            .context("Failed to set timeouts")?;
-
-        // The USB reset can glitch the FT2232H data bus, injecting
-        // garbage bytes into the FPGA's protocol parser.  Wait 5ms
-        // (covers USB reset settling + FPGA idle timeout of ~546µs).
-        thread::sleep(Duration::from_millis(5));
-        ft.purge_all().ok();
-
-        let mut trash = [0u8; 4096];
-        loop {
-            let n = ft.queue_status().context("Failed to query queue status")?;
-            if n == 0 {
-                break;
-            }
-            let to_read = std::cmp::min(n, trash.len());
-            let _ = ft.read(&mut trash[..to_read]);
-        }
-
-        Ok(Self { ft })
-    }
-}
-
-#[cfg(feature = "d2xx")]
-impl Transport for Ft245Transport {
-    fn write_all(&mut self, data: &[u8]) -> Result<()> {
-        use libftd2xx::FtdiCommon;
-        self.ft.write_all(data)?;
-        Ok(())
-    }
-
-    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
-        use libftd2xx::FtdiCommon;
-        let mut pos = 0;
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while pos < buf.len() {
-            if Instant::now() > deadline {
-                bail!("FT245 read timeout: got {} of {} bytes", pos, buf.len());
-            }
-            let n = self.ft.read(&mut buf[pos..])?;
-            if n == 0 {
-                thread::sleep(Duration::from_micros(100));
-            }
-            pos += n;
-        }
-        Ok(())
-    }
-}
-
-// ---------------------------------------------------------------------------
-// FT245 transport -- rs-ftdi backend (pure Rust, nusb)
-// ---------------------------------------------------------------------------
-
-#[cfg(all(feature = "ftdi", not(feature = "d2xx")))]
+#[cfg(feature = "ftdi")]
 pub(crate) struct Ft245Transport {
     dev: ftdi::FtdiDevice,
 }
 
-#[cfg(all(feature = "ftdi", not(feature = "d2xx")))]
+#[cfg(feature = "ftdi")]
 impl Ft245Transport {
     pub(crate) fn open(serial: Option<&str>) -> Result<Self> {
         // Open the FT2232H Channel A.  The EEPROM must already be
-        // configured for "245 FIFO" mode (same as the D2XX path).
+        // configured for "245 FIFO" mode.
         let mut dev = if let Some(sn) = serial {
             let filter = ftdi::DeviceFilter::new(FTDI_VID, FT2232H_PID).serial(sn);
             ftdi::FtdiDevice::open_with_filter(&filter, ftdi::Interface::A)
@@ -302,7 +211,7 @@ impl Ft245Transport {
     }
 }
 
-#[cfg(all(feature = "ftdi", not(feature = "d2xx")))]
+#[cfg(feature = "ftdi")]
 impl Transport for Ft245Transport {
     fn write_all(&mut self, data: &[u8]) -> Result<()> {
         self.dev.write_all(data).map_err(|e| anyhow!(e))?;

--- a/tool/src/transport.rs
+++ b/tool/src/transport.rs
@@ -1,12 +1,10 @@
 use crate::protocol::CMD_VERSION;
-#[cfg(feature = "ftdi")]
 use anyhow::anyhow;
 use anyhow::{Context, Result, bail};
 use serialport::SerialPort;
 use std::io::{Read, Write};
 use std::thread;
 use std::time::Duration;
-#[cfg(feature = "ftdi")]
 use std::time::Instant;
 
 const BAUD_RATE: u32 = 2_000_000;
@@ -26,9 +24,7 @@ pub(crate) const UART_READ_BLOCK_SIZE: usize = 4096; // 512 bursts * 8 bytes
 pub(crate) const SDRAM_SIZE_BYTES: u64 = 64 * 1024 * 1024;
 
 // FT2232H USB identifiers
-#[cfg(feature = "ftdi")]
 pub(crate) const FTDI_VID: u16 = 0x0403;
-#[cfg(feature = "ftdi")]
 pub(crate) const FT2232H_PID: u16 = 0x6010;
 
 // ---------------------------------------------------------------------------
@@ -146,12 +142,10 @@ impl Transport for SerialTransport {
 // FT245 transport -- ftdi-nusb backend (pure Rust)
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "ftdi")]
 pub(crate) struct Ft245Transport {
     dev: ftdi::FtdiDevice,
 }
 
-#[cfg(feature = "ftdi")]
 impl Ft245Transport {
     pub(crate) fn open(serial: Option<&str>) -> Result<Self> {
         // Open the FT2232H Channel A.  The EEPROM must already be
@@ -211,7 +205,6 @@ impl Ft245Transport {
     }
 }
 
-#[cfg(feature = "ftdi")]
 impl Transport for Ft245Transport {
     fn write_all(&mut self, data: &[u8]) -> Result<()> {
         self.dev.write_all(data).map_err(|e| anyhow!(e))?;


### PR DESCRIPTION
Use the published `ftdi-nusb` backend exclusively for native FT245 access.

This removes the optional proprietary D2XX dependency, feature, transport implementation, diagnostics paths, and build target. It also updates the setup documentation to use `ftdi_eeprom`.

Validated with:
- `cargo check --manifest-path tool/Cargo.toml`
- `cargo check --manifest-path tool/Cargo.toml --no-default-features`
- `cargo fmt --manifest-path tool/Cargo.toml -- --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * FT245 tools now use the pure-Rust FTDI backend exclusively.
  * Removed support and build options for the D2XX backend.
  * Device probing, diagnostics, resets, and data transfers continue through the supported FTDI workflow.
  * Updated setup requirements and Linux FT245 EEPROM instructions to use `ftdi_eeprom`.
  * Removed the obsolete D2XX build target from the available commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->