### PR TITLE
Update ftdi-nusb to 0.3.0

### DIFF
--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -751,6 +751,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,13 +819,14 @@ dependencies = [
 
 [[package]]
 name = "ftdi-nusb"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e3391b248c458fce989a635a3afdd2297764e17645172c1d5fabc1779231de"
+checksum = "ea9f51291e4b1fc406826ca889011256c94ed8763487490bb4d3bec0126067c7"
 dependencies = [
+ "futures-lite",
+ "futures-timer",
  "js-sys",
  "log",
- "maybe-async",
  "nusb",
  "thiserror 2.0.20",
  "wasm-bindgen",
@@ -843,6 +850,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +884,12 @@ name = "futures-task"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -1882,6 +1914,12 @@ checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -14,7 +14,7 @@ cli = [
     "dep:rflasher-chips",
     "dep:ctrlc",
 ]
-ftdi = ["cli", "dep:ftdi-nusb", "ftdi-nusb/std", "dep:nusb"]
+ftdi = ["cli", "dep:ftdi-nusb", "dep:nusb"]
 wasm = [
     "dep:async-trait",
     "dep:eframe",
@@ -23,7 +23,6 @@ wasm = [
     "dep:tracing-wasm",
     "dep:rflasher-chips",
     "dep:ftdi-nusb",
-    "ftdi-nusb/wasm",
     "dep:nusb",
     "dep:wasm-bindgen",
     "dep:wasm-bindgen-futures",
@@ -36,7 +35,7 @@ wasm = [
 [dependencies]
 anyhow = "1.0"
 async-trait = { version = "0.1.92", optional = true }
-ftdi-nusb = { version = "0.2", default-features = false, optional = true }
+ftdi-nusb = { version = "0.3.0", default-features = false, optional = true }
 nusb = { version = "0.2.7", optional = true }
 zerocopy = { version = "=0.8.55", features = ["derive"] }
 wasm-bindgen = { version = "0.2.127", optional = true }

--- a/tool/src/transport.rs
+++ b/tool/src/transport.rs
@@ -146,19 +146,19 @@ impl Transport for SerialTransport {
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "ftdi")]
-pub(crate) fn open_ft2232h(serial: Option<&str>) -> Result<ftdi_nusb::FtdiDevice> {
+pub(crate) fn open_ft2232h(serial: Option<&str>) -> Result<ftdi_nusb::blocking::FtdiDevice> {
     if let Some(serial) = serial {
         let filter = ftdi_nusb::DeviceFilter::new(FTDI_VID, FT2232H_PID).serial(serial);
-        return ftdi_nusb::FtdiDevice::open_with_filter(&filter, ftdi_nusb::Interface::A)
+        return ftdi_nusb::blocking::FtdiDevice::open_with_filter(&filter, ftdi_nusb::Interface::A)
             .with_context(|| format!("No FT2232H with serial '{serial}'"));
     }
 
     // DeviceFilter matches the USB product string configured in ft2232h.conf;
     // the interface is selected separately below.
     let filter = ftdi_nusb::DeviceFilter::new(FTDI_VID, FT2232H_PID).description("NORbert FT245");
-    ftdi_nusb::FtdiDevice::open_with_filter(&filter, ftdi_nusb::Interface::A)
+    ftdi_nusb::blocking::FtdiDevice::open_with_filter(&filter, ftdi_nusb::Interface::A)
         .or_else(|_| {
-            ftdi_nusb::FtdiDevice::open_with_interface(
+            ftdi_nusb::blocking::FtdiDevice::open_with_interface(
                 FTDI_VID,
                 FT2232H_PID,
                 ftdi_nusb::Interface::A,
@@ -169,7 +169,7 @@ pub(crate) fn open_ft2232h(serial: Option<&str>) -> Result<ftdi_nusb::FtdiDevice
 
 #[cfg(feature = "ftdi")]
 pub(crate) struct Ft245Transport {
-    dev: ftdi_nusb::FtdiDevice,
+    dev: ftdi_nusb::blocking::FtdiDevice,
 }
 
 #[cfg(feature = "ftdi")]


### PR DESCRIPTION
`ftdi-nusb` 0.3.0 unifies its asynchronous API across targets and removes the previous `std` and `wasm` feature flags.

This updates the dependency and lockfile, removes the obsolete feature selections, and uses the new blocking device wrapper for the native FT245 transport. The WebUSB path continues using the asynchronous device API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated FTDI device communication to use the blocking interface for improved compatibility.
  * Updated the FTDI library integration to version 0.3.0.
  * Adjusted FTDI and WebAssembly feature configuration to match the updated library behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->