### PR TITLE
Run Rust and Verilog checks on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  rust:
+    name: Rust and WebAssembly
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tool -> target
+          key: wasm32-unknown-unknown
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: trunk
+
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install --yes libudev-dev pkg-config
+
+      - name: Check formatting
+        run: cargo fmt --manifest-path tool/Cargo.toml --all -- --check
+
+      - name: Test native tool
+        run: cargo test --manifest-path tool/Cargo.toml
+
+      - name: Lint native tool
+        run: cargo clippy --manifest-path tool/Cargo.toml --all-targets -- --deny warnings
+
+      - name: Lint WebAssembly tool
+        run: cargo clippy --manifest-path tool/Cargo.toml --target wasm32-unknown-unknown --no-default-features --features wasm -- --deny warnings
+
+      - name: Build Web UI
+        run: trunk build --release
+
+  verilog:
+    name: Verilog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: YosysHQ/setup-oss-cad-suite@v4
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Run Yosys and Verilator checks
+        run: make lint

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -15,40 +15,28 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - uses: Swatinem/rust-cache@v2
         with:
           workspaces: tool -> target
           key: wasm32-unknown-unknown
 
-      - uses: taiki-e/install-action@fcf5432d9f50d67e37ee6e29bdb7a224ff67b4a7 # v2
+      - uses: taiki-e/install-action@v2
         with:
           tool: trunk
-
-      - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install --yes libudev-dev pkg-config
-
-      - name: Test native tool
-        run: cargo test --manifest-path tool/Cargo.toml
-
-      - name: Lint native tool
-        run: cargo clippy --manifest-path tool/Cargo.toml --all-targets -- --deny warnings
-
-      - name: Lint WebAssembly tool
-        run: cargo clippy --manifest-path tool/Cargo.toml --target wasm32-unknown-unknown --no-default-features --features wasm -- --deny warnings
 
       - name: Build Web UI
         run: trunk build --release --public-url /NORbert/
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
@@ -64,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        uses: actions/deploy-pages@v5

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,11 @@ CST_FILE = tangprimer25k.cst
 # Gowin IDE output
 BITSTREAM = impl/pnr/spi_flash.fs
 
-.PHONY: all build lint prog flash clean tool webui webui-serve ftdi-setup help
+# Open-source lint tools use Yosys' GW5A primitive declarations so the
+# generated PLL wrapper can be elaborated without the proprietary simulator.
+GOWIN_CELLS = $(shell yosys-config --datdir)/gowin/cells_xtra_gw5a.v
+
+.PHONY: all build lint lint-yosys lint-verilator prog flash clean tool webui webui-serve ftdi-setup help
 
 all: build
 
@@ -35,9 +39,21 @@ build: $(BITSTREAM)
 $(BITSTREAM): $(VERILOG_FILES) $(CST_FILE) build.tcl
 	gw_sh build.tcl
 
-# Lint with yosys (quick syntax/logic check)
-lint:
-	yosys -p "read_verilog $(VERILOG_FILES); synth_gowin -top top -noflatten"
+# Open-source syntax, elaboration, and synthesis checks.
+lint: lint-yosys lint-verilator
+
+lint-yosys:
+	yosys -Q -q \
+		-w "define gw1n not used.*" \
+		-w "Yosys has only limited support for tri-state logic.*" \
+		-e ".*" \
+		-p "read_verilog -lib $(GOWIN_CELLS); read_verilog $(VERILOG_FILES); synth_gowin -family gw5a -top top -noflatten; check"
+
+lint-verilator:
+	verilator --lint-only --top-module top \
+		-Wno-CASEINCOMPLETE -Wno-DEFPARAM -Wno-PINMISSING \
+		-Wno-WIDTHTRUNC -Wno-WIDTHEXPAND \
+		$(GOWIN_CELLS) $(VERILOG_FILES)
 
 # Program the device (volatile - lost on power cycle)
 prog: $(BITSTREAM)
@@ -74,7 +90,7 @@ help:
 	@echo "  make build   - Synthesize + PnR (default, requires gw_sh)"
 	@echo "  make prog    - Program FPGA (volatile)"
 	@echo "  make flash   - Program to flash (persistent)"
-	@echo "  make lint    - Lint Verilog with yosys"
+	@echo "  make lint    - Check Verilog with Yosys and Verilator"
 	@echo "  make tool    - Build spi-flash-tool (ftdi-nusb backend, default)"
 	@echo "  make webui  - Build the WebUSB/Web Serial browser UI"
 	@echo "  make webui-serve - Build and serve the UI at http://localhost:8081"


### PR DESCRIPTION
Pull requests currently do not have a dedicated workflow that validates both the host software and FPGA sources before merge.

This adds parallel Rust/WebAssembly and Verilog CI jobs. The Rust job runs formatting, tests, native and WASM Clippy, and a production WebUI build. The Verilog job uses OSS CAD Suite to run a Gowin-aware Yosys synthesis/check pass and Verilator linting. The Pages workflow is reduced to deployment work instead of duplicating CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated validation for Rust, WebAssembly, native code, and hardware designs.
  * Added formatting, testing, linting, and Web UI build checks.
  * Streamlined Web UI deployment setup and verification.

* **Bug Fixes**
  * Improved hardware linting through complementary synthesis and compatibility checks.
  * Added support for GW5A primitive declarations during synthesis validation.
  * Updated the lint workflow guidance to reflect the combined checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->